### PR TITLE
feat: add PyPI backfill and Houdini material skills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         description: "Tag name for manual asset build, for example v0.1.0. Leave empty to only run release-please."
         required: false
         default: ""
+      publish_to_pypi:
+        description: "Publish rebuilt dist artifacts for tag_name to PyPI. Use to backfill an existing GitHub release."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,6 +59,24 @@ jobs:
         run: python -m pip install --upgrade pip build twine
       - name: Build package
         run: python -m build
+      - name: Verify wheel contains bundled skills
+        run: |
+          python - <<'PY'
+          import glob
+          import zipfile
+
+          wheels = sorted(glob.glob("dist/dcc_mcp_houdini-*.whl"))
+          assert wheels, "wheel missing"
+          with zipfile.ZipFile(wheels[-1]) as zf:
+              names = set(zf.namelist())
+          required = {
+              "dcc_mcp_houdini/skills/houdini-scene/SKILL.md",
+              "dcc_mcp_houdini/skills/houdini-nodes/SKILL.md",
+              "dcc_mcp_houdini/skills/houdini-materials/SKILL.md",
+          }
+          missing = sorted(required - names)
+          assert not missing, missing
+          PY
       - name: Check package
         run: python -m twine check dist/*
       - name: Upload dist artifacts
@@ -66,21 +89,32 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [release-please, build]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '' && inputs.publish_to_pypi == true)
     environment:
       name: pypi
       url: https://pypi.org/p/dcc-mcp-houdini
     permissions:
       id-token: write
+    env:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:
       - name: Download dist artifacts
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
-      - name: Publish to PyPI
+      - name: Publish to PyPI with trusted publishing
+        if: env.PYPI_API_TOKEN == ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
+          print-hash: true
+      - name: Publish to PyPI with API token
+        if: env.PYPI_API_TOKEN != ''
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
           print-hash: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@ When adding or changing bundled skills, load the project skill:
 | Skill | Tools |
 |-------|-------|
 | `houdini-scripting` | `execute_python`, `get_session_info` |
-| `houdini-scene` | `get_scene_info`, `list_obj_nodes` |
+| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
 | `houdini-nodes` | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
+| `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/loonghao/dcc-mcp-houdini/actions/workflows/ci.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-houdini/actions/workflows/ci.yml)
 [![E2E](https://github.com/loonghao/dcc-mcp-houdini/actions/workflows/e2e.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-houdini/actions/workflows/e2e.yml)
 [![Release](https://github.com/loonghao/dcc-mcp-houdini/actions/workflows/release.yml/badge.svg)](https://github.com/loonghao/dcc-mcp-houdini/actions/workflows/release.yml)
+[![PyPI](https://img.shields.io/pypi/v/dcc-mcp-houdini.svg)](https://pypi.org/project/dcc-mcp-houdini/)
 [![Python](https://img.shields.io/badge/python-3.7%2B-blue.svg)](pyproject.toml)
 [![Downloads](https://img.shields.io/github/downloads/loonghao/dcc-mcp-houdini/total.svg)](https://github.com/loonghao/dcc-mcp-houdini/releases)
 [![License](https://img.shields.io/github/license/loonghao/dcc-mcp-houdini.svg)](LICENSE)
@@ -27,6 +28,12 @@ skills-first Houdini automation tools to agents.
 ## Installation
 
 ### Release Wheel
+
+```bash
+pip install dcc-mcp-houdini
+```
+
+For an unreleased GitHub asset, install a release wheel directly:
 
 ```bash
 pip install https://github.com/loonghao/dcc-mcp-houdini/releases/download/v0.1.0/dcc_mcp_houdini-0.1.0-py3-none-any.whl
@@ -103,13 +110,22 @@ just houdini-version=20.5 houdini-dev-debug-win
 just build-houdini-package platform=win64
 ```
 
+## Release Publishing
+
+The Release workflow publishes to PyPI when `release-please` creates a new
+release. To backfill an existing GitHub release tag, run the Release workflow
+manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
+PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
+available.
+
 ## Bundled Skills
 
 | Skill | Stage | Tools |
 |-------|-------|-------|
 | `houdini-scripting` | bootstrap | `execute_python`, `get_session_info` |
-| `houdini-scene` | scene | `get_scene_info`, `list_obj_nodes` |
+| `houdini-scene` | scene | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
 | `houdini-nodes` | authoring | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
+| `houdini-materials` | authoring | `create_material`, `assign_material` |
 | `houdini-hda` | authoring | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
 | `houdini-automation` | pipeline | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 

--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -22,7 +22,7 @@ STAGES: Tuple[str, ...] = (
 STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "bootstrap": ("houdini-scripting",),
     "scene": ("houdini-scene",),
-    "authoring": ("houdini-nodes", "houdini-hda"),
+    "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
     "interchange": (),
     "pipeline": ("houdini-automation",),
 }

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,7 +6,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene` | yes |
-| `authoring` | `houdini-nodes`, `houdini-hda` | no |
+| `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
 | `interchange` | _(planned: USD, FBX, Alembic)_ | no |
 | `pipeline` | `houdini-automation` | no |
 
@@ -17,6 +17,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Verify MCP session | `houdini_scripting__get_session_info` |
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
+| Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: houdini-materials
+description: >-
+  Authoring skill - create Houdini material nodes and assign them to renderable
+  nodes through typed HOM operations. Use when building lookdev/material
+  workflows. Not for generic node graph edits.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, materials, lookdev, shader, assignment, authoring]
+    search-hint: "create material, assign material, shader node, lookdev"
+    tools: tools.yaml
+---
+
+# houdini-materials
+
+Typed material authoring for Houdini scenes. Use `create_material` for material
+network nodes and `assign_material` for renderable OBJ/SOP nodes with a material
+path parameter.

--- a/src/dcc_mcp_houdini/skills/houdini-materials/scripts/_material_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/scripts/_material_common.py
@@ -1,0 +1,44 @@
+"""Shared helpers for Houdini material skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dcc_mcp_core.skill import skill_error
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def hou_import_error() -> dict:
+    """Standard error when the HOM module is unavailable."""
+    return skill_error("Houdini not available", "hou could not be imported")
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def set_parm_value(node: Any, name: str, value: Any) -> None:
+    """Set either a scalar parm or a tuple parm."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is not None:
+            parm_tuple.set(tuple(value))
+            return
+
+    parm = node.parm(name)
+    if parm is None:
+        raise ValueError("Parameter {!r} not found on {}".format(name, node.path()))
+    parm.set(value)

--- a/src/dcc_mcp_houdini/skills/houdini-materials/scripts/assign_material.py
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/scripts/assign_material.py
@@ -1,0 +1,53 @@
+"""Assign a Houdini material node to a target node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _material_common import get_node, hou_import_error, node_summary
+
+
+def assign_material(
+    target_node_path: str,
+    material_node_path: str,
+    parameter_name: str = "shop_materialpath",
+) -> dict:
+    """Assign *material_node_path* by setting *parameter_name* on the target."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        target = get_node(hou, target_node_path)
+        material = get_node(hou, material_node_path)
+        parm = target.parm(parameter_name)
+        if parm is None:
+            raise ValueError("Parameter {!r} not found on {}".format(parameter_name, target.path()))
+        parm.set(material.path())
+        return skill_success(
+            "Assigned Houdini material",
+            target=node_summary(target),
+            material=node_summary(material),
+            parameter_name=parameter_name,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to assign Houdini material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return assign_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-materials/scripts/create_material.py
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/scripts/create_material.py
@@ -1,0 +1,85 @@
+"""Create a Houdini material node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _material_common import get_node, hou_import_error, node_summary, set_parm_value
+
+
+def _shader_candidates(shader_type: str) -> list:
+    candidates = [shader_type]
+    if shader_type == "principledshader::2.0":
+        candidates.append("principledshader")
+    return candidates
+
+
+def create_material(
+    parent_path: str = "/mat",
+    shader_type: str = "principledshader::2.0",
+    material_name: Optional[str] = None,
+    parameters: Optional[Dict[str, Any]] = None,
+    exact_type_name: bool = False,
+    set_current: bool = False,
+) -> dict:
+    """Create a material/shader node and set optional parameters."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        parent = get_node(hou, parent_path)
+        last_error = None
+        material = None
+        created_type = shader_type
+        for candidate in _shader_candidates(shader_type):
+            try:
+                material = parent.createNode(
+                    candidate,
+                    node_name=material_name,
+                    run_init_scripts=True,
+                    load_contents=True,
+                    exact_type_name=exact_type_name,
+                )
+                created_type = candidate
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+        if material is None:
+            raise last_error or RuntimeError("Could not create material")
+
+        for name, value in (parameters or {}).items():
+            set_parm_value(material, name, value)
+        if set_current and hasattr(material, "setCurrent"):
+            material.setCurrent(True, clear_all_selected=True)
+
+        return skill_success(
+            "Created Houdini material",
+            parent_path=parent.path(),
+            requested_shader_type=shader_type,
+            shader_type=created_type,
+            material=node_summary(material),
+            parameters=list((parameters or {}).keys()),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create Houdini material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-materials/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/tools.yaml
@@ -1,0 +1,80 @@
+tools:
+  - name: create_material
+    description: >-
+      Create a Houdini material/shader node under a material network, optionally
+      setting parameters. Mutates the scene.
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: "/mat"
+          description: Material network path, commonly /mat.
+        shader_type:
+          type: string
+          default: "principledshader::2.0"
+          description: Houdini shader node type to create.
+        material_name:
+          type: string
+          description: Optional material node name. Houdini chooses a unique name when omitted.
+        parameters:
+          type: object
+          description: Parameter name to value map for the new material.
+          additionalProperties: true
+        exact_type_name:
+          type: boolean
+          default: false
+          description: Require an exact operator type name match.
+        set_current:
+          type: boolean
+          default: false
+          description: Make the new material node current/selected when supported.
+    read_only: false
+    destructive: false
+    idempotent: false
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    source_file: scripts/create_material.py
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    next-tools:
+      on-success:
+        - houdini_materials__assign_material
+      on-failure:
+        - houdini_scene__list_child_nodes
+
+  - name: assign_material
+    description: >-
+      Assign an existing Houdini material node to a target node by setting a
+      material path parameter such as shop_materialpath. Mutates the scene.
+    input_schema:
+      type: object
+      required: [target_node_path, material_node_path]
+      properties:
+        target_node_path:
+          type: string
+          description: Renderable OBJ/SOP node path that receives the material.
+        material_node_path:
+          type: string
+          description: Material node path to assign.
+        parameter_name:
+          type: string
+          default: "shop_materialpath"
+          description: String parameter on the target node that stores the material path.
+    read_only: false
+    destructive: false
+    idempotent: true
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    source_file: scripts/assign_material.py
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    next-tools:
+      on-failure:
+        - houdini_scene__get_node_info

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: houdini-scene
 description: >-
-  Scene skill — read-only inspection of the active Houdini hip file and /obj node
-  graph. Use when you need frame range, hip path, or object-level nodes. Not for
-  creating geometry, sims, or exports — use future authoring/interchange skills.
+  Scene skill — read-only inspection of the active Houdini hip file and node
+  graphs. Use when you need frame range, hip path, object-level nodes, or node
+  details. Not for creating geometry, sims, or exports — use authoring or
+  interchange skills.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
 allowed-tools: Bash Read Write Edit
@@ -14,7 +15,7 @@ metadata:
     stage: scene
     version: "1.0.0"
     tags: [houdini, scene, hip, nodes, obj]
-    search-hint: "scene info, hip file, list nodes, obj context, frame range"
+    search-hint: "scene info, hip file, list nodes, node details, obj context, frame range"
     tools: tools.yaml
 ---
 
@@ -25,6 +26,7 @@ Read-only scene inventory for agents. All tools are `affinity: main` because the
 ## Suggested flow
 
 1. `get_scene_info` — hip path, playback range, /obj child count
-2. `list_obj_nodes` — filter by node type when needed
+2. `list_obj_nodes` or `list_child_nodes` — filter by node type when needed
+3. `get_node_info` — inspect flags, child paths, and connections
 
 On failure, load `houdini-scripting` and call `get_session_info`, or use gateway diagnostics when available.

--- a/src/dcc_mcp_houdini/skills/houdini-scene/scripts/get_node_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/scripts/get_node_info.py
@@ -1,0 +1,95 @@
+"""Inspect a Houdini node without changing the scene."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _call_or_none(obj: Any, method_name: str) -> Any:
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return method()
+    except Exception:
+        return None
+
+
+def _path_or_none(node: Any) -> Optional[str]:
+    if node is None:
+        return None
+    path = _call_or_none(node, "path")
+    return str(path) if path is not None else None
+
+
+def _optional_bool(node: Any, method_name: str) -> Optional[bool]:
+    value = _call_or_none(node, method_name)
+    return bool(value) if value is not None else None
+
+
+def _type_context(node: Any) -> dict:
+    type_obj = node.type()
+    category = _call_or_none(type_obj, "category")
+    return {
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+        "category": category.name() if category is not None and hasattr(category, "name") else None,
+    }
+
+
+def _connection_paths(nodes: Any) -> List[Optional[str]]:
+    if nodes is None:
+        return []
+    return [_path_or_none(node) for node in nodes]
+
+
+def get_node_info(node_path: str, include_connections: bool = True) -> dict:
+    """Return a JSON-safe summary for *node_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = hou.node(node_path)
+        if node is None:
+            return skill_error("Houdini node not found", node_path)
+
+        children = list(node.children())
+        context = {
+            "path": node.path(),
+            "name": node.name(),
+            "parent_path": _path_or_none(_call_or_none(node, "parent")),
+            "child_count": len(children),
+            "children": [_path_or_none(child) for child in children],
+            "flags": {
+                "bypassed": _optional_bool(node, "isBypassed"),
+                "display": _optional_bool(node, "isDisplayFlagSet"),
+                "render": _optional_bool(node, "isRenderFlagSet"),
+                "template": _optional_bool(node, "isTemplateFlagSet"),
+                "current": _optional_bool(node, "isCurrent"),
+                "selected": _optional_bool(node, "isSelected"),
+                "hidden": _optional_bool(node, "isHidden"),
+            },
+        }
+        context.update(_type_context(node))
+        if include_connections:
+            context["inputs"] = _connection_paths(_call_or_none(node, "inputs"))
+            context["outputs"] = _connection_paths(_call_or_none(node, "outputs"))
+
+        return skill_success("Inspected Houdini node", node=context)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to inspect Houdini node")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`get_node_info`."""
+    return get_node_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene/scripts/list_child_nodes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/scripts/list_child_nodes.py
@@ -1,0 +1,91 @@
+"""List child nodes below a Houdini network path."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _type_name(node: Any) -> str:
+    type_obj = node.type()
+    return type_obj.name() if hasattr(type_obj, "name") else str(type_obj)
+
+
+def _optional_bool(node: Any, method_name: str) -> bool:
+    method = getattr(node, method_name, None)
+    if not callable(method):
+        return False
+    try:
+        return bool(method())
+    except Exception:
+        return False
+
+
+def _node_summary(node: Any, depth: int) -> dict:
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": _type_name(node),
+        "depth": depth,
+        "hidden": _optional_bool(node, "isHidden"),
+    }
+
+
+def list_child_nodes(
+    parent_path: str = "/obj",
+    type_filter: Optional[str] = None,
+    recursive: bool = False,
+    max_depth: int = 1,
+    include_hidden: bool = False,
+) -> dict:
+    """List child nodes below *parent_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = hou.node(parent_path)
+        if parent is None:
+            return skill_error("Houdini node not found", parent_path)
+        if max_depth < 0:
+            return skill_error("Invalid max_depth", "max_depth must be >= 0")
+
+        nodes: List[dict] = []
+        lowered_filter = type_filter.lower() if type_filter else None
+
+        def visit(container: Any, depth: int) -> None:
+            for child in container.children():
+                hidden = _optional_bool(child, "isHidden")
+                type_name = _type_name(child)
+                if include_hidden or not hidden:
+                    if lowered_filter is None or lowered_filter in type_name.lower():
+                        nodes.append(_node_summary(child, depth))
+                if recursive and depth < max_depth:
+                    visit(child, depth + 1)
+
+        visit(parent, 0)
+        return skill_success(
+            "Listed Houdini child nodes",
+            parent_path=parent.path(),
+            nodes=nodes,
+            count=len(nodes),
+            type_filter=type_filter,
+            recursive=recursive,
+            max_depth=max_depth,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list Houdini child nodes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`list_child_nodes`."""
+    return list_child_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
@@ -46,3 +46,76 @@ tools:
     next-tools:
       on-failure:
         - houdini_scene__get_scene_info
+  - name: list_child_nodes
+    description: >-
+      List child nodes below any Houdini network path, optionally filtered by
+      node type and recursively traversed to a bounded depth. Does not modify
+      the scene.
+    source_file: scripts/list_child_nodes.py
+    execution: sync
+    affinity: main
+    group: scene-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: "/obj"
+          description: Network path whose children should be listed.
+        type_filter:
+          type: string
+          description: Optional substring filter on Houdini node type name.
+        recursive:
+          type: boolean
+          default: false
+          description: Traverse descendants when true.
+        max_depth:
+          type: integer
+          minimum: 0
+          default: 1
+          description: Maximum descendant depth when recursive is true.
+        include_hidden:
+          type: boolean
+          default: false
+          description: Include nodes for which Houdini reports isHidden().
+    next-tools:
+      on-success:
+        - houdini_scene__get_node_info
+      on-failure:
+        - houdini_scene__get_scene_info
+  - name: get_node_info
+    description: >-
+      Return a read-only summary for a Houdini node including path, type,
+      category, parent, child count, flags, and optional input/output links.
+    source_file: scripts/get_node_info.py
+    execution: sync
+    affinity: main
+    group: scene-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Houdini node path to inspect.
+        include_connections:
+          type: boolean
+          default: true
+          description: Include input and output node paths when available.
+    next-tools:
+      on-failure:
+        - houdini_scene__list_child_nodes

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,34 @@
+"""Release workflow contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _release_workflow() -> dict:
+    text = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    return yaml.load(text, Loader=yaml.BaseLoader)
+
+
+def test_release_workflow_can_backfill_pypi_for_existing_tag() -> None:
+    workflow = _release_workflow()
+
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert inputs["publish_to_pypi"]["type"] == "boolean"
+    assert inputs["publish_to_pypi"]["default"] == "false"
+
+    publish_job = workflow["jobs"]["publish"]
+    assert "inputs.tag_name != ''" in publish_job["if"]
+    assert "inputs.publish_to_pypi == true" in publish_job["if"]
+
+
+def test_release_build_verifies_bundled_skills_before_publish() -> None:
+    workflow = _release_workflow()
+    build_steps = workflow["jobs"]["build"]["steps"]
+    verify_steps = [step for step in build_steps if step.get("name") == "Verify wheel contains bundled skills"]
+    assert verify_steps, "release build should verify wheel skill payload"
+    assert "houdini-materials/SKILL.md" in verify_steps[0]["run"]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -62,6 +62,7 @@ def test_stage_loader_maps_bootstrap_and_scene() -> None:
 
     assert "houdini-scripting" in skills_for_stage("bootstrap")
     assert "houdini-scene" in skills_for_stage("scene")
+    assert "houdini-materials" in skills_for_stage("authoring")
     cfg = build_minimal_mode_for_stages(["scene"])
     assert "houdini-scene" in cfg.skills
     assert "houdini-scripting" in cfg.skills
@@ -136,6 +137,81 @@ class TestListObjNodesSkill:
         assert result["success"] is True
         assert result["context"]["count"] == 1
         assert result["context"]["nodes"][0]["name"] == "geo1"
+
+
+class TestSceneNodeInspectionSkills:
+    def test_list_child_nodes_with_recursive_filter(self) -> None:
+        mod = _load_script("houdini-scene", "list_child_nodes.py")
+        box = MagicMock()
+        box.path.return_value = "/obj/geo1/box1"
+        box.name.return_value = "box1"
+        box.type.return_value.name.return_value = "box"
+        box.isHidden.return_value = False
+        box.children.return_value = []
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        geo.name.return_value = "geo1"
+        geo.type.return_value.name.return_value = "geo"
+        geo.isHidden.return_value = False
+        geo.children.return_value = [box]
+        obj = MagicMock()
+        obj.path.return_value = "/obj"
+        obj.children.return_value = [geo]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = obj
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_child_nodes("/obj", type_filter="box", recursive=True, max_depth=1)
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["nodes"][0]["path"] == "/obj/geo1/box1"
+        assert result["context"]["nodes"][0]["depth"] == 1
+
+    def test_get_node_info_with_connections(self) -> None:
+        mod = _load_script("houdini-scene", "get_node_info.py")
+        category = MagicMock()
+        category.name.return_value = "Sop"
+        type_obj = MagicMock()
+        type_obj.name.return_value = "box"
+        type_obj.category.return_value = category
+        parent = MagicMock()
+        parent.path.return_value = "/obj/geo1"
+        child = MagicMock()
+        child.path.return_value = "/obj/geo1/child"
+        input_node = MagicMock()
+        input_node.path.return_value = "/obj/geo1/input"
+        output_node = MagicMock()
+        output_node.path.return_value = "/obj/geo1/output"
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/box1"
+        node.name.return_value = "box1"
+        node.type.return_value = type_obj
+        node.parent.return_value = parent
+        node.children.return_value = [child]
+        node.inputs.return_value = [input_node, None]
+        node.outputs.return_value = [output_node]
+        node.isBypassed.return_value = False
+        node.isDisplayFlagSet.return_value = True
+        node.isRenderFlagSet.return_value = False
+        node.isTemplateFlagSet.return_value = False
+        node.isCurrent.return_value = True
+        node.isSelected.return_value = True
+        node.isHidden.return_value = False
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_node_info("/obj/geo1/box1")
+
+        assert result["success"] is True
+        info = result["context"]["node"]
+        assert info["type"] == "box"
+        assert info["category"] == "Sop"
+        assert info["parent_path"] == "/obj/geo1"
+        assert info["child_count"] == 1
+        assert info["inputs"] == ["/obj/geo1/input", None]
+        assert info["outputs"] == ["/obj/geo1/output"]
 
 
 class TestNodeSkills:
@@ -248,6 +324,58 @@ class TestHdaSkills:
         assert result["success"] is True
         assert result["context"]["definition_count"] == 1
         assert result["context"]["definitions"][0]["node_type_name"] == "my_hda"
+
+
+class TestMaterialSkills:
+    def test_create_material_sets_parameters(self) -> None:
+        mod = _load_script("houdini-materials", "create_material.py")
+        tuple_parm = MagicMock()
+        scalar_parm = MagicMock()
+        material = MagicMock()
+        material.path.return_value = "/mat/clay"
+        material.name.return_value = "clay"
+        material.type.return_value.name.return_value = "principledshader::2.0"
+        material.parmTuple.side_effect = lambda name: tuple_parm if name == "basecolor" else None
+        material.parm.side_effect = lambda name: scalar_parm if name == "rough" else None
+        parent = MagicMock()
+        parent.path.return_value = "/mat"
+        parent.createNode.return_value = material
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_material(
+                material_name="clay",
+                parameters={"basecolor": [0.8, 0.4, 0.2], "rough": 0.65},
+            )
+
+        assert result["success"] is True
+        parent.createNode.assert_called_once()
+        tuple_parm.set.assert_called_once_with((0.8, 0.4, 0.2))
+        scalar_parm.set.assert_called_once_with(0.65)
+        assert result["context"]["material"]["path"] == "/mat/clay"
+
+    def test_assign_material_sets_material_path(self) -> None:
+        mod = _load_script("houdini-materials", "assign_material.py")
+        parm = MagicMock()
+        target = MagicMock()
+        target.path.return_value = "/obj/geo1"
+        target.name.return_value = "geo1"
+        target.type.return_value.name.return_value = "geo"
+        target.parm.return_value = parm
+        material = MagicMock()
+        material.path.return_value = "/mat/clay"
+        material.name.return_value = "clay"
+        material.type.return_value.name.return_value = "principledshader::2.0"
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {"/obj/geo1": target, "/mat/clay": material}.get(path)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.assign_material("/obj/geo1", "/mat/clay")
+
+        assert result["success"] is True
+        parm.set.assert_called_once_with("/mat/clay")
+        assert result["context"]["target"]["path"] == "/obj/geo1"
 
 
 class TestAutomationSkills:


### PR DESCRIPTION
## Summary
- add manual PyPI backfill support for existing release tags and verify bundled skills are present in release wheels
- add `houdini-materials` with typed material creation and assignment tools
- extend `houdini-scene` with child-node listing and node inspection tools

## Validation
- `python -m pytest -q`
- `python -m pytest tests\test_packaging.py -q -m "not e2e and not integration"`
- `ruff check src/ tests/ tools/ packaging/`
- `ruff format --check src/ tests/ tools/ packaging/`
- `python tools\lint_skills.py --warnings-as-errors`
- `python tools\check_py37_syntax.py src tests tools packaging`
- `python -m build`
- `python -m twine check dist\*`
- verified built wheel contains `houdini-materials` and bundled skill metadata