### PR TITLE
fix: keep release runtime version managed

### DIFF
--- a/src/dcc_mcp_houdini/__version__.py
+++ b/src/dcc_mcp_houdini/__version__.py
@@ -1,3 +1,3 @@
 """Version info for dcc-mcp-houdini."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.0"  # x-release-please-version

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -32,3 +32,12 @@ def test_release_build_verifies_bundled_skills_before_publish() -> None:
     verify_steps = [step for step in build_steps if step.get("name") == "Verify wheel contains bundled skills"]
     assert verify_steps, "release build should verify wheel skill payload"
     assert "houdini-materials/SKILL.md" in verify_steps[0]["run"]
+
+
+def test_release_please_updates_runtime_version_file() -> None:
+    config = yaml.safe_load((ROOT / "release-please-config.json").read_text(encoding="utf-8"))
+    extra_files = config["packages"]["."]["extra-files"]
+    version_file = ROOT / "src" / "dcc_mcp_houdini" / "__version__.py"
+
+    assert "src/dcc_mcp_houdini/__version__.py" in extra_files
+    assert "x-release-please-version" in version_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add the release-please version marker to the runtime version file
- add a release workflow contract test so version bumps keep pyproject, manifest, and runtime metadata aligned

## Validation
- python -m pytest tests/test_release_workflow.py tests/test_skills.py
- ruff check src tests tools packaging
- ruff format --check src tests tools packaging
- python tools/lint_skills.py --warnings-as-errors
- python -m build --outdir dist_check
- python -m twine check dist_check\\*
- python packaging\\assemble_houdini_package.py --platform win64 --dist-dir dist_check --output-dir dist_houdini_check
- python packaging\\assemble_houdini_package.py --platform linux --dist-dir dist_check --output-dir dist_houdini_check
- python packaging\\assemble_houdini_package.py --platform macos --dist-dir dist_check --output-dir dist_houdini_check