### PR TITLE
feat: latest dcc-mcp-core integrations + agent install skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ skills-first Houdini automation tools to agents.
 - Prometheus metrics endpoint (`/metrics`), job persistence, and workflow engine support
 - Optional licensed Houdini Docker E2E workflow
 
+## Agent install (recommended)
+
+Let your AI agent do the setup. In an MCP-capable agent (Cursor, Claude, etc.),
+just say:
+
+> 帮我参考 loonghao/dcc-mcp-houdini/install.md 去安装
+
+The agent reads [`install.md`](install.md), runs the
+`dcc-mcp-houdini-setup` skill to install dependencies into Houdini's `hython`,
+generates an MCP host config, guides the Houdini package / `123.py` autostart
+step, and runs a smoke prompt to confirm the connection.
+
 ## Installation
 
 ### Release Wheel

--- a/install.md
+++ b/install.md
@@ -1,0 +1,94 @@
+# dcc-mcp-houdini Agent Install
+
+Use this page when an agent is asked to install or configure
+`loonghao/dcc-mcp-houdini` for SideFX Houdini.
+
+## Agent Instruction
+
+If the user says "帮我参考 loonghao/dcc-mcp-houdini/install.md 去安装",
+do this:
+
+1. Read `skills/dcc-mcp-houdini-setup/SKILL.md`.
+2. Run the setup script from the repository root.
+3. Help the user install the Houdini package so `123.py` autostarts the server.
+4. Configure the MCP host with the generated Streamable HTTP JSON.
+5. Run the smoke prompt to prove the connection works.
+
+## One Command
+
+From the repository root:
+
+```bash
+python skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py
+```
+
+For an end-user install from PyPI instead of this checkout:
+
+```bash
+python skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py --source pypi
+```
+
+If `hython` is not auto-detected:
+
+```bash
+python skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py --hython "C:\Program Files\Side Effects Software\Houdini 20.5.487\bin\hython.exe"
+```
+
+`hython` ships with Houdini. Typical locations:
+
+- Windows: `C:\Program Files\Side Effects Software\Houdini X.Y.ZZZ\bin\hython.exe`
+- macOS: `/Applications/Houdini/HoudiniX.Y.ZZZ/.../Resources/bin/hython`
+- Linux: `/opt/hfsX.Y.ZZZ/bin/hython`
+
+## Houdini Autostart Step
+
+After the script finishes, the user must make the server start with Houdini.
+The recommended path is the bundled Houdini package:
+
+1. Install the Houdini package (quickinstall ZIP `install.ps1` / `install.sh`,
+   or a `dcc_mcp_houdini.json` package file pointing at the package root).
+2. The package adds `scripts/` to `HOUDINI_PATH`; on startup `123.py` extracts
+   bundled wheels into `vendor/` and starts the MCP server unless
+   `DCC_MCP_HOUDINI_AUTOSTART=0`.
+3. Start Houdini and watch the console for:
+   `dcc-mcp-houdini MCP server started: http://127.0.0.1:8765/mcp`.
+
+Autostart mode exposes MCP at:
+
+```text
+http://127.0.0.1:8765/mcp
+```
+
+Multi-instance auto-gateway mode (`DCC_MCP_GATEWAY_PORT=9765`) uses:
+
+```text
+http://127.0.0.1:9765/mcp
+```
+
+You can also start the server manually from an `hython` session:
+
+```python
+import dcc_mcp_houdini
+server = dcc_mcp_houdini.start_server()
+print(server.mcp_url)  # http://127.0.0.1:8765/mcp
+```
+
+## MCP Config
+
+Use this JSON for Cursor, Claude Desktop, or any MCP Streamable HTTP host:
+
+```json
+{
+  "mcpServers": {
+    "houdini": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+The setup script also writes config snippets and a smoke prompt under:
+
+```text
+.dcc-mcp/agent-setup/
+```

--- a/skills/dcc-mcp-houdini-setup/SKILL.md
+++ b/skills/dcc-mcp-houdini-setup/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: dcc-mcp-houdini-setup
+description: |-
+  Set up dcc-mcp-houdini for an agent or operator: install Houdini Python
+  dependencies with hython, generate MCP host configuration, guide the user
+  through the Houdini package / 123.py autostart load step, and run a first
+  live-tool smoke prompt.
+license: MIT
+allowed-tools: Bash Read
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: operator
+    stage: bootstrap
+    version: 1.0.0
+    tags:
+    - houdini
+    - mcp
+    - setup
+    - hython
+    - autostart
+---
+# dcc-mcp-houdini setup
+
+Use this skill when a user wants an agent to prepare a machine so any MCP
+host can use `dcc-mcp-houdini` with SideFX Houdini.
+
+This is an operator skill, not a Houdini runtime skill. Do not load it through
+the Houdini MCP server. Run it from the repository checkout or copy its steps
+into another agent's instructions.
+
+If the user says "帮我参考 `loonghao/dcc-mcp-houdini/install.md` 去安装", read the
+root `install.md` first, then follow this skill.
+
+## Goal
+
+End with:
+
+- `dcc-mcp-houdini` and its pip dependencies installed into the target Houdini
+  `hython` environment.
+- An MCP host config snippet that points to the Houdini MCP server.
+- The user guided to install the Houdini package so `scripts/123.py` autostarts
+  the server (or to start it manually from `hython`).
+- A live smoke prompt that proves the agent can discover and call Houdini tools.
+
+## Fast Path
+
+From the repository root, run:
+
+```bash
+python skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py
+```
+
+The script:
+
+1. Finds `hython` from `--hython`, `HYTHON`, `DCC_MCP_HOUDINI_HYTHON`, `PATH`,
+   or common Side Effects Software install locations.
+2. Installs this checkout into Houdini: `hython -m pip install -e .`
+   (`dcc-mcp-houdini` defines no runtime extra; `dcc-mcp-core` is pulled in
+   automatically).
+3. Verifies `import dcc_mcp_houdini`.
+4. Writes reusable MCP JSON snippets and a smoke prompt under
+   `.dcc-mcp/agent-setup/`.
+
+Use PyPI instead of the local checkout when setting up an end-user machine:
+
+```bash
+python skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py --source pypi
+```
+
+If discovery fails, ask the user for the full `hython` path and re-run:
+
+```bash
+python skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py --hython "C:\Program Files\Side Effects Software\Houdini 20.5.487\bin\hython.exe"
+```
+
+## MCP Configuration
+
+The Houdini `123.py` autostart hook starts the embedded MCP server on the direct
+port by default. Configure the MCP host with:
+
+```json
+{
+  "mcpServers": {
+    "houdini": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+Use `http://127.0.0.1:9765/mcp` only when running multiple Houdini sessions
+behind the auto-gateway (`DCC_MCP_GATEWAY_PORT=9765`).
+
+When editing an existing MCP config, preserve unrelated servers. Merge only the
+`houdini` server entry unless the user asks for a different server name.
+
+## User Hand-Off: Load the Houdini Package / Autostart
+
+After pip setup and MCP JSON generation, tell the user to make the server start
+with Houdini. The recommended path is the bundled Houdini package:
+
+1. Install the Houdini package (quickinstall ZIP `install.ps1` / `install.sh`,
+   or a `dcc_mcp_houdini.json` package file pointing at the package root).
+2. The package adds `scripts/` to `HOUDINI_PATH`; on startup `123.py` extracts
+   bundled wheels into `vendor/` and starts the MCP server.
+3. Start Houdini and watch the console / shell for:
+   `dcc-mcp-houdini MCP server started: http://127.0.0.1:8765/mcp`.
+
+To run from a manual `hython` session instead of the package autostart:
+
+```python
+import dcc_mcp_houdini
+server = dcc_mcp_houdini.start_server()
+print(server.mcp_url)  # http://127.0.0.1:8765/mcp
+```
+
+Set `DCC_MCP_HOUDINI_AUTOSTART=0` to disable package autostart.
+
+## First Live Smoke Prompt
+
+Ask the MCP host to run this prompt after Houdini is open and the server is
+running:
+
+```text
+Use the Houdini MCP server. First call dcc_capability_manifest with loaded_only=false.
+Then load the houdini-nodes skill, create a geo node named mcp_setup_smoke_geo
+under /obj, list the obj-level nodes, and tell me the MCP URL and created node path.
+Use typed tools where available and avoid execute_python unless no typed tool fits.
+```
+
+Expected behavior:
+
+- The agent discovers capabilities without dumping every schema.
+- The agent loads `houdini-nodes`.
+- The agent calls `houdini_nodes__create_node` with `parent_path=/obj`,
+  `node_type=geo`, `node_name=mcp_setup_smoke_geo`.
+- The new node appears in the Houdini scene.
+- `houdini_scene__list_obj_nodes` confirms it exists.
+
+## Troubleshooting
+
+- `hython` not found: ask for the exact Houdini version and the
+  `bin/hython` path, then pass `--hython`.
+- Pip bootstrap fails: run `hython -m ensurepip --upgrade`, then repeat install.
+- MCP connection refused: Houdini is not running, autostart is disabled
+  (`DCC_MCP_HOUDINI_AUTOSTART=0`), or the host points at `9765` while the
+  session is on the direct `8765` port.
+- Tool missing: call `dcc_capability_manifest` or `search_skills`, then
+  `load_skill("<skill-name>")`.
+- Autostart silent: check the Houdini console for a
+  `dcc-mcp-houdini autostart failed` line and confirm the package JSON points at
+  the correct package root.

--- a/skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py
+++ b/skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py
@@ -1,0 +1,232 @@
+"""Prepare a Houdini hython environment for dcc-mcp-houdini MCP use."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+DEFAULT_DIRECT_URL = "http://127.0.0.1:8765/mcp"
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:9765/mcp"
+
+
+def run(command: List[str], cwd: Optional[Path] = None) -> None:
+    print("+ " + " ".join(command))
+    subprocess.check_call(command, cwd=str(cwd) if cwd else None)
+
+
+def _hython_name() -> str:
+    return "hython.exe" if os.name == "nt" else "hython"
+
+
+def _glob_install_roots() -> Iterable[Path]:
+    """Yield candidate hython binaries from common Houdini install locations."""
+    name = _hython_name()
+    if os.name == "nt":
+        roots = [
+            os.environ.get("ProgramFiles"),
+            os.environ.get("ProgramFiles(x86)"),
+            os.environ.get("ProgramW6432"),
+        ]
+        for root in roots:
+            if not root:
+                continue
+            sidefx = Path(root) / "Side Effects Software"
+            if not sidefx.is_dir():
+                continue
+            for houdini_dir in sorted(sidefx.glob("Houdini*"), reverse=True):
+                yield houdini_dir / "bin" / name
+    elif sys.platform == "darwin":
+        apps = Path("/Applications/Houdini")
+        if apps.is_dir():
+            for houdini_dir in sorted(apps.glob("Houdini*"), reverse=True):
+                yield houdini_dir / "Frameworks" / "Houdini.framework" / "Versions" / "Current" / "Resources" / "bin" / name
+                yield houdini_dir / "bin" / name
+    else:
+        opt = Path("/opt")
+        if opt.is_dir():
+            for hfs_dir in sorted(opt.glob("hfs*"), reverse=True):
+                yield hfs_dir / "bin" / name
+
+
+def candidate_hython_paths() -> Iterable[Path]:
+    env_value = os.environ.get("HYTHON") or os.environ.get("DCC_MCP_HOUDINI_HYTHON")
+    if env_value:
+        yield Path(env_value)
+
+    path_match = shutil.which("hython")
+    if path_match:
+        yield Path(path_match)
+
+    for candidate in _glob_install_roots():
+        yield candidate
+
+
+def resolve_hython(explicit: Optional[str]) -> Path:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.exists():
+            return path
+        raise SystemExit("hython does not exist: %s" % path)
+
+    seen = set()
+    for path in candidate_hython_paths():
+        expanded = path.expanduser()
+        key = str(expanded).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        if expanded.exists():
+            return expanded
+
+    raise SystemExit(
+        "Could not find hython. Re-run with --hython, or set HYTHON / "
+        "DCC_MCP_HOUDINI_HYTHON to the full path "
+        "(for example C:\\Program Files\\Side Effects Software\\Houdini 20.5.487\\bin\\hython.exe)."
+    )
+
+
+def find_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in [current] + list(current.parents):
+        if (parent / "pyproject.toml").exists() and (parent / "src" / "dcc_mcp_houdini").exists():
+            return parent
+    return Path.cwd()
+
+
+def _extra_exists(repo_root: Path, extra: str) -> bool:
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        return False
+    text = pyproject.read_text(encoding="utf-8")
+    return ("\n%s = [" % extra) in text or ("\n%s=[" % extra) in text
+
+
+def install_package(hython: Path, source: str, repo_root: Path, skip_install: bool) -> None:
+    if skip_install:
+        print("Skipping pip install because --skip-install was passed.")
+        return
+
+    run([str(hython), "-m", "ensurepip", "--upgrade"])
+    run(
+        [
+            str(hython),
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "pip<25; python_version<'3.8'",
+            "pip; python_version>='3.8'",
+        ]
+    )
+
+    if source == "local":
+        # dcc-mcp-houdini defines no runtime extra (only a dev extra in
+        # pyproject), so install the plain editable checkout. dcc-mcp-core is a
+        # hard dependency and is resolved automatically.
+        target = "."
+        if _extra_exists(repo_root, "sidecar"):
+            target = ".[sidecar]"
+        run([str(hython), "-m", "pip", "install", "-e", target], cwd=repo_root)
+    elif source == "pypi":
+        run([str(hython), "-m", "pip", "install", "--upgrade", "dcc-mcp-houdini"])
+    else:
+        raise SystemExit("Unknown source: %s" % source)
+
+
+def verify_import(hython: Path) -> None:
+    code = (
+        "import dcc_mcp_houdini; "
+        "print('dcc-mcp-houdini', dcc_mcp_houdini.__version__); "
+        "import dcc_mcp_core; "
+        "print('dcc-mcp-core import ok')"
+    )
+    run([str(hython), "-c", code])
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print("Wrote %s" % path)
+
+
+def write_mcp_snippets(out_dir: Path, server_name: str, mcp_url: str) -> None:
+    payload = {"mcpServers": {server_name: {"url": mcp_url}}}
+    write_json(out_dir / "mcp-streamable-http.json", payload)
+
+    gateway_payload = {"mcpServers": {server_name: {"url": DEFAULT_GATEWAY_URL}}}
+    write_json(out_dir / "mcp-gateway-9765.json", gateway_payload)
+
+    smoke_prompt = """Use the Houdini MCP server. First call dcc_capability_manifest with loaded_only=false.
+Then load the houdini-nodes skill, create a geo node named mcp_setup_smoke_geo
+under /obj, list the obj-level nodes, and tell me the MCP URL and created node path.
+Use typed tools where available and avoid execute_python unless no typed tool fits.
+"""
+    smoke_path = out_dir / "smoke-prompt.txt"
+    smoke_path.write_text(smoke_prompt, encoding="utf-8")
+    print("Wrote %s" % smoke_path)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hython", help="Full path to Houdini hython.")
+    parser.add_argument(
+        "--source",
+        choices=["local", "pypi"],
+        default="local",
+        help="Install from this checkout or from PyPI. Default: local.",
+    )
+    parser.add_argument(
+        "--mcp-url",
+        default=DEFAULT_DIRECT_URL,
+        help="MCP URL to write into generated host config. Default: direct autostart URL.",
+    )
+    parser.add_argument(
+        "--server-name",
+        default="houdini",
+        help="MCP server name in generated config. Default: houdini.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=".dcc-mcp/agent-setup",
+        help="Directory for generated MCP snippets. Default: .dcc-mcp/agent-setup.",
+    )
+    parser.add_argument(
+        "--skip-install",
+        action="store_true",
+        help="Only verify imports and write MCP snippets.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]) -> int:
+    args = parse_args(argv)
+    repo_root = find_repo_root()
+    hython = resolve_hython(args.hython)
+    out_dir = (repo_root / args.out_dir).resolve()
+
+    print("Repository: %s" % repo_root)
+    print("hython: %s" % hython)
+    print("MCP URL: %s" % args.mcp_url)
+
+    install_package(hython, args.source, repo_root, args.skip_install)
+    verify_import(hython)
+    write_mcp_snippets(out_dir, args.server_name, args.mcp_url)
+
+    print("")
+    print("Next:")
+    print("1. Install the Houdini package so 123.py autostart runs (see install.md).")
+    print("2. Start Houdini; watch for the 'dcc-mcp-houdini MCP server started' line.")
+    print("3. Configure the MCP host with %s." % (out_dir / "mcp-streamable-http.json"))
+    print("4. Run the smoke prompt in %s." % (out_dir / "smoke-prompt.txt"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/dcc_mcp_houdini/__init__.py
+++ b/src/dcc_mcp_houdini/__init__.py
@@ -1,16 +1,48 @@
 """SideFX Houdini adapter for DCC MCP Core."""
 
 from dcc_mcp_houdini.__version__ import __version__
+from dcc_mcp_houdini._capability_manifest import (
+    CapabilityRecord,
+    HoudiniCapabilityManifestBuilder,
+    build_manifest_payload,
+    register_capability_mcp_tool,
+)
+from dcc_mcp_houdini._context_snapshot import (
+    HoudiniContextSnapshotProvider,
+    collect_gateway_metadata,
+    make_snapshot_provider,
+)
 from dcc_mcp_houdini._env import (
     ENV_ENABLE_GATEWAY_FAILOVER,
     ENV_GATEWAY_PORT,
     ENV_METRICS,
     ENV_PORT,
+    ENV_PROJECT_TOOLS,
+    ENV_QT_UI_INSPECTOR,
     ENV_READINESS_TIMEOUT_SECS,
+    ENV_RESOURCES,
+    ENV_SEMANTIC_EMBEDDER,
+    ENV_SEMANTIC_INDEX,
     resolve_enable_gateway_failover,
     resolve_minimal_mode_enabled,
 )
+from dcc_mcp_houdini._project_tools import (
+    HoudiniSceneResolver,
+    ProjectToolsIntegration,
+)
+from dcc_mcp_houdini._project_tools import (
+    attach_to_server as attach_project_tools,
+)
+from dcc_mcp_houdini._qt_inspector import register_houdini_qt_ui_inspector
 from dcc_mcp_houdini._readiness import ReadinessBinder, install_readiness
+from dcc_mcp_houdini._resources import (
+    HoudiniResourceBinder,
+    install_resources,
+)
+from dcc_mcp_houdini._semantic_index import (
+    HoudiniSemanticIndex,
+    build_semantic_index,
+)
 from dcc_mcp_houdini._skill_loader import (
     MINIMAL_SKILLS,
     STAGE_SKILLS,
@@ -58,21 +90,36 @@ __all__ = [
     "ENV_GATEWAY_PORT",
     "ENV_METRICS",
     "ENV_PORT",
+    "ENV_PROJECT_TOOLS",
+    "ENV_QT_UI_INSPECTOR",
     "ENV_READINESS_TIMEOUT_SECS",
+    "ENV_RESOURCES",
+    "ENV_SEMANTIC_EMBEDDER",
+    "ENV_SEMANTIC_INDEX",
+    "CapabilityRecord",
     "HoudiniCallableDispatcher",
+    "HoudiniCapabilityManifestBuilder",
+    "HoudiniContextSnapshotProvider",
     "HoudiniHost",
     "HoudiniMcpServer",
+    "HoudiniResourceBinder",
+    "HoudiniSceneResolver",
+    "HoudiniSemanticIndex",
     "HoudiniServerOptions",
     "HoudiniStandaloneDispatcher",
     "MINIMAL_SKILLS",
     "MissingParamError",
+    "ProjectToolsIntegration",
     "ReadinessBinder",
     "SERVER_NAME",
     "STAGES",
     "STAGE_SKILLS",
+    "attach_project_tools",
+    "build_manifest_payload",
     "build_minimal_mode_config",
     "build_minimal_mode_for_stages",
-    "skills_for_stage",
+    "build_semantic_index",
+    "collect_gateway_metadata",
     "create_execution_stack",
     "get_houdini_version_string",
     "get_houdini_version_tuple",
@@ -82,11 +129,16 @@ __all__ = [
     "houdini_from_exception",
     "houdini_success",
     "install_readiness",
+    "install_resources",
     "is_houdini_available",
     "is_hou_available",
+    "make_snapshot_provider",
+    "register_capability_mcp_tool",
+    "register_houdini_qt_ui_inspector",
     "require_param",
     "resolve_enable_gateway_failover",
     "resolve_minimal_mode_enabled",
+    "skills_for_stage",
     "start_server",
     "stop_server",
     "with_houdini",

--- a/src/dcc_mcp_houdini/_capability_manifest.py
+++ b/src/dcc_mcp_houdini/_capability_manifest.py
@@ -1,0 +1,563 @@
+"""Compact Houdini capability manifest for gateway indexing.
+
+Mirrors :mod:`dcc_mcp_maya.capability_manifest`.  The gateway capability index
+wants a **compact** view of what each DCC instance can do without paying the
+cost of exploding every unloaded skill's full MCP schema into ``tools/list``.
+
+SOLID notes
+-----------
+* :class:`CapabilityRecord` — value object; no behaviour.
+* :class:`HoudiniCapabilityManifestBuilder` — single responsibility: project
+  the live ``SkillCatalog`` into a list of :class:`CapabilityRecord`.
+* :func:`build_manifest_payload` — pure function turning a builder output into
+  the final manifest dict (adds instance metadata + capability flags).
+* :func:`register_capability_mcp_tool` — side effect: registers the
+  ``dcc_capability_manifest`` MCP tool so agents can fetch the manifest without
+  going through the gateway REST route.
+
+No module here talks to Houdini directly — the snapshot is requested from
+whatever provider is installed on the server, so the code is safe in headless /
+test contexts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CapabilityRecord",
+    "HoudiniCapabilityManifestBuilder",
+    "build_manifest_payload",
+    "register_capability_mcp_tool",
+]
+
+_DCC_NAME = "houdini"
+
+# Stub-prefix filter mirrors what the core gateway filter drops from the index.
+_SKILL_STUB_PREFIX = "__skill__"
+_GROUP_STUB_PREFIX = "__group__"
+
+
+# ---------------------------------------------------------------------------
+# Value object
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CapabilityRecord:
+    """Compact per-action record.
+
+    Field semantics match the core CapabilityIndex record so gateway-side
+    consumers can ingest the manifest directly.
+    """
+
+    tool_slug: str
+    backend_tool: str
+    skill_name: str
+    summary: str
+    loaded: bool
+    tags: List[str] = field(default_factory=list)
+    execution: Optional[str] = None
+    affinity: Optional[str] = None
+    timeout_hint_secs: Optional[int] = None
+    has_schema: bool = False
+    group: Optional[str] = None
+    load_hint: Dict[str, Any] = field(default_factory=dict)
+    requires_load_skill: bool = False
+    callable_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Plain dict form suitable for JSON serialisation."""
+        payload = asdict(self)
+        out = {k: v for k, v in payload.items() if v not in (None, [], "", {})}
+        if out.get("requires_load_skill") is False:
+            out.pop("requires_load_skill", None)
+        if out.get("callable_id") == out.get("backend_tool"):
+            out.pop("callable_id", None)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+class HoudiniCapabilityManifestBuilder:
+    """Turn live catalog state into a list of :class:`CapabilityRecord`.
+
+    Dependencies are injected via constructor for testability:
+
+    * ``skill_lister`` — returns the catalog's skill summaries.
+    * ``action_lister`` — returns raw action dicts.
+    * ``is_loaded`` — predicate ``(skill_name) -> bool``.
+    * ``skill_info_lister`` — returns per-skill detail (for unloaded tools).
+
+    The builder never touches Houdini state — it only projects what the catalog
+    already discovered, so calling it during startup is safe.
+    """
+
+    def __init__(
+        self,
+        dcc_name: str = _DCC_NAME,
+        *,
+        skill_lister: Optional[Callable[[], List[Any]]] = None,
+        action_lister: Optional[Callable[[], List[Any]]] = None,
+        is_loaded: Optional[Callable[[str], bool]] = None,
+        skill_info_lister: Optional[Callable[[str], Any]] = None,
+    ) -> None:
+        self._dcc_name = dcc_name
+        self._skill_lister = skill_lister
+        self._action_lister = action_lister
+        self._is_loaded = is_loaded
+        self._skill_info_lister = skill_info_lister
+
+    # ------------------------------------------------------------------ API
+
+    def build(self) -> List[CapabilityRecord]:
+        """Return records for every non-stub action in the catalog."""
+        skills_by_name = self._collect_skill_info()
+        records: List[CapabilityRecord] = []
+        covered_tools: set[str] = set()
+
+        for action in self._collect_actions():
+            record = self._project_action(action, skills_by_name)
+            if record is None:
+                continue
+            records.append(record)
+            covered_tools.add(record.backend_tool)
+
+        for skill_name, skill_info in skills_by_name.items():
+            if self._is_loaded_safe(skill_name):
+                continue
+            for tool in self._collect_skill_tools(skill_name, skill_info):
+                record = self._project_unloaded_action(
+                    skill_name=skill_name,
+                    tool=tool,
+                    skill_info=skill_info,
+                )
+                if record is None:
+                    continue
+                if record.backend_tool in covered_tools:
+                    continue
+                records.append(record)
+                covered_tools.add(record.backend_tool)
+
+        return records
+
+    # ------------------------------------------------------------ internals
+
+    def _collect_skill_info(self) -> Dict[str, Dict[str, Any]]:
+        skills: Dict[str, Dict[str, Any]] = {}
+        if self._skill_lister is None:
+            return skills
+        try:
+            raw = self._skill_lister() or []
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: skill_lister failed: %s", exc)
+            return skills
+
+        for item in raw:
+            entry = _as_dict(item)
+            name = entry.get("name") or entry.get("skill_name")
+            if not name:
+                continue
+            skills[name] = entry
+        return skills
+
+    def _collect_actions(self) -> List[Dict[str, Any]]:
+        if self._action_lister is None:
+            return []
+        try:
+            raw = self._action_lister() or []
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: action_lister failed: %s", exc)
+            return []
+        return [_as_dict(a) for a in raw if a]
+
+    def _project_action(
+        self,
+        action: Dict[str, Any],
+        skills_by_name: Dict[str, Dict[str, Any]],
+    ) -> Optional[CapabilityRecord]:
+        name = action.get("name") or action.get("tool")
+        if not name or _is_stub(name):
+            return None
+
+        skill_name = action.get("skill") or action.get("skill_name") or _derive_skill(name)
+        skill_info = skills_by_name.get(skill_name or "", {})
+        summary = _truncate(
+            _first_nonempty(
+                action.get("summary"),
+                action.get("description"),
+                skill_info.get("summary"),
+                skill_info.get("description"),
+                "",
+            ),
+            200,
+        )
+
+        tags: List[str] = []
+        for source in (
+            action.get("tags"),
+            skill_info.get("tags"),
+            [action.get("category")],
+            [action.get("group")],
+        ):
+            tags.extend(_as_str_list(source))
+        tags = sorted({t for t in tags if t})
+
+        loaded = self._is_loaded_safe(skill_name) if skill_name else False
+
+        execution = _maybe_str(action.get("execution"))
+        affinity = _maybe_str(action.get("affinity"))
+        timeout_hint = _maybe_int(action.get("timeout_hint_secs"))
+
+        has_schema = bool(action.get("input_schema") or action.get("inputSchema"))
+
+        slug = _slugify_tool_slug(self._dcc_name, name)
+        return CapabilityRecord(
+            tool_slug=slug,
+            backend_tool=name,
+            skill_name=skill_name or "",
+            summary=summary or "",
+            loaded=bool(loaded),
+            tags=tags,
+            execution=execution,
+            affinity=affinity,
+            timeout_hint_secs=timeout_hint,
+            has_schema=has_schema,
+            group=_maybe_str(action.get("group")),
+            callable_id=name,
+        )
+
+    def _collect_skill_tools(
+        self,
+        skill_name: str,
+        skill_info: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        """Return per-tool entries declared by an unloaded skill."""
+        tools = skill_info.get("tools") or skill_info.get("actions")
+        if isinstance(tools, list) and tools and isinstance(tools[0], dict):
+            return [dict(t) for t in tools]
+
+        if self._skill_info_lister is None:
+            return []
+        try:
+            info = self._skill_info_lister(skill_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: skill_info(%r) raised %s", skill_name, exc)
+            return []
+        if not info:
+            return []
+        entry = _as_dict(info)
+        collected = entry.get("tools") or entry.get("actions") or []
+        return [_as_dict(t) for t in collected if t]
+
+    def _project_unloaded_action(
+        self,
+        *,
+        skill_name: str,
+        tool: Dict[str, Any],
+        skill_info: Dict[str, Any],
+    ) -> Optional[CapabilityRecord]:
+        tool_name = tool.get("name") or tool.get("tool")
+        if not tool_name or _is_stub(tool_name):
+            return None
+
+        backend_tool = "{}__{}".format(skill_name.replace("-", "_"), tool_name)
+        summary = _truncate(
+            _first_nonempty(
+                tool.get("summary"),
+                tool.get("description"),
+                "",
+            ),
+            160,
+        )
+
+        tags: List[str] = []
+        for source in (
+            tool.get("tags"),
+            skill_info.get("tags"),
+            [tool.get("category")],
+            [tool.get("group")],
+        ):
+            tags.extend(_as_str_list(source))
+        tags = sorted({t for t in tags if t})
+
+        schema = tool.get("input_schema") or tool.get("inputSchema")
+        has_schema = bool(schema) and not _is_stub(tool_name)
+
+        return CapabilityRecord(
+            tool_slug=_slugify_tool_slug(self._dcc_name, backend_tool),
+            backend_tool=backend_tool,
+            skill_name=skill_name,
+            summary=summary,
+            loaded=False,
+            tags=tags,
+            execution=_maybe_str(tool.get("execution")),
+            affinity=_maybe_str(tool.get("affinity")),
+            timeout_hint_secs=_maybe_int(tool.get("timeout_hint_secs")),
+            has_schema=has_schema,
+            group=_maybe_str(tool.get("group")),
+            requires_load_skill=True,
+            load_hint={"tool": "load_skill", "arguments": {"skill_name": skill_name}},
+            callable_id=backend_tool,
+        )
+
+    def _is_loaded_safe(self, skill_name: str) -> bool:
+        if self._is_loaded is None:
+            return False
+        try:
+            return bool(self._is_loaded(skill_name))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: is_loaded(%r) raised %s", skill_name, exc)
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+
+def build_manifest_payload(
+    records: List[CapabilityRecord],
+    *,
+    dcc_name: str = _DCC_NAME,
+    dcc_version: Optional[str] = None,
+    scene: Optional[str] = None,
+    display_name: Optional[str] = None,
+    instance_id: Optional[str] = None,
+    documents: Optional[List[str]] = None,
+    extra_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Wrap records with instance metadata for gateway ingestion."""
+    loaded_records = [r for r in records if r.loaded]
+    unloaded_records = [r for r in records if not r.loaded]
+    manifest = {
+        "schema_version": "1",
+        "dcc_type": dcc_name,
+        "metadata": {
+            "instance_id": instance_id,
+            "dcc_version": dcc_version,
+            "scene": scene,
+            "display_name": display_name,
+            "documents": documents or [],
+        },
+        "totals": {
+            "actions": len(records),
+            "loaded_actions": len(loaded_records),
+            "unloaded_actions": len(unloaded_records),
+            "skills": len({r.skill_name for r in records if r.skill_name}),
+            "loaded_skills": len({r.skill_name for r in loaded_records if r.skill_name}),
+            "unloaded_skills": len({r.skill_name for r in unloaded_records if r.skill_name}),
+        },
+        "capabilities": [r.to_dict() for r in records],
+    }
+    if extra_metadata:
+        manifest["metadata"].update({k: v for k, v in extra_metadata.items() if v is not None})
+    manifest["metadata"] = {k: v for k, v in manifest["metadata"].items() if v not in (None, "")}
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# MCP tool registration
+# ---------------------------------------------------------------------------
+
+
+def register_capability_mcp_tool(server: Any, *, builder: HoudiniCapabilityManifestBuilder) -> bool:
+    """Register ``dcc_capability_manifest`` as an MCP tool.
+
+    Returns ``True`` when the registration succeeded.  Both registry
+    declaration and handler wiring are wrapped in try/except so failures only
+    disable the capability tool without breaking server startup.
+    """
+    inner = getattr(server, "_server", None)
+    if inner is None:
+        logger.debug("capability manifest: server has no inner _server; skipping")
+        return False
+
+    tool_name = "dcc_capability_manifest"
+    description = (
+        "Return a compact Houdini capability manifest listing every discoverable "
+        "action (loaded and unloaded), tagged by skill/group. Prefer this over "
+        "tools/list when the caller only needs to decide which skill to load."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "loaded_only": {
+                "type": "boolean",
+                "description": "When true, omit records for unloaded skills.",
+                "default": False,
+            },
+        },
+        "additionalProperties": False,
+    }
+
+    def handler(params: Dict[str, Any]) -> Dict[str, Any]:
+        records = builder.build()
+        if params.get("loaded_only"):
+            records = [r for r in records if r.loaded]
+
+        instance_id = _extract_instance_id(server)
+        scene = getattr(getattr(server, "_config", None), "scene", None)
+        version = getattr(getattr(server, "_config", None), "dcc_version", None)
+        payload = build_manifest_payload(
+            records,
+            dcc_name=_DCC_NAME,
+            dcc_version=version,
+            scene=scene,
+            instance_id=instance_id,
+        )
+        return {
+            "success": True,
+            "message": "Houdini capability manifest",
+            "context": payload,
+        }
+
+    registry = getattr(inner, "registry", None)
+    declared = False
+    if registry is not None and hasattr(registry, "register"):
+        try:
+            registry.register(
+                tool_name,
+                description=description,
+                category="dcc",
+                tags=["capability", "manifest", "dcc", "houdini"],
+                dcc=_DCC_NAME,
+                input_schema=json.dumps(input_schema),
+                skill_name="dcc-adapter",
+                group="capability",
+                execution="sync",
+                thread_affinity="any",
+                enabled=True,
+            )
+            declared = True
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("capability manifest: registry.register failed: %s", exc)
+
+    if not declared:
+        logger.debug("capability manifest: could not declare tool — skipping")
+        return False
+
+    try:
+        inner.register_handler(tool_name, handler)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("capability manifest: register_handler failed: %s", exc)
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SLUG_CLEAN_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _slugify_tool_slug(dcc_name: str, tool_name: str) -> str:
+    """Produce a placeholder slug; the gateway rewrites ``instance`` at ingest."""
+    clean_dcc = _SLUG_CLEAN_RE.sub("_", dcc_name)
+    clean_tool = _SLUG_CLEAN_RE.sub("_", tool_name)
+    return "{}.instance.{}".format(clean_dcc, clean_tool)
+
+
+def _is_stub(name: str) -> bool:
+    return name.startswith(_SKILL_STUB_PREFIX) or name.startswith(_GROUP_STUB_PREFIX)
+
+
+def _derive_skill(tool_name: str) -> Optional[str]:
+    """Infer the parent skill from the ``{skill}__{script}`` convention."""
+    if "__" not in tool_name:
+        return None
+    return tool_name.split("__", 1)[0].replace("_", "-")
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            result = to_dict()
+            if isinstance(result, dict):
+                return result
+        except (TypeError, ValueError, AttributeError) as exc:
+            logger.debug("capability manifest: to_dict(%r) failed: %s", type(value), exc)
+    out: Dict[str, Any] = {}
+    for attr in dir(value):
+        if attr.startswith("_"):
+            continue
+        try:
+            candidate = getattr(value, attr)
+        except (AttributeError, TypeError) as exc:
+            logger.debug("capability manifest: getattr(%r, %s) failed: %s", type(value), attr, exc)
+            continue
+        if callable(candidate):
+            continue
+        out[attr] = candidate
+    return out
+
+
+def _as_str_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [str(v) for v in value if v]
+    return [str(value)]
+
+
+def _first_nonempty(*values: Any) -> str:
+    for v in values:
+        if v:
+            return str(v)
+    return ""
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _maybe_str(value: Any) -> Optional[str]:
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+def _maybe_int(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_instance_id(server: Any) -> Optional[str]:
+    """Best-effort extraction of this adapter's instance_id."""
+    for chain in (
+        ("instance_id",),
+        ("_config", "instance_id"),
+        ("_server", "instance_id"),
+        ("_handle", "instance_id"),
+    ):
+        target = server
+        try:
+            for part in chain:
+                target = getattr(target, part)
+            if target:
+                return str(target)
+        except AttributeError:
+            continue
+    return None

--- a/src/dcc_mcp_houdini/_context_snapshot.py
+++ b/src/dcc_mcp_houdini/_context_snapshot.py
@@ -1,0 +1,209 @@
+"""Houdini context snapshot provider for gateway routing and REST ``/v1/context``.
+
+Mirrors :mod:`dcc_mcp_maya.context_snapshot`.  Feeds Houdini-specific live
+scene state (hip file, frame range, object count, version) into core's
+post-tool ``append_context_snapshot`` helper and into
+:meth:`DccServerBase.update_gateway_metadata`.
+
+Design
+------
+* :class:`HoudiniContextSnapshotProvider` is a callable that returns a fresh
+  context dict on every invocation.  It is **small**, **pure**, and tolerant
+  of a missing ``hou`` module: in standalone / headless / subprocess contexts
+  it returns a minimal stub instead of crashing.
+* :func:`collect_gateway_metadata` returns the subset consumed by
+  :meth:`DccServerBase.update_gateway_metadata` (scene / version / documents /
+  display_name).
+
+Both helpers obey *Single Responsibility* — they only collect state.  They
+never mutate Houdini, and they never raise.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HoudiniContextSnapshotProvider",
+    "collect_gateway_metadata",
+    "make_snapshot_provider",
+]
+
+
+class HoudiniContextSnapshotProvider:
+    """Callable returning a fresh Houdini context snapshot.
+
+    Register with
+    :meth:`dcc_mcp_core.server_base.DccServerBase.set_context_snapshot_provider`
+    so the core post-tool wrapper can append ``context.houdini`` to every
+    result envelope.
+
+    Parameters
+    ----------
+    hou_provider:
+        Optional factory returning the ``hou`` module (or a duck-typed
+        stand-in for tests).  Defaults to a lazy import of ``hou`` with a
+        headless-safe fallback.
+    """
+
+    def __init__(self, hou_provider: Optional[Callable[[], Any]] = None) -> None:
+        self._hou_provider = hou_provider or _default_hou_provider
+
+    # ------------------------------------------------------------------ API
+
+    def __call__(self) -> Dict[str, Any]:
+        return self.collect()
+
+    def collect(self) -> Dict[str, Any]:
+        """Return a fresh context snapshot dict.
+
+        Keys (all optional — omitted when unavailable)::
+
+            {
+                "dcc":          "houdini",
+                "scene":        "/path/to/current.hip",
+                "scene_saved":  True | False,
+                "frame":        1001,
+                "frame_range":  [1001, 1100],
+                "obj_node_count": 12,
+                "display_name": "Houdini 20.5 — shot.hip",
+                "version":      "20.5.445",
+                "pid":          12345,
+                "available":    True | False,
+            }
+
+        The method never raises; ``hou`` probes are guarded so headless /
+        standalone contexts return ``{"dcc": "houdini", "available": False}``.
+        """
+        snapshot: Dict[str, Any] = {
+            "dcc": "houdini",
+            "pid": os.getpid(),
+            "available": False,
+        }
+
+        hou = self._safe_hou()
+        if hou is None:
+            return snapshot
+
+        snapshot["available"] = True
+
+        # Scene (hip) path ---------------------------------------------------
+        scene = _safe(lambda: hou.hipFile.path())
+        has_file = _safe(lambda: bool(hou.hipFile.hasFile()))
+        if scene and has_file:
+            snapshot["scene"] = scene
+        modified = _safe(lambda: bool(hou.hipFile.hasUnsavedChanges()))
+        if modified is not None:
+            snapshot["scene_saved"] = not modified
+
+        # Timeline -----------------------------------------------------------
+        frame = _safe(lambda: hou.frame())
+        if frame is not None:
+            try:
+                snapshot["frame"] = int(frame)
+            except (TypeError, ValueError):
+                pass
+
+        play_range = _safe(lambda: hou.playbar.playbackRange())
+        if play_range is not None:
+            try:
+                snapshot["frame_range"] = [int(play_range[0]), int(play_range[1])]
+            except (TypeError, ValueError, IndexError):
+                pass
+
+        # Object count -------------------------------------------------------
+        obj_count = _safe(lambda: len(hou.node("/obj").children()) if hou.node("/obj") is not None else 0)
+        if obj_count is not None:
+            snapshot["obj_node_count"] = int(obj_count)
+
+        # Version ------------------------------------------------------------
+        version = _safe(lambda: hou.applicationVersionString())
+        if version:
+            snapshot["version"] = str(version)
+
+        display = _derive_display_name(snapshot.get("scene"), snapshot.get("version"))
+        if display:
+            snapshot["display_name"] = display
+
+        return snapshot
+
+    # ------------------------------------------------------------ internals
+
+    def _safe_hou(self) -> Any:
+        try:
+            return self._hou_provider()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("HoudiniContextSnapshotProvider: hou unavailable: %s", exc)
+            return None
+
+
+def collect_gateway_metadata(
+    provider: Optional[Callable[[], Dict[str, Any]]] = None,
+) -> Dict[str, Optional[Any]]:
+    """Return a subset snapshot suitable for :meth:`update_gateway_metadata`.
+
+    Returns a dict with keys ``scene`` / ``version`` / ``documents`` /
+    ``display_name``.  Houdini is a single-document DCC, so ``documents`` is
+    ``[scene]`` when a hip file is open, otherwise ``[]``.
+    """
+    if provider is None:
+        provider = HoudiniContextSnapshotProvider()
+    snapshot = provider() or {}
+    scene = snapshot.get("scene")
+    documents: Optional[List[str]] = [scene] if scene else []
+    return {
+        "scene": scene if scene else None,
+        "version": snapshot.get("version"),
+        "documents": documents,
+        "display_name": snapshot.get("display_name"),
+    }
+
+
+def make_snapshot_provider(
+    hou_provider: Optional[Callable[[], Any]] = None,
+) -> HoudiniContextSnapshotProvider:
+    """Factory for a :class:`HoudiniContextSnapshotProvider`."""
+    return HoudiniContextSnapshotProvider(hou_provider=hou_provider)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_hou_provider() -> Any:
+    """Return the ``hou`` module when available, else ``None``."""
+    try:
+        import hou  # noqa: PLC0415
+
+        return hou
+    except Exception:  # noqa: BLE001 — headless / non-Houdini interpreter
+        return None
+
+
+def _safe(fn: Callable[[], Any]) -> Any:
+    """Invoke ``fn`` swallowing any exception, returning ``None`` on failure."""
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001 — hou raises hou.OperationFailed etc.
+        logger.debug("HoudiniContextSnapshot: probe raised %s", exc)
+        return None
+
+
+def _derive_display_name(scene: Optional[str], version: Optional[str]) -> Optional[str]:
+    """Produce a human-readable instance label for gateway disambiguation."""
+    if scene:
+        try:
+            basename = os.path.basename(scene) or scene
+        except Exception:  # noqa: BLE001
+            basename = scene
+        if version:
+            return "Houdini {} — {}".format(version, basename)
+        return "Houdini — {}".format(basename)
+    if version:
+        return "Houdini {}".format(version)
+    return None

--- a/src/dcc_mcp_houdini/_env.py
+++ b/src/dcc_mcp_houdini/_env.py
@@ -16,11 +16,21 @@ ENV_ENABLE_GATEWAY_FAILOVER = "DCC_MCP_HOUDINI_ENABLE_GATEWAY_FAILOVER"
 ENV_READINESS_TIMEOUT_SECS = "DCC_MCP_HOUDINI_READINESS_TIMEOUT_SECS"
 ENV_PORT = "DCC_MCP_HOUDINI_PORT"
 ENV_GATEWAY_PORT = "DCC_MCP_GATEWAY_PORT"
+
+# Optional core-integration opt-out / opt-in switches (parity with Maya).
+ENV_RESOURCES = "DCC_MCP_HOUDINI_RESOURCES"
+ENV_PROJECT_TOOLS = "DCC_MCP_HOUDINI_PROJECT_TOOLS"
+ENV_QT_UI_INSPECTOR = "DCC_MCP_HOUDINI_QT_UI_INSPECTOR"
+ENV_SEMANTIC_INDEX = "DCC_MCP_HOUDINI_SEMANTIC_INDEX"
+ENV_SEMANTIC_EMBEDDER = "DCC_MCP_HOUDINI_SEMANTIC_EMBEDDER"
+
 DEFAULT_JOB_DB_FILENAME = "jobs.db"
+
+_TRUTHY = ("1", "true", "yes", "on")
 
 
 def _env_truthy(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
 
 
 def get_extra_skill_paths() -> list[str]:
@@ -89,3 +99,42 @@ def resolve_minimal_mode_enabled() -> bool:
     """Return True when progressive minimal mode should be used at startup."""
     raw = os.environ.get("DCC_MCP_MINIMAL", "1").strip().lower()
     return raw not in ("0", "false", "no", "off")
+
+
+def _resolve_default_on(env_name: str, flag: Optional[bool]) -> bool:
+    """Resolve an opt-out switch: explicit ``flag`` > env (``"0"`` disables) > True."""
+    if flag is not None:
+        return bool(flag)
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return True
+    return raw.strip() != "0"
+
+
+def resolve_resources_enabled(flag: Optional[bool] = None) -> bool:
+    """Resolve whether MCP resource publishing should run (default enabled)."""
+    return _resolve_default_on(ENV_RESOURCES, flag)
+
+
+def resolve_project_tools_enabled(flag: Optional[bool] = None) -> bool:
+    """Resolve whether project-state tools should be wired (default enabled)."""
+    return _resolve_default_on(ENV_PROJECT_TOOLS, flag)
+
+
+def resolve_qt_ui_inspector_enabled(env: Optional[dict] = None) -> bool:
+    """Return ``True`` unless ``DCC_MCP_HOUDINI_QT_UI_INSPECTOR`` is falsey (default on)."""
+    environ = env if env is not None else os.environ
+    return str(environ.get(ENV_QT_UI_INSPECTOR, "1")).strip().lower() in _TRUTHY
+
+
+def resolve_semantic_index_enabled(env: Optional[dict] = None) -> bool:
+    """Return ``True`` when ``DCC_MCP_HOUDINI_SEMANTIC_INDEX`` is truthy (default off)."""
+    environ = env if env is not None else os.environ
+    return str(environ.get(ENV_SEMANTIC_INDEX, "")).strip().lower() in _TRUTHY
+
+
+def resolve_semantic_embedder_kind(env: Optional[dict] = None) -> str:
+    """Return the embedder kind: ``"hashed"`` (default) or ``"onnx"``."""
+    environ = env if env is not None else os.environ
+    kind = str(environ.get(ENV_SEMANTIC_EMBEDDER, "hashed")).strip().lower()
+    return "onnx" if kind == "onnx" else "hashed"

--- a/src/dcc_mcp_houdini/_project_tools.py
+++ b/src/dcc_mcp_houdini/_project_tools.py
@@ -1,0 +1,228 @@
+"""Houdini integration for ``dcc_mcp_core.register_project_tools``.
+
+Mirrors :mod:`dcc_mcp_maya._project_tools`.  Wires the four project-persistence
+MCP/REST tools from ``dcc-mcp-core``:
+
+* ``project_save``   — persist current Houdini project state to ``.dcc-mcp/project.json``
+* ``project_load``   — read an existing ``project.json`` back
+* ``project_resume`` — return the rehydration payload an agent needs to restore
+  scene, assets, active skills, tool groups and checkpoint IDs
+* ``project_status`` — pure-read snapshot of the current state
+
+Design notes (SOLID)
+--------------------
+* **Single Responsibility** — only orchestration: resolve the *current*
+  Houdini hip file (so agents can call ``project_save`` with no arguments while
+  inside Houdini) and forward to ``register_project_tools``.
+* **Open/Closed** — the scene resolver is injectable
+  (:class:`HoudiniSceneResolver`).  Tests subclass it to fake a hip path
+  without touching ``hou``.
+* **Dependency Inversion** — scene resolution is isolated behind
+  :class:`HoudiniSceneResolver`, while core project persistence is used via its
+  public ``register_project_tools`` contract.
+
+Opt-out
+-------
+Set ``DCC_MCP_HOUDINI_PROJECT_TOOLS=0`` to skip registration.  Default is
+**enabled** because the four tools are pure filesystem operations.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from dcc_mcp_core import DccProject, register_project_tools
+
+from dcc_mcp_houdini._env import ENV_PROJECT_TOOLS, resolve_project_tools_enabled
+
+logger = logging.getLogger(__name__)
+
+_DCC_NAME = "houdini"
+
+__all__ = [
+    "ENV_PROJECT_TOOLS",
+    "HoudiniSceneResolver",
+    "ProjectToolsIntegration",
+    "attach_to_server",
+    "resolve_enabled",
+]
+
+# ``resolve_enabled`` kept as a module-level alias for parity with Maya tests.
+resolve_enabled = resolve_project_tools_enabled
+
+
+# ---------------------------------------------------------------------------
+# Scene resolution strategy
+# ---------------------------------------------------------------------------
+
+
+class HoudiniSceneResolver:
+    """Resolve the *current* Houdini hip file path, if one is saved.
+
+    Returning ``None`` is a first-class signal — :func:`bind` then skips
+    binding a default project so the four MCP tools require an explicit
+    ``scene_path`` / ``project_dir`` argument from the caller.
+
+    The default implementation calls ``hou.hipFile.path()`` inside a guarded
+    import block so this module remains usable outside Houdini (unit tests,
+    headless ``hython`` before a hip is loaded, gateway-only deployments).
+    """
+
+    def current_scene(self) -> Optional[str]:
+        """Return the absolute hip path, or ``None`` when unavailable/unsaved."""
+        try:
+            import hou  # noqa: PLC0415
+        except Exception:  # noqa: BLE001 — Houdini unavailable
+            return None
+        try:
+            if not bool(hou.hipFile.hasFile()):
+                return None
+            scene = hou.hipFile.path()
+        except Exception as exc:  # noqa: BLE001 — Houdini in odd state
+            logger.debug("HoudiniSceneResolver: hou.hipFile.path() failed: %s", exc)
+            return None
+        scene = (scene or "").strip()
+        return scene or None
+
+
+# ---------------------------------------------------------------------------
+# Integration object
+# ---------------------------------------------------------------------------
+
+
+class ProjectToolsIntegration:
+    """Bind ``register_project_tools`` against a :class:`HoudiniMcpServer`."""
+
+    def __init__(
+        self,
+        *,
+        dcc_name: str = _DCC_NAME,
+        scene_resolver: Optional[HoudiniSceneResolver] = None,
+    ) -> None:
+        self.dcc_name = dcc_name
+        self.scene_resolver = scene_resolver or HoudiniSceneResolver()
+        self.bound_scene: Optional[str] = None
+        self.bound_project: Any = None
+        self.registered: bool = False
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def bind(
+        self,
+        server: Any,
+        *,
+        project_factory: Optional[Callable[[str], Any]] = None,
+        explicit_project: Any = None,
+    ) -> bool:
+        """Register the four project tools on *server*.
+
+        Returns ``True`` when the four tools were registered, ``False`` when the
+        inner server is unavailable or registration fails.
+        """
+        inner = self._inner_server(server)
+        if inner is None:
+            return False
+
+        project = explicit_project
+        if project is None:
+            scene = self._safe_resolve_scene()
+            if scene:
+                factory = project_factory or DccProject.open
+                try:
+                    project = factory(scene)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "ProjectToolsIntegration.bind: DccProject.open(%s) failed: %s",
+                        scene,
+                        exc,
+                    )
+                    project = None
+
+        try:
+            register_project_tools(inner, dcc_name=self.dcc_name, project=project)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ProjectToolsIntegration.bind: register_project_tools raised: %s",
+                exc,
+            )
+            return False
+
+        self.bound_scene = getattr(project, "state", None) and project.state.scene_path
+        self.bound_project = project
+        self.registered = True
+        logger.info(
+            "[%s] project tools registered (default scene=%s)",
+            self.dcc_name,
+            self.bound_scene or "<none>",
+        )
+        return True
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _inner_server(server: Any) -> Any:
+        """Return the inner Rust ``McpHttpServer`` (or ``None``).
+
+        ``register_project_tools`` calls ``server.registry`` *and*
+        ``server.register_handler``.  Only the inner ``_server`` exposes both,
+        so we never duck-type the wrapper (that would register tools but leave
+        their handlers unwired → silent 404 at call time).
+        """
+        inner = getattr(server, "_server", None)
+        if inner is None:
+            return None
+        if not hasattr(inner, "register_handler") or not hasattr(inner, "registry"):
+            return None
+        return inner
+
+    def _safe_resolve_scene(self) -> Optional[str]:
+        """Run the scene resolver, swallowing any unexpected error."""
+        try:
+            scene = self.scene_resolver.current_scene()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("ProjectToolsIntegration: scene resolver raised: %s", exc)
+            return None
+        if not scene:
+            return None
+        try:
+            scene = str(Path(scene))
+        except Exception:  # noqa: BLE001
+            scene = str(scene)
+        return scene
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+def attach_to_server(
+    server: Any,
+    *,
+    enabled: Optional[bool] = None,
+    dcc_name: str = _DCC_NAME,
+    scene_resolver: Optional[HoudiniSceneResolver] = None,
+    project_factory: Optional[Callable[[str], Any]] = None,
+    explicit_project: Any = None,
+) -> Optional[ProjectToolsIntegration]:
+    """One-shot helper used by :meth:`HoudiniMcpServer.register_builtin_actions`.
+
+    Returns the :class:`ProjectToolsIntegration` instance when registration
+    succeeded, or ``None`` when the env var disabled the surface or
+    registration failed.
+    """
+    if not resolve_project_tools_enabled(enabled):
+        return None
+    integration = ProjectToolsIntegration(
+        dcc_name=dcc_name,
+        scene_resolver=scene_resolver,
+    )
+    if integration.bind(
+        server,
+        project_factory=project_factory,
+        explicit_project=explicit_project,
+    ):
+        return integration
+    return None

--- a/src/dcc_mcp_houdini/_qt_inspector.py
+++ b/src/dcc_mcp_houdini/_qt_inspector.py
@@ -1,0 +1,156 @@
+"""Adopt the shared core ``qt-ui-inspector`` skill in Houdini.
+
+Mirrors :mod:`dcc_mcp_maya._qt_inspector`.  ``dcc-mcp-core`` ships a
+DCC-agnostic, read-only Qt UI inspector (``register_qt_ui_inspector``) exposing
+five tools — ``list_windows``, ``find_widgets``, ``describe_widget``,
+``snapshot_tree``, ``wait_for_widget``.  Houdini uses PySide2 / PySide6, so
+these let agents locate panes, dialogs, buttons, tree/table views, etc. **by
+text / objectName / class / accessibleName** instead of generating ad-hoc
+PySide enumeration scripts through ``execute_python``.
+
+Two Houdini-specific concerns are handled here:
+
+* **Main-thread affinity.** ``QApplication.allWidgets()`` /
+  ``topLevelWidgets()`` must be read on Houdini's UI thread.  MCP tool handlers
+  run on a tokio worker thread, so each inspector handler is wrapped to marshal
+  onto Houdini's main thread via the host dispatcher (the same queue
+  ``execute_python`` uses).  In headless ``hython`` / pytest the wrapper runs
+  inline.
+* **Clear capability message.** The core tools already return structured
+  ``qt-binding-unavailable`` / ``qt-no-application`` envelopes when Qt or a
+  running ``QApplication`` is missing.
+
+Operator opt-out: ``DCC_MCP_HOUDINI_QT_UI_INSPECTOR=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Optional
+
+from dcc_mcp_houdini._env import ENV_QT_UI_INSPECTOR, resolve_qt_ui_inspector_enabled
+
+logger = logging.getLogger(__name__)
+
+_DCC_NAME = "houdini"
+
+__all__ = [
+    "ENV_QT_UI_INSPECTOR",
+    "register_houdini_qt_ui_inspector",
+    "resolve_qt_ui_inspector_enabled",
+]
+
+
+def _on_main_thread() -> bool:
+    """Best-effort check whether we are already on the interpreter main thread.
+
+    In interactive Houdini, the host pump drains queued callables on Houdini's
+    main thread (the Python main thread).  MCP handlers run on tokio worker
+    threads, so this guard prevents a deadlock when a handler is somehow already
+    executing on the main thread.
+    """
+    return threading.current_thread() is threading.main_thread()
+
+
+def _make_marshaller(dispatcher: Any) -> Callable[[Callable[[], Any]], Any]:
+    """Return a callable that runs ``fn`` on Houdini's main thread.
+
+    Falls back to inline execution when already on the main thread, when no
+    dispatcher is available (headless ``hython`` / pytest), or when the
+    dispatcher cannot marshal.
+    """
+
+    def _marshal(fn: Callable[[], Any]) -> Any:
+        if dispatcher is None or _on_main_thread():
+            return fn()
+        dispatch = getattr(dispatcher, "dispatch_callable", None)
+        if not callable(dispatch):
+            return fn()
+        try:
+            return dispatch(fn, affinity="main", action_name="qt_ui_inspector", execution="sync")
+        except Exception as exc:  # noqa: BLE001 — degrade to inline rather than fail the call
+            logger.debug("[houdini] qt inspector main-thread marshalling failed, running inline: %s", exc)
+            return fn()
+
+    return _marshal
+
+
+def _wrap_main_thread(handler: Callable[[Any], Any], marshal: Callable[[Callable[[], Any]], Any]) -> Callable[[Any], Any]:
+    def wrapper(params: Any) -> Any:
+        return marshal(lambda: handler(params))
+
+    return wrapper
+
+
+class _MainThreadHandlerProxy:
+    """Server proxy that wraps every registered handler in main-thread routing.
+
+    ``register_qt_ui_inspector`` uses only ``server.registry`` and
+    ``server.register_handler`` — both are forwarded; ``register_handler``
+    additionally wraps the handler so the read happens on Houdini's UI thread.
+    """
+
+    def __init__(self, inner_server: Any, marshal: Callable[[Callable[[], Any]], Any]) -> None:
+        self._server = inner_server
+        self._marshal = marshal
+
+    @property
+    def registry(self) -> Any:
+        return self._server.registry
+
+    def register_handler(self, name: str, handler: Callable[[Any], Any]) -> Any:
+        return self._server.register_handler(name, _wrap_main_thread(handler, self._marshal))
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - passthrough
+        return getattr(self._server, item)
+
+
+def register_houdini_qt_ui_inspector(
+    server: Any,
+    *,
+    dcc_name: str = _DCC_NAME,
+    dispatcher: Any = None,
+) -> bool:
+    """Register the shared ``qt_ui_inspector__*`` tools on the inner MCP server.
+
+    Parameters
+    ----------
+    server:
+        The :class:`HoudiniMcpServer` wrapper (exposes ``_server`` and, when
+        available, ``_houdini_dispatcher``).
+    dcc_name:
+        DCC name tag for the core registration.
+    dispatcher:
+        Optional explicit host dispatcher used for main-thread marshalling.
+        Defaults to ``server._houdini_dispatcher``.
+
+    Returns ``True`` when the core inspector was registered, ``False`` when
+    disabled by env var or unavailable in the installed core.
+    """
+    if not resolve_qt_ui_inspector_enabled():
+        logger.info("[%s] qt-ui-inspector disabled via %s", dcc_name, ENV_QT_UI_INSPECTOR)
+        return False
+
+    inner = getattr(server, "_server", None)
+    if inner is None:
+        logger.debug("[%s] qt-ui-inspector: no inner server; skipping", dcc_name)
+        return False
+
+    try:
+        from dcc_mcp_core.skills.qt_ui_inspector import register_qt_ui_inspector  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001 — older core without the shared skill
+        logger.info("[%s] qt-ui-inspector unavailable in installed dcc-mcp-core: %s", dcc_name, exc)
+        return False
+
+    if dispatcher is None:
+        dispatcher = getattr(server, "_houdini_dispatcher", None)
+    marshal = _make_marshaller(dispatcher)
+
+    try:
+        register_qt_ui_inspector(_MainThreadHandlerProxy(inner, marshal), dcc_name=dcc_name)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[%s] qt-ui-inspector registration failed: %s", dcc_name, exc)
+        return False
+    logger.info("[%s] qt-ui-inspector tools registered (main-thread routed)", dcc_name)
+    return True

--- a/src/dcc_mcp_houdini/_resources.py
+++ b/src/dcc_mcp_houdini/_resources.py
@@ -1,0 +1,433 @@
+"""Houdini resource publishing wiring.
+
+Mirrors :mod:`dcc_mcp_maya._resources`.  Core ships
+``McpHttpServer.resources()`` → ``ResourceHandle`` with ``set_scene`` /
+``register_producer`` / ``notify_updated``.  ``scene://current`` is a built-in
+resource URI that returns ``status: no_scene_published`` until the embedding
+adapter calls ``set_scene(...)``.  This module is that adapter for Houdini.
+
+Public surface:
+
+* :class:`HoudiniResourceBinder` — composes a Houdini scene-snapshot publisher
+  (``scene://current``) plus an optional ``houdini-help://<nodetype>`` producer.
+* :func:`install_resources(server)` — one-shot helper invoked from
+  :meth:`HoudiniMcpServer.register_builtin_actions`.
+
+SOLID notes
+-----------
+* **Single Responsibility** — each producer is a pure function from URI to
+  ``{"mimeType", "text"}``; the binder only orchestrates registration and
+  scene-snapshot lifetime.
+* **Open/Closed** — the snapshot source and the hip-event installer are
+  injectable, so tests can drive the throttling state machine without a live
+  Houdini.
+* **Dependency Inversion** — every Houdini-specific call (``hou``) is
+  lazy-imported inside the producer body so the module is importable in plain
+  Python.
+
+Operator opt-out: ``DCC_MCP_HOUDINI_RESOURCES=0``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+from dcc_mcp_houdini._env import ENV_RESOURCES, resolve_resources_enabled
+
+logger = logging.getLogger(__name__)
+
+#: Throttle for ``scene://current`` republishing.
+DEFAULT_SCENE_THROTTLE_SECS: float = 0.5
+
+#: Houdini-specific dynamic resource URI scheme for node-type help.
+SCHEME_HOUDINI_HELP = "houdini-help://"
+
+__all__ = [
+    "ENV_RESOURCES",
+    "DEFAULT_SCENE_THROTTLE_SECS",
+    "SCHEME_HOUDINI_HELP",
+    "HoudiniResourceBinder",
+    "install_resources",
+    "resolve_enabled",
+]
+
+
+# ``resolve_enabled`` kept as a module-level alias for parity with Maya tests.
+resolve_enabled = resolve_resources_enabled
+
+
+# ---------------------------------------------------------------------------
+# Producer callables — pure functions, lazy hou import
+# ---------------------------------------------------------------------------
+
+
+def _read_text(text: str, mime: str = "text/plain") -> Dict[str, Any]:
+    """Build the ``{"mimeType", "text"}`` reply expected by core."""
+    return {"mimeType": mime, "text": text}
+
+
+def _hou():
+    """Lazy ``hou`` import; returns ``None`` outside Houdini."""
+    try:
+        import hou  # noqa: PLC0415
+
+        return hou
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _parse_path_uri(uri: str, *, scheme: str) -> Optional[List[str]]:
+    """Strip *scheme* prefix and split the rest on ``/`` (empty parts skipped)."""
+    if not uri.startswith(scheme):
+        return None
+    tail = uri[len(scheme):]
+    return [p for p in tail.split("/") if p]
+
+
+def _houdini_help_producer(uri: str) -> Dict[str, Any]:
+    """Producer for ``houdini-help://<category>/<nodetype>`` URIs.
+
+    Returns the node type's help text via ``hou.nodeType(...).help()`` when
+    available.  When ``hou`` is unavailable (headless/non-Houdini) or the type
+    cannot be resolved, returns a JSON envelope so agents degrade gracefully.
+
+    URI grammar:
+        ``houdini-help://<nodetype>``                — search common categories
+        ``houdini-help://<category>/<nodetype>``     — explicit category
+    """
+    parsed = _parse_path_uri(uri, scheme=SCHEME_HOUDINI_HELP)
+    if not parsed:
+        return _read_text(
+            json.dumps({"status": "invalid_uri", "uri": uri, "hint": "houdini-help://<category>/<nodetype>"}),
+            mime="application/json",
+        )
+
+    hou = _hou()
+    if hou is None:
+        return _read_text(
+            json.dumps({"status": "houdini_unavailable", "uri": uri}),
+            mime="application/json",
+        )
+
+    if len(parsed) >= 2:
+        categories = [parsed[0]]
+        type_name = parsed[1]
+    else:
+        categories = ["Sop", "Object", "Driver", "Dop", "Cop2", "Vop", "Lop", "Top"]
+        type_name = parsed[0]
+
+    try:
+        node_type = _resolve_node_type(hou, categories, type_name)
+    except Exception as exc:  # noqa: BLE001
+        return _read_text(
+            json.dumps({"status": "error", "node_type": type_name, "error": str(exc)}),
+            mime="application/json",
+        )
+    if node_type is None:
+        return _read_text(
+            json.dumps({"status": "node_type_not_found", "node_type": type_name}),
+            mime="application/json",
+        )
+    try:
+        text = node_type.help()
+    except Exception as exc:  # noqa: BLE001
+        return _read_text(
+            json.dumps({"status": "help_unavailable", "node_type": type_name, "error": str(exc)}),
+            mime="application/json",
+        )
+    return _read_text(text or "(no help text)")
+
+
+def _resolve_node_type(hou: Any, categories: List[str], type_name: str) -> Any:
+    """Return the first matching ``hou.NodeType`` across *categories*, or None."""
+    for category in categories:
+        cat_fn = getattr(hou, "{}NodeTypeCategory".format(category), None)
+        if cat_fn is None:
+            # Fall back to hou.nodeType("<category>/<type>") form.
+            node_type = _safe_node_type(hou, "{}/{}".format(category.lower(), type_name))
+            if node_type is not None:
+                return node_type
+            continue
+        try:
+            node_type = hou.nodeType(cat_fn(), type_name)
+        except Exception:  # noqa: BLE001
+            node_type = None
+        if node_type is not None:
+            return node_type
+    return None
+
+
+def _safe_node_type(hou: Any, path: str) -> Any:
+    try:
+        return hou.nodeType(path)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Hip-file event installer (default uses hou.hipFile.addEventCallback)
+# ---------------------------------------------------------------------------
+
+
+SnapshotProvider = Callable[[], Dict[str, Any]]
+EventInstaller = Callable[[Callable[[], None]], List[Any]]
+EventRemover = Callable[[List[Any]], None]
+BusyChecker = Callable[[], bool]
+
+
+def _default_event_installer(callback: Callable[[], None]) -> List[Any]:
+    """Register a Houdini hip-file event callback wrapping *callback*.
+
+    Returns a list of opaque handles for cleanup.  Best-effort: a missing
+    ``hou`` produces an empty list (headless mode).
+    """
+    hou = _hou()
+    if hou is None:
+        return []
+
+    def _wrapper(*_args: Any, **_kwargs: Any) -> None:
+        callback()
+
+    try:
+        hou.hipFile.addEventCallback(_wrapper)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("resources: hipFile.addEventCallback refused: %s", exc)
+        return []
+    return [_wrapper]
+
+
+def _default_event_remover(handles: List[Any]) -> None:
+    """Tear down callbacks installed by :func:`_default_event_installer`."""
+    hou = _hou()
+    if hou is None:
+        return
+    for handle in handles:
+        try:
+            hou.hipFile.removeEventCallback(handle)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: hipFile.removeEventCallback failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Houdini-side binder
+# ---------------------------------------------------------------------------
+
+
+class HoudiniResourceBinder:
+    """Compose every ``server._server.resources()`` call for Houdini.
+
+    Lifecycle::
+
+        binder = HoudiniResourceBinder()
+        binder.bind(server)             # registers producers + scene snapshot
+        binder.install_scene_events()   # opt-in hip-file callback
+        # ... server runs ...
+        binder.unbind()                 # detach callbacks
+    """
+
+    def __init__(
+        self,
+        *,
+        snapshot_provider: Optional[SnapshotProvider] = None,
+        event_installer: Optional[EventInstaller] = None,
+        event_remover: Optional[EventRemover] = None,
+        busy_checker: Optional[BusyChecker] = None,
+        throttle_secs: float = DEFAULT_SCENE_THROTTLE_SECS,
+    ) -> None:
+        self.snapshot_provider: Optional[SnapshotProvider] = snapshot_provider
+        self.event_installer: EventInstaller = event_installer or _default_event_installer
+        self.event_remover: EventRemover = event_remover or _default_event_remover
+        self.busy_checker: Optional[BusyChecker] = busy_checker
+        self.throttle_secs: float = max(0.0, float(throttle_secs))
+
+        self.bound_server: Any = None
+        self.handle: Any = None
+        self.registered_producers: List[str] = []
+        self.scene_event_handles: List[Any] = []
+        self.scene_publish_count: int = 0
+
+        self._lock = threading.Lock()
+        self._pending_publish: bool = False
+        self._last_publish_at: float = 0.0
+        self._publish_timer: Optional[threading.Timer] = None
+        self._unbound: bool = False
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def bind(self, server: Any) -> bool:
+        """Bind the binder to *server*; returns ``True`` on success."""
+        if self.bound_server is server:
+            return True
+        self.bound_server = server
+        self._unbound = False
+
+        try:
+            self.handle = server._server.resources()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: server.resources() unavailable: %s", exc)
+            return False
+
+        self._register_producer(SCHEME_HOUDINI_HELP, _houdini_help_producer)
+
+        if self.snapshot_provider is not None:
+            self._publish_scene_now()
+        return True
+
+    def install_scene_events(self) -> List[Any]:
+        """Hook hip-file events so scene mutations republish ``scene://current``."""
+        if self.bound_server is None:
+            return []
+        if self.scene_event_handles:
+            return list(self.scene_event_handles)
+        handles = self.event_installer(self._on_scene_event)
+        self.scene_event_handles = list(handles)
+        return list(self.scene_event_handles)
+
+    def unbind(self) -> None:
+        """Detach callbacks and stop pending publishes.  Idempotent."""
+        if self._unbound:
+            return
+        self._unbound = True
+
+        with self._lock:
+            timer = self._publish_timer
+            self._publish_timer = None
+            self._pending_publish = False
+        if timer is not None:
+            try:
+                timer.cancel()
+            except Exception:  # noqa: BLE001
+                pass
+
+        if self.scene_event_handles:
+            try:
+                self.event_remover(self.scene_event_handles)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("resources: event remover raised: %s", exc)
+            self.scene_event_handles = []
+
+    def publish_scene(self, payload: Optional[Dict[str, Any]] = None) -> None:
+        """Publish a scene snapshot now, bypassing throttling."""
+        if self.handle is None:
+            return
+        if payload is None:
+            if self.snapshot_provider is None:
+                return
+            try:
+                payload = self.snapshot_provider()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("resources: snapshot provider raised: %s", exc)
+                return
+        try:
+            self.handle.set_scene(payload)
+            self.scene_publish_count += 1
+            self._last_publish_at = time.monotonic()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: set_scene raised: %s", exc)
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    def _register_producer(self, scheme: str, producer: Callable[[str], Dict[str, Any]]) -> None:
+        if self.handle is None:
+            return
+        try:
+            self.handle.register_producer(scheme, producer)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: register_producer(%s) raised: %s", scheme, exc)
+            return
+        self.registered_producers.append(scheme)
+
+    def _is_executor_busy(self) -> bool:
+        if self.busy_checker is None:
+            return False
+        try:
+            return bool(self.busy_checker())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: busy checker raised: %s", exc)
+            return False
+
+    def _on_scene_event(self) -> None:
+        """Hip-event callback: schedule a throttled scene republish."""
+        if self._unbound or self._is_executor_busy():
+            return
+        with self._lock:
+            now = time.monotonic()
+            since = now - self._last_publish_at
+            if since >= self.throttle_secs:
+                schedule_now = True
+                self._pending_publish = False
+            else:
+                schedule_now = False
+                if not self._pending_publish:
+                    delay = self.throttle_secs - since
+                    self._pending_publish = True
+                    self._publish_timer = threading.Timer(delay, self._on_throttle_fire)
+                    self._publish_timer.daemon = True
+                    self._publish_timer.start()
+        if schedule_now:
+            self._publish_scene_now()
+
+    def _on_throttle_fire(self) -> None:
+        """Trailing-edge throttle handler — runs on a Timer thread."""
+        if self._unbound or self._is_executor_busy():
+            return
+        with self._lock:
+            self._pending_publish = False
+            self._publish_timer = None
+        self._publish_scene_now()
+
+    def _publish_scene_now(self) -> None:
+        self.publish_scene()
+        self._sync_gateway_scene_metadata()
+
+    def _sync_gateway_scene_metadata(self) -> None:
+        """Push scene path / version into the gateway registry (best effort)."""
+        server = self.bound_server
+        if server is None:
+            return
+        publish = getattr(server, "publish_capability_snapshot", None)
+        if publish is None:
+            return
+        try:
+            publish(reason="scene_resource")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("resources: publish_capability_snapshot failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+def install_resources(
+    server: Any,
+    *,
+    enabled: Optional[bool] = None,
+    snapshot_provider: Optional[SnapshotProvider] = None,
+    install_scene_events: bool = True,
+    busy_checker: Optional[BusyChecker] = None,
+    throttle_secs: float = DEFAULT_SCENE_THROTTLE_SECS,
+) -> Optional[HoudiniResourceBinder]:
+    """One-shot helper called from :meth:`HoudiniMcpServer.register_builtin_actions`.
+
+    Returns the :class:`HoudiniResourceBinder` when installation succeeded, or
+    ``None`` when resources were disabled (``DCC_MCP_HOUDINI_RESOURCES=0``) or
+    the inner Rust ``McpHttpServer.resources()`` raised.
+    """
+    if not resolve_resources_enabled(enabled):
+        logger.debug("resources: disabled via env var")
+        return None
+    binder = HoudiniResourceBinder(
+        snapshot_provider=snapshot_provider,
+        busy_checker=busy_checker,
+        throttle_secs=throttle_secs,
+    )
+    if not binder.bind(server):
+        return None
+    if install_scene_events:
+        binder.install_scene_events()
+    return binder

--- a/src/dcc_mcp_houdini/_semantic_index.py
+++ b/src/dcc_mcp_houdini/_semantic_index.py
@@ -1,0 +1,208 @@
+"""Optional morphology-aware semantic skill recall.
+
+Mirrors :mod:`dcc_mcp_maya._semantic_index`.  ``HoudiniMcpServer.find_skills``
+routes through the Rust BM25-lite scorer in ``dcc-mcp-skills``.  That path is
+excellent for exact / tokenised queries but misses morphology variants a
+natural-language MCP agent commonly produces — ``"rendering the active frame"``
+does not tokenise to the literal ``render`` token in a ``houdini-render``
+skill's name / summary.
+
+This module fuses the Python-side ``VectorSkillIndex`` (``HashedEmbedder``
+char-3-gram defaults, zero runtime deps) with a ``LexicalSkillIndex`` through
+``RrfFusionIndex``.  The fused index is used **only to augment** the canonical
+base results: base ordering is preserved verbatim and vector-only recalls are
+appended afterwards.
+
+The whole feature is gated behind ``DCC_MCP_HOUDINI_SEMANTIC_INDEX=1`` so the
+default behaviour is unchanged.  When ``dcc-mcp-core[semantic]`` is installed,
+``DCC_MCP_HOUDINI_SEMANTIC_EMBEDDER=onnx`` swaps ``HashedEmbedder`` for the real
+dense ``OnnxEmbedder`` without touching any call site.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Sequence
+
+from dcc_mcp_houdini._env import (
+    ENV_SEMANTIC_EMBEDDER,
+    ENV_SEMANTIC_INDEX,
+    resolve_semantic_embedder_kind,
+    resolve_semantic_index_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ENV_SEMANTIC_EMBEDDER",
+    "ENV_SEMANTIC_INDEX",
+    "HoudiniSemanticIndex",
+    "build_semantic_index",
+    "resolve_embedder_kind",
+    "resolve_semantic_index_enabled",
+]
+
+# Aliases for parity with Maya's module-level helper names.
+resolve_embedder_kind = resolve_semantic_embedder_kind
+
+
+def _summary_text(summary: Any) -> str:
+    """Best-effort description string from a ``SkillSummary``-like object/dict."""
+    parts: List[str] = []
+    for attr in ("description", "search_hint", "summary"):
+        value = _get(summary, attr)
+        value = str(value) if value else ""
+        if value and value not in parts:
+            parts.append(value)
+    return " ".join(parts)
+
+
+def _summary_name(summary: Any) -> Optional[str]:
+    name = _get(summary, "name")
+    return str(name) if name else None
+
+
+def _get(obj: Any, attr: str) -> Any:
+    """Read ``attr`` from an object or dict, returning ``None`` when absent."""
+    if isinstance(obj, dict):
+        return obj.get(attr)
+    return getattr(obj, attr, None)
+
+
+def _build_embedder(kind: str) -> Any:
+    """Construct the requested embedder, falling back to ``HashedEmbedder``."""
+    from dcc_mcp_core import HashedEmbedder  # noqa: PLC0415
+
+    if kind != "onnx":
+        return HashedEmbedder()
+    try:
+        from dcc_mcp_core import OnnxEmbedder  # noqa: PLC0415
+
+        return OnnxEmbedder()
+    except Exception as exc:  # noqa: BLE001 — EmbedderError / ImportError
+        logger.warning(
+            "[houdini] DCC_MCP_HOUDINI_SEMANTIC_EMBEDDER=onnx requested but unavailable "
+            "(%s); falling back to HashedEmbedder. Install dcc-mcp-core[semantic].",
+            exc,
+        )
+        return HashedEmbedder()
+
+
+class HoudiniSemanticIndex:
+    """Lexical + vector fusion index used to augment base ``find_skills``."""
+
+    def __init__(self, fusion: Any, embedder_kind: str) -> None:
+        self._fusion = fusion
+        self.embedder_kind = embedder_kind
+        self._signature: Optional[frozenset] = None
+
+    # ── construction ────────────────────────────────────────────────────
+    @classmethod
+    def build(cls, *, embedder_kind: Optional[str] = None) -> Optional["HoudiniSemanticIndex"]:
+        """Build the fused index, or ``None`` when core lacks the semantic API."""
+        try:
+            from dcc_mcp_core import LexicalSkillIndex, RrfFusionIndex, VectorSkillIndex  # noqa: PLC0415
+        except Exception as exc:  # noqa: BLE001 — older core without the vector API
+            logger.info(
+                "[houdini] semantic index requested but dcc-mcp-core lacks "
+                "VectorSkillIndex (%s); needs dcc-mcp-core>=0.17.38.",
+                exc,
+            )
+            return None
+        kind = embedder_kind or resolve_semantic_embedder_kind()
+        try:
+            fusion = (
+                RrfFusionIndex()
+                .register("lex", LexicalSkillIndex())
+                .register("vec", VectorSkillIndex(embedder=_build_embedder(kind)))
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[houdini] failed to build semantic fusion index: %s", exc)
+            return None
+        return cls(fusion, kind)
+
+    # ── indexing / recall ───────────────────────────────────────────────
+    def rebuild(self, summaries: Sequence[Any]) -> None:
+        """(Re)index ``summaries`` only when the skill set changed."""
+        from dcc_mcp_core import SkillDocument  # noqa: PLC0415
+
+        signature = frozenset(
+            (name, str(_get(s, "version") or ""))
+            for s, name in ((s, _summary_name(s)) for s in summaries)
+            if name is not None
+        )
+        if signature == self._signature:
+            return
+        docs = []
+        for summary in summaries:
+            name = _summary_name(summary)
+            if name is None:
+                continue
+            tags = _get(summary, "tags") or ()
+            docs.append(
+                SkillDocument(
+                    skill_id=name,
+                    name=name,
+                    summary=_summary_text(summary),
+                    tags=tuple(str(t) for t in tags),
+                    dcc_name=str(_get(summary, "dcc") or ""),
+                )
+            )
+        self._fusion.clear()
+        if docs:
+            self._fusion.index(docs)
+        self._signature = signature
+
+    def recall(self, query: str, *, k: int = 16) -> List[str]:
+        """Return fused-rank ``skill_id``s for ``query`` (best first)."""
+        if not query or not str(query).strip():
+            return []
+        try:
+            hits = self._fusion.search(str(query), k=k)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[houdini] semantic recall failed for %r: %s", query, exc)
+            return []
+        return [hit.skill_id for hit in hits]
+
+    # ── fusion / augmentation ───────────────────────────────────────────
+    def augment(
+        self,
+        base: Sequence[Any],
+        query: Optional[str],
+        all_summaries: Sequence[Any],
+        *,
+        limit: Optional[int] = None,
+    ) -> List[Any]:
+        """Append morphology-recalled skills after the canonical ``base`` list.
+
+        ``base`` ordering is preserved verbatim — RRF promotes, never demotes.
+        Skills surfaced only by the vector backend are appended in fused-rank
+        order.
+        """
+        result = list(base)
+        if not query or not str(query).strip():
+            return result
+        try:
+            self.rebuild(all_summaries)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[houdini] semantic rebuild failed: %s", exc)
+            return result
+
+        by_name = {name: s for s, name in ((s, _summary_name(s)) for s in all_summaries) if name is not None}
+        present = {_summary_name(s) for s in result}
+        for skill_id in self.recall(query):
+            if skill_id in present or skill_id not in by_name:
+                continue
+            result.append(by_name[skill_id])
+            present.add(skill_id)
+
+        if limit is not None and limit >= 0:
+            result = result[:limit]
+        return result
+
+
+def build_semantic_index() -> Optional[HoudiniSemanticIndex]:
+    """Return a ready index when the feature is enabled, else ``None``."""
+    if not resolve_semantic_index_enabled():
+        return None
+    return HoudiniSemanticIndex.build()

--- a/src/dcc_mcp_houdini/server.py
+++ b/src/dcc_mcp_houdini/server.py
@@ -11,6 +11,15 @@ from dcc_mcp_core import DccServerOptions, HostExecutionBridge, MinimalModeConfi
 from dcc_mcp_core.server_base import DccServerBase
 
 from dcc_mcp_houdini.__version__ import __version__
+from dcc_mcp_houdini._capability_manifest import (
+    HoudiniCapabilityManifestBuilder,
+    build_manifest_payload,
+    register_capability_mcp_tool,
+)
+from dcc_mcp_houdini._context_snapshot import (
+    HoudiniContextSnapshotProvider,
+    collect_gateway_metadata,
+)
 from dcc_mcp_houdini._skill_loader import build_minimal_mode_config
 from dcc_mcp_houdini._version_probe import get_houdini_version_string
 
@@ -177,6 +186,55 @@ class HoudiniMcpServer(DccServerBase):
 
         self.readiness = install_readiness(self)
 
+        # ── Context snapshot + capability manifest ──────────────────────
+        # Houdini-specific context provider feeds both the core post-tool
+        # ``append_context_snapshot`` wrapper and the per-DCC ``/v1/context``
+        # REST endpoint.  Wrapped so a missing core API never breaks startup.
+        self._snapshot_provider_impl: HoudiniContextSnapshotProvider = HoudiniContextSnapshotProvider()
+        try:
+            self.set_context_snapshot_provider(self._snapshot_provider_impl)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] set_context_snapshot_provider failed: %s", _DCC_NAME, exc)
+
+        self._capability_builder: HoudiniCapabilityManifestBuilder = HoudiniCapabilityManifestBuilder(
+            dcc_name=_DCC_NAME,
+            skill_lister=self.list_skills,
+            action_lister=self._list_actions_safe,
+            is_loaded=self.is_skill_loaded,
+            skill_info_lister=self._skill_info_safe,
+        )
+
+        # Populated by :meth:`register_builtin_actions`.
+        self._project_tools: Any = None
+        self._resources: Any = None
+
+        # ── Morphology-aware semantic recall (opt-in) ───────────────────
+        try:
+            from dcc_mcp_houdini._semantic_index import build_semantic_index
+
+            self._semantic = build_semantic_index()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] semantic index init failed: %s", _DCC_NAME, exc)
+            self._semantic = None
+        if self._semantic is not None:
+            logger.info("[%s] semantic skill recall enabled (embedder=%s)", _DCC_NAME, self._semantic.embedder_kind)
+
+    def _list_actions_safe(self) -> List[Any]:
+        """Best-effort ``list_actions`` for the capability builder."""
+        try:
+            return list(self.list_actions())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] list_actions failed: %s", _DCC_NAME, exc)
+            return []
+
+    def _skill_info_safe(self, name: str) -> Any:
+        """Best-effort ``get_skill_info`` for the capability builder."""
+        try:
+            return self.get_skill_info(name)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] get_skill_info(%r) failed: %s", _DCC_NAME, name, exc)
+            return None
+
     def _version_string(self) -> str:
         """Return the Houdini version via ``hou.applicationVersionString()``."""
         return get_houdini_version_string()
@@ -219,6 +277,182 @@ class HoudiniMcpServer(DccServerBase):
             include_bundled=include_bundled,
             minimal_mode=minimal_mode,
         )
+
+        # ── Core integrations (parity with Maya's registration phases) ───
+        # Each step degrades gracefully: an unavailable core API or a
+        # registration failure is logged at debug and never breaks startup.
+        self._register_recipes_tools(extra_skill_paths, include_bundled)
+        self._register_skill_reference_docs_tools(extra_skill_paths, include_bundled)
+        self._register_introspect_tools()
+        self._register_feedback_tool()
+        self._register_qt_ui_inspector()
+        self._register_capability_manifest_tool()
+        self._attach_project_tools()
+        self._attach_resources()
+
+    # ── Core integration wiring (optional / graceful) ───────────────────
+
+    def _scan_skill_metadata_for_sidecars(
+        self,
+        extra_skill_paths: Optional[List[str]],
+        include_bundled: bool,
+    ) -> List[Any]:
+        """Return ``SkillMetadata`` list aligned with ``collect_skill_search_paths``."""
+        from dcc_mcp_core import scan_and_load_lenient
+
+        paths = self.collect_skill_search_paths(
+            extra_paths=extra_skill_paths if extra_skill_paths is not None else self._extra_skill_paths,
+            include_bundled=include_bundled,
+            filter_existing=True,
+        )
+        extra = paths if paths else None
+        skills, _skipped = scan_and_load_lenient(extra_paths=extra, dcc_name=_DCC_NAME)
+        return skills
+
+    def _register_skill_metadata_tools(
+        self,
+        register_fn: Any,
+        kind: str,
+        extra_skill_paths: Optional[List[str]],
+        include_bundled: bool,
+    ) -> None:
+        try:
+            skills = self._scan_skill_metadata_for_sidecars(extra_skill_paths, include_bundled)
+            register_fn(self._server, skills=skills, dcc_name=_DCC_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] %s tools failed: %s", _DCC_NAME, kind, exc)
+
+    def _register_recipes_tools(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+    ) -> None:
+        """Register ``recipes__*`` tools for ``metadata.dcc-mcp.recipes`` sidecars."""
+        try:
+            from dcc_mcp_core.recipes import register_recipes_tools
+        except ImportError as exc:
+            logger.debug("[%s] recipes tools skipped (import): %s", _DCC_NAME, exc)
+            return
+        self._register_skill_metadata_tools(register_recipes_tools, "recipes", extra_skill_paths, include_bundled)
+
+    def _register_skill_reference_docs_tools(
+        self,
+        extra_skill_paths: Optional[List[str]] = None,
+        include_bundled: bool = True,
+    ) -> None:
+        """Register ``skill_refs__*`` for sibling reference Markdown/text docs."""
+        try:
+            from dcc_mcp_core.skill_reference_docs import register_skill_reference_docs_tools
+        except ImportError as exc:
+            logger.debug("[%s] skill_refs tools skipped (import): %s", _DCC_NAME, exc)
+            return
+        self._register_skill_metadata_tools(
+            register_skill_reference_docs_tools,
+            "skill_refs",
+            extra_skill_paths,
+            include_bundled,
+        )
+
+    def _register_introspect_tools(self) -> None:
+        """Register the core ``dcc_introspect__*`` runtime-introspection tools."""
+        try:
+            from dcc_mcp_core import register_introspect_tools
+        except ImportError as exc:
+            logger.debug("[%s] introspect tools skipped (import): %s", _DCC_NAME, exc)
+            return
+        try:
+            register_introspect_tools(self._server, dcc_name=_DCC_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] introspect tools failed: %s", _DCC_NAME, exc)
+
+    def _register_feedback_tool(self) -> None:
+        """Register the core ``dcc_feedback__report`` tool."""
+        try:
+            from dcc_mcp_core import register_feedback_tool
+        except ImportError as exc:
+            logger.debug("[%s] feedback tool skipped (import): %s", _DCC_NAME, exc)
+            return
+        try:
+            register_feedback_tool(self._server, dcc_name=_DCC_NAME)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] feedback tool failed: %s", _DCC_NAME, exc)
+
+    def _register_qt_ui_inspector(self) -> None:
+        """Adopt the shared core ``qt_ui_inspector__*`` tools (main-thread routed)."""
+        try:
+            from dcc_mcp_houdini._qt_inspector import register_houdini_qt_ui_inspector
+
+            register_houdini_qt_ui_inspector(self, dcc_name=_DCC_NAME, dispatcher=self._houdini_dispatcher)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] qt-ui-inspector registration failed: %s", _DCC_NAME, exc)
+
+    def _register_capability_manifest_tool(self) -> None:
+        try:
+            register_capability_mcp_tool(self, builder=self._capability_builder)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] capability manifest MCP tool registration failed: %s", _DCC_NAME, exc)
+
+    def _attach_project_tools(self) -> None:
+        try:
+            from dcc_mcp_houdini import _project_tools
+
+            self._project_tools = _project_tools.attach_to_server(self)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] project tools registration failed: %s", _DCC_NAME, exc)
+
+    def _attach_resources(self) -> None:
+        try:
+            from dcc_mcp_houdini import _resources
+
+            self._resources = _resources.install_resources(
+                self,
+                snapshot_provider=self._snapshot_provider_impl.collect,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] resources registration failed: %s", _DCC_NAME, exc)
+
+    def build_capability_manifest(self, *, loaded_only: bool = False) -> Dict[str, Any]:
+        """Return the compact Houdini capability manifest as a dict."""
+        records = self._capability_builder.build()
+        if loaded_only:
+            records = [r for r in records if r.loaded]
+        instance_id = getattr(self, "instance_id", None)
+        scene = getattr(self._config, "scene", None)
+        version = getattr(self._config, "dcc_version", None)
+        return build_manifest_payload(
+            records,
+            dcc_name=_DCC_NAME,
+            dcc_version=version,
+            scene=scene,
+            instance_id=instance_id,
+        )
+
+    def publish_capability_snapshot(self, *, reason: str = "manual") -> bool:
+        """Push current Houdini context into the gateway registry (best effort)."""
+        if not self.is_running:
+            return False
+        gateway_port = getattr(self._config, "gateway_port", 0)
+        if not gateway_port or gateway_port <= 0:
+            return False
+        try:
+            meta = collect_gateway_metadata(self._snapshot_provider_impl)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] capability snapshot: provider failed: %s", _DCC_NAME, exc)
+            return False
+        if not any((meta.get("scene"), meta.get("version"), meta.get("display_name"))):
+            logger.debug("[%s] capability snapshot (%s): skipped — no actionable state", _DCC_NAME, reason)
+            return False
+        try:
+            ok = self.update_gateway_metadata(
+                scene=meta.get("scene"),
+                version=meta.get("version"),
+                documents=meta.get("documents"),
+                display_name=meta.get("display_name"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] update_gateway_metadata failed (%s): %s", _DCC_NAME, reason, exc)
+            return False
+        return bool(ok)
 
     def start(self, *, install_atexit_hook: bool = True) -> HoudiniMcpServer:
         """Start the MCP HTTP server. Returns *self* for chaining."""
@@ -281,7 +515,7 @@ class HoudiniMcpServer(DccServerBase):
         tags_list: List[str] = tags if tags is not None else []
         dcc_name: str = dcc if dcc is not None else _DCC_NAME
         try:
-            return list(
+            base = list(
                 self._server.search_skills(
                     query=query,
                     tags=tags_list,
@@ -291,7 +525,20 @@ class HoudiniMcpServer(DccServerBase):
                 )
             )
         except TypeError:
-            return list(self._server.search_skills(query=query, tags=tags_list, dcc=dcc_name))
+            base = list(self._server.search_skills(query=query, tags=tags_list, dcc=dcc_name))
+
+        # When the opt-in semantic index is enabled, augment the canonical BM25
+        # results with morphology recalls. Base ordering is preserved (promote,
+        # never demote); vector-only hits are appended.
+        if self._semantic is not None and query:
+            try:
+                return self._semantic.augment(base, query, self.list_skills(), limit=limit)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[%s] semantic augment failed: %s", _DCC_NAME, exc)
+        return base
+
+    # Alias mirroring Maya's public ``search_skills`` surface.
+    search_skills = find_skills
 
     def is_skill_loaded(self, skill_name: str) -> bool:
         """Return ``True`` if the named skill is currently loaded."""
@@ -311,6 +558,12 @@ class HoudiniMcpServer(DccServerBase):
 
     def stop(self) -> None:
         """Stop the MCP server and detach the Houdini host adapter."""
+        if self._resources is not None:
+            try:
+                self._resources.unbind()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[%s] resources.unbind failed: %s", _DCC_NAME, exc)
+
         host = self._houdini_host
         if host is not None:
             try:

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -1,0 +1,303 @@
+"""Unit tests for :mod:`dcc_mcp_houdini._capability_manifest`.
+
+These tests verify the SOLID projection from live catalog state into a compact
+gateway-friendly manifest. No live Houdini is required — the builder only
+projects injected catalog data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+from dcc_mcp_houdini._capability_manifest import (
+    CapabilityRecord,
+    HoudiniCapabilityManifestBuilder,
+    _as_dict,
+    build_manifest_payload,
+    register_capability_mcp_tool,
+)
+
+
+class _BadToDict:
+    keep = "visible"
+
+    def to_dict(self):
+        raise ValueError("bad conversion")
+
+
+def test_as_dict_falls_back_when_to_dict_raises_expected_error():
+    assert _as_dict(_BadToDict())["keep"] == "visible"
+
+
+def _action(
+    name: str,
+    *,
+    skill: str = None,
+    summary: str = "",
+    tags: List[str] = None,
+    execution: str = "sync",
+    timeout_hint_secs: int = None,
+    input_schema: Dict[str, Any] = None,
+    group: str = None,
+) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {"name": name}
+    if skill is not None:
+        entry["skill"] = skill
+    if summary:
+        entry["summary"] = summary
+    if tags is not None:
+        entry["tags"] = tags
+    if execution:
+        entry["execution"] = execution
+    if timeout_hint_secs is not None:
+        entry["timeout_hint_secs"] = timeout_hint_secs
+    if input_schema is not None:
+        entry["input_schema"] = input_schema
+    if group:
+        entry["group"] = group
+    return entry
+
+
+def _skill(name: str, *, tags: List[str] = None, summary: str = "") -> Dict[str, Any]:
+    out: Dict[str, Any] = {"name": name}
+    if tags is not None:
+        out["tags"] = tags
+    if summary:
+        out["summary"] = summary
+    return out
+
+
+def test_builder_empty_catalog_returns_empty_records():
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: [],
+        action_lister=lambda: [],
+        is_loaded=lambda _: False,
+    )
+    assert builder.build() == []
+
+
+def test_builder_tolerates_missing_lister_callables():
+    builder = HoudiniCapabilityManifestBuilder()
+    assert builder.build() == []
+
+
+def test_builder_projects_loaded_and_unloaded_actions():
+    actions = [
+        _action("houdini_scene__get_scene_info", skill="houdini-scene", summary="Scene info", tags=["scene"]),
+        _action(
+            "houdini_scripting__execute_python",
+            skill="houdini-scripting",
+            summary="Run python",
+            tags=["python"],
+            execution="async",
+            timeout_hint_secs=120,
+            input_schema={"type": "object"},
+        ),
+        _action("houdini_render__render", skill="houdini-render", summary="Render", tags=["render"]),
+    ]
+    skills = [
+        _skill("houdini-scene", tags=["scene", "io"]),
+        _skill("houdini-scripting", tags=["scripting"]),
+        _skill("houdini-render", tags=["render"]),
+    ]
+    loaded = {"houdini-scene", "houdini-scripting"}
+
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: skills,
+        action_lister=lambda: actions,
+        is_loaded=lambda name: name in loaded,
+    )
+    records = builder.build()
+    assert len(records) == 3
+    by_name = {r.backend_tool: r for r in records}
+    assert by_name["houdini_scene__get_scene_info"].loaded is True
+    assert by_name["houdini_render__render"].loaded is False
+    rec = by_name["houdini_scripting__execute_python"]
+    assert rec.execution == "async"
+    assert rec.timeout_hint_secs == 120
+    assert rec.has_schema is True
+    assert rec.tool_slug == "houdini.instance.houdini_scripting__execute_python"
+    assert set(by_name["houdini_scene__get_scene_info"].tags) >= {"scene", "io"}
+
+
+def test_builder_drops_skill_and_group_stubs():
+    actions = [
+        _action("houdini_scene__get_scene_info", skill="houdini-scene"),
+        _action("__skill__houdini_render", skill="houdini-render"),
+        _action("__group__houdini-render.extended", skill="houdini-render"),
+    ]
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: [_skill("houdini-scene")],
+        action_lister=lambda: actions,
+        is_loaded=lambda _: False,
+    )
+    records = builder.build()
+    assert [r.backend_tool for r in records] == ["houdini_scene__get_scene_info"]
+
+
+def test_builder_truncates_long_summary():
+    long = "x" * 500
+    actions = [_action("houdini_scene__get_scene_info", skill="houdini-scene", summary=long)]
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: [_skill("houdini-scene")],
+        action_lister=lambda: actions,
+        is_loaded=lambda _: True,
+    )
+    record = builder.build()[0]
+    assert len(record.summary) <= 200
+    assert record.summary.endswith("…")
+
+
+def test_builder_infers_skill_from_tool_name_convention():
+    actions = [_action("houdini_scene__get_scene_info")]
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: [],
+        action_lister=lambda: actions,
+        is_loaded=lambda _: False,
+    )
+    record = builder.build()[0]
+    assert record.skill_name == "houdini-scene"
+
+
+def test_capability_record_to_dict_omits_empty_optional_fields():
+    rec = CapabilityRecord(
+        tool_slug="houdini.instance.houdini_scene__get_scene_info",
+        backend_tool="houdini_scene__get_scene_info",
+        skill_name="houdini-scene",
+        summary="",
+        loaded=False,
+    )
+    dumped = rec.to_dict()
+    assert "summary" not in dumped
+    assert "tags" not in dumped
+    assert dumped["loaded"] is False
+
+
+def test_build_manifest_payload_headers_and_totals():
+    records = [
+        CapabilityRecord("houdini.instance.a", "a", "s1", "", True),
+        CapabilityRecord("houdini.instance.b", "b", "s2", "", False),
+    ]
+    payload = build_manifest_payload(records, dcc_version="20.5", scene="/a.hip", instance_id="abc")
+    assert payload["schema_version"] == "1"
+    assert payload["dcc_type"] == "houdini"
+    assert payload["metadata"]["scene"] == "/a.hip"
+    assert payload["totals"] == {
+        "actions": 2,
+        "loaded_actions": 1,
+        "unloaded_actions": 1,
+        "skills": 2,
+        "loaded_skills": 1,
+        "unloaded_skills": 1,
+    }
+
+
+def test_build_manifest_payload_strips_none_metadata():
+    payload = build_manifest_payload([], dcc_version=None, scene="", instance_id=None)
+    assert "dcc_version" not in payload["metadata"]
+    assert "scene" not in payload["metadata"]
+    assert "instance_id" not in payload["metadata"]
+
+
+class _FakeRegistry:
+    def __init__(self):
+        self.registered: List[tuple] = []
+
+    def register(self, name, **kwargs):
+        self.registered.append((name, kwargs))
+
+
+class _FakeInner:
+    def __init__(self):
+        self.registry = _FakeRegistry()
+        self.handlers: Dict[str, Any] = {}
+
+    def register_handler(self, name: str, handler):
+        self.handlers[name] = handler
+
+
+def test_register_capability_mcp_tool_returns_manifest_via_handler():
+    inner = _FakeInner()
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: [_skill("houdini-scene")],
+        action_lister=lambda: [_action("houdini_scene__get_scene_info", skill="houdini-scene")],
+        is_loaded=lambda _: True,
+    )
+    fake_server = MagicMock()
+    fake_server._server = inner
+    fake_server._config = MagicMock(scene="/p/a.hip", dcc_version="20.5")
+
+    ok = register_capability_mcp_tool(fake_server, builder=builder)
+    assert ok is True
+    assert "dcc_capability_manifest" in inner.handlers
+    declared = [name for name, _ in inner.registry.registered]
+    assert "dcc_capability_manifest" in declared
+
+    result = inner.handlers["dcc_capability_manifest"]({})
+    assert result["success"] is True
+    assert result["context"]["totals"]["loaded_actions"] == 1
+    assert result["context"]["capabilities"][0]["backend_tool"] == "houdini_scene__get_scene_info"
+
+
+def test_register_capability_mcp_tool_honours_loaded_only_param():
+    inner = _FakeInner()
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: [_skill("houdini-scene"), _skill("houdini-render")],
+        action_lister=lambda: [
+            _action("houdini_scene__get_scene_info", skill="houdini-scene"),
+            _action("houdini_render__render", skill="houdini-render"),
+        ],
+        is_loaded=lambda name: name == "houdini-scene",
+    )
+    fake_server = MagicMock()
+    fake_server._server = inner
+    fake_server._config = MagicMock(scene=None, dcc_version="20.5")
+
+    register_capability_mcp_tool(fake_server, builder=builder)
+    handler = inner.handlers["dcc_capability_manifest"]
+    full = handler({})["context"]
+    subset = handler({"loaded_only": True})["context"]
+    assert full["totals"]["actions"] == 2
+    assert subset["totals"]["actions"] == 1
+
+
+def test_register_capability_mcp_tool_missing_inner_returns_false():
+    fake_server = MagicMock()
+    fake_server._server = None
+    builder = HoudiniCapabilityManifestBuilder()
+    assert register_capability_mcp_tool(fake_server, builder=builder) is False
+
+
+def test_builder_projects_unloaded_skills_with_load_hint():
+    actions = [_action("houdini_scene__get_scene_info", skill="houdini-scene")]
+    skills = [_skill("houdini-scene"), _skill("houdini-nodes", tags=["nodes"])]
+    skill_info_map = {
+        "houdini-nodes": {
+            "tags": ["nodes"],
+            "tools": [
+                {
+                    "name": "create_node",
+                    "description": "Create a node.",
+                    "execution": "sync",
+                    "group": "nodes",
+                    "input_schema": {"type": "object"},
+                },
+                {"name": "__skill__houdini-nodes"},
+            ],
+        },
+    }
+    builder = HoudiniCapabilityManifestBuilder(
+        skill_lister=lambda: skills,
+        action_lister=lambda: actions,
+        is_loaded=lambda name: name == "houdini-scene",
+        skill_info_lister=lambda name: skill_info_map.get(name),
+    )
+    records = builder.build()
+    by_tool = {r.backend_tool: r for r in records}
+    create = by_tool["houdini_nodes__create_node"]
+    assert create.loaded is False
+    assert create.requires_load_skill is True
+    assert create.load_hint == {"tool": "load_skill", "arguments": {"skill_name": "houdini-nodes"}}
+    assert "nodes" in create.tags
+    assert not any(r.backend_tool.startswith("__skill__") for r in records)

--- a/tests/test_context_snapshot.py
+++ b/tests/test_context_snapshot.py
@@ -1,0 +1,115 @@
+"""Unit tests for :mod:`dcc_mcp_houdini._context_snapshot`.
+
+A fake ``hou`` is injected via the ``hou_provider`` parameter so we can assert
+every branch — including the headless / unavailable fallback — without a live
+Houdini.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from dcc_mcp_houdini._context_snapshot import (
+    HoudiniContextSnapshotProvider,
+    collect_gateway_metadata,
+    make_snapshot_provider,
+)
+
+
+def _fake_hou(*, scene="/projects/shot.hip", has_file=True, unsaved=False, version="20.5.445", obj_count=3):
+    hip = SimpleNamespace(
+        path=lambda: scene,
+        name=lambda: scene,
+        hasFile=lambda: has_file,
+        hasUnsavedChanges=lambda: unsaved,
+    )
+    playbar = SimpleNamespace(playbackRange=lambda: (1001.0, 1100.0))
+    children = [object()] * obj_count
+    obj_node = SimpleNamespace(children=lambda: children)
+    return SimpleNamespace(
+        hipFile=hip,
+        playbar=playbar,
+        frame=lambda: 1001,
+        node=lambda path: obj_node if path == "/obj" else None,
+        applicationVersionString=lambda: version,
+    )
+
+
+def test_provider_collects_full_snapshot_when_houdini_available():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: _fake_hou())
+    snap = provider()
+    assert snap["dcc"] == "houdini"
+    assert snap["available"] is True
+    assert snap["scene"] == "/projects/shot.hip"
+    assert snap["scene_saved"] is True
+    assert snap["frame"] == 1001
+    assert snap["frame_range"] == [1001, 1100]
+    assert snap["obj_node_count"] == 3
+    assert snap["version"] == "20.5.445"
+    assert snap["display_name"] == "Houdini 20.5.445 — shot.hip"
+    assert snap["pid"] > 0
+
+
+def test_provider_returns_stub_when_hou_unavailable():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: None)
+    snap = provider()
+    assert snap["available"] is False
+    assert snap["dcc"] == "houdini"
+    assert "scene" not in snap
+
+
+def test_provider_survives_hou_factory_exception():
+    def boom():
+        raise RuntimeError("hou not initialised")
+
+    provider = HoudiniContextSnapshotProvider(hou_provider=boom)
+    snap = provider()
+    assert snap["available"] is False
+
+
+def test_provider_unsaved_hip_omits_scene():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: _fake_hou(has_file=False))
+    snap = provider()
+    assert "scene" not in snap
+    assert snap["available"] is True
+
+
+def test_provider_returns_fresh_dict_each_call():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: _fake_hou())
+    snap1 = provider()
+    snap2 = provider()
+    assert snap1 is not snap2
+
+
+def test_collect_gateway_metadata_single_document():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: _fake_hou(scene="/p/a.hip"))
+    meta = collect_gateway_metadata(provider)
+    assert meta["scene"] == "/p/a.hip"
+    assert meta["version"] == "20.5.445"
+    assert meta["documents"] == ["/p/a.hip"]
+    assert meta["display_name"] == "Houdini 20.5.445 — a.hip"
+
+
+def test_collect_gateway_metadata_no_scene_produces_empty_documents():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: _fake_hou(has_file=False))
+    meta = collect_gateway_metadata(provider)
+    assert meta["scene"] is None
+    assert meta["documents"] == []
+    assert meta["version"] == "20.5.445"
+
+
+def test_collect_gateway_metadata_headless_returns_all_none_or_empty():
+    provider = HoudiniContextSnapshotProvider(hou_provider=lambda: None)
+    meta = collect_gateway_metadata(provider)
+    assert meta == {"scene": None, "version": None, "documents": [], "display_name": None}
+
+
+def test_collect_gateway_metadata_defaults_to_builtin_provider():
+    meta = collect_gateway_metadata()
+    assert set(meta) == {"scene", "version", "documents", "display_name"}
+
+
+def test_make_snapshot_provider_returns_callable_provider():
+    provider = make_snapshot_provider(hou_provider=lambda: _fake_hou())
+    assert callable(provider)
+    assert provider()["available"] is True

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -1,0 +1,179 @@
+"""Unit tests for :mod:`dcc_mcp_houdini._project_tools`.
+
+These cover the pure logic of :class:`ProjectToolsIntegration`,
+:class:`HoudiniSceneResolver`, env-var resolution, and the defensive paths —
+all without a live Houdini or a running server.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Optional
+
+import dcc_mcp_houdini
+from dcc_mcp_houdini import (
+    HoudiniSceneResolver,
+    ProjectToolsIntegration,
+    attach_project_tools,
+)
+from dcc_mcp_houdini._project_tools import ENV_PROJECT_TOOLS, resolve_enabled
+
+
+class TestEnvResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = os.environ.pop(ENV_PROJECT_TOOLS, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop(ENV_PROJECT_TOOLS, None)
+        if self._saved is not None:
+            os.environ[ENV_PROJECT_TOOLS] = self._saved
+
+    def test_default_is_enabled(self) -> None:
+        self.assertTrue(resolve_enabled(None))
+
+    def test_env_zero_disables(self) -> None:
+        os.environ[ENV_PROJECT_TOOLS] = "0"
+        self.assertFalse(resolve_enabled(None))
+
+    def test_env_one_enables(self) -> None:
+        os.environ[ENV_PROJECT_TOOLS] = "1"
+        self.assertTrue(resolve_enabled(None))
+
+    def test_explicit_true_overrides_env_zero(self) -> None:
+        os.environ[ENV_PROJECT_TOOLS] = "0"
+        self.assertTrue(resolve_enabled(True))
+
+    def test_explicit_false_overrides_env_one(self) -> None:
+        os.environ[ENV_PROJECT_TOOLS] = "1"
+        self.assertFalse(resolve_enabled(False))
+
+
+class _StaticSceneResolver(HoudiniSceneResolver):
+    def __init__(self, scene: Optional[str]) -> None:
+        self._scene = scene
+        self.calls = 0
+
+    def current_scene(self) -> Optional[str]:
+        self.calls += 1
+        return self._scene
+
+
+class _RaisingSceneResolver(HoudiniSceneResolver):
+    def current_scene(self) -> Optional[str]:
+        raise RuntimeError("hou.hipFile blew up")
+
+
+class TestHoudiniSceneResolverDefault(unittest.TestCase):
+    def test_returns_none_outside_houdini(self) -> None:
+        resolver = HoudiniSceneResolver()
+        self.assertIsNone(resolver.current_scene())
+
+
+class TestProjectToolsIntegrationUnit(unittest.TestCase):
+    def test_inner_server_picked_when_both_attrs_present(self) -> None:
+        class _Inner:
+            registry = object()
+
+            def register_handler(self, name: str, fn: Any) -> None:
+                pass
+
+        class _Outer:
+            _server = _Inner()
+
+        outer = _Outer()
+        self.assertIs(ProjectToolsIntegration._inner_server(outer), outer._server)
+
+    def test_inner_server_returns_none_when_register_handler_missing(self) -> None:
+        class _BadInner:
+            registry = object()
+
+        class _Outer:
+            _server = _BadInner()
+
+        self.assertIsNone(ProjectToolsIntegration._inner_server(_Outer()))
+
+    def test_inner_server_returns_none_when_no_inner(self) -> None:
+        class _Outer:
+            pass
+
+        self.assertIsNone(ProjectToolsIntegration._inner_server(_Outer()))
+
+    def test_safe_resolve_scene_swallows_resolver_errors(self) -> None:
+        integration = ProjectToolsIntegration(scene_resolver=_RaisingSceneResolver())
+        self.assertIsNone(integration._safe_resolve_scene())
+
+    def test_safe_resolve_scene_normalises_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            scene = os.path.join(td, "shot.hip")
+            integration = ProjectToolsIntegration(scene_resolver=_StaticSceneResolver(scene))
+            resolved = integration._safe_resolve_scene()
+            self.assertEqual(Path(resolved), Path(scene))
+
+    def test_bind_returns_false_when_inner_server_missing(self) -> None:
+        integration = ProjectToolsIntegration(scene_resolver=_StaticSceneResolver(None))
+
+        class _NoInner:
+            pass
+
+        self.assertFalse(integration.bind(_NoInner()))
+        self.assertFalse(integration.registered)
+
+    def test_attach_to_server_skipped_when_disabled(self) -> None:
+        result = attach_project_tools(object(), enabled=False)
+        self.assertIsNone(result)
+
+
+class _FakeRegistry:
+    def __init__(self):
+        self.registered = []
+
+    def register(self, name, **kwargs):
+        self.registered.append((name, kwargs))
+
+
+class _FakeInner:
+    def __init__(self):
+        self.registry = _FakeRegistry()
+        self.handlers = {}
+
+    def register_handler(self, name, handler):
+        self.handlers[name] = handler
+
+
+class _FakeServer:
+    def __init__(self):
+        self._server = _FakeInner()
+
+
+class TestProjectToolsBindWithFakeScene(unittest.TestCase):
+    """Bind succeeds against a duck-typed server and a fake scene resolver."""
+
+    def test_bind_registers_project_tools_with_fake_scene(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            scene = os.path.join(td, "shot_010.hip")
+            Path(scene).write_text("// hip\n", encoding="utf-8")
+            integration = ProjectToolsIntegration(scene_resolver=_StaticSceneResolver(scene))
+            server = _FakeServer()
+            ok = integration.bind(server)
+            self.assertTrue(ok)
+            self.assertTrue(integration.registered)
+            # The four project tools must be declared on the inner registry.
+            declared = {name for name, _ in server._server.registry.registered}
+            assert {"project_save", "project_load", "project_resume", "project_status"} <= declared
+
+    def test_bind_without_scene_still_registers_tools(self) -> None:
+        integration = ProjectToolsIntegration(scene_resolver=_StaticSceneResolver(None))
+        server = _FakeServer()
+        ok = integration.bind(server)
+        self.assertTrue(ok)
+        self.assertIsNone(integration.bound_project)
+
+
+class TestPublicSurface(unittest.TestCase):
+    def test_top_level_exports(self) -> None:
+        for name in ("ENV_PROJECT_TOOLS", "HoudiniSceneResolver", "ProjectToolsIntegration", "attach_project_tools"):
+            self.assertTrue(hasattr(dcc_mcp_houdini, name), f"dcc_mcp_houdini.{name} should be importable")
+            self.assertIn(name, dcc_mcp_houdini.__all__, f"{name} missing from __all__")

--- a/tests/test_qt_inspector.py
+++ b/tests/test_qt_inspector.py
@@ -1,0 +1,154 @@
+"""Unit tests for :mod:`dcc_mcp_houdini._qt_inspector`.
+
+No live Houdini / Qt is required: we verify env gating, the graceful path when
+the inner server is missing, and that the main-thread proxy wraps handlers and
+marshals through an injected dispatcher.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, List
+
+import pytest
+
+from dcc_mcp_houdini import _qt_inspector
+from dcc_mcp_houdini._qt_inspector import (
+    ENV_QT_UI_INSPECTOR,
+    _MainThreadHandlerProxy,
+    _make_marshaller,
+    register_houdini_qt_ui_inspector,
+    resolve_qt_ui_inspector_enabled,
+)
+
+
+class TestEnvGating:
+    def test_default_enabled(self) -> None:
+        assert resolve_qt_ui_inspector_enabled({}) is True
+
+    @pytest.mark.parametrize("token", ["0", "false", "no", "off"])
+    def test_disabled_tokens(self, token: str) -> None:
+        assert resolve_qt_ui_inspector_enabled({ENV_QT_UI_INSPECTOR: token}) is False
+
+    def test_disabled_env_short_circuits_registration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_QT_UI_INSPECTOR, "0")
+
+        class _Server:
+            _server = object()
+
+        assert register_houdini_qt_ui_inspector(_Server()) is False
+
+
+class TestMissingInner:
+    def test_missing_inner_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_QT_UI_INSPECTOR, raising=False)
+
+        class _Server:
+            _server = None
+
+        assert register_houdini_qt_ui_inspector(_Server()) is False
+
+
+class _FakeDispatcher:
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def dispatch_callable(self, func: Callable[[], Any], **kwargs: Any) -> Any:
+        self.calls.append(kwargs.get("action_name", ""))
+        return func()
+
+
+class TestMarshaller:
+    def test_inline_when_no_dispatcher(self) -> None:
+        marshal = _make_marshaller(None)
+        assert marshal(lambda: 42) == 42
+
+    def test_inline_when_on_main_thread(self) -> None:
+        dispatcher = _FakeDispatcher()
+        marshal = _make_marshaller(dispatcher)
+        # The test runs on the main thread, so the marshaller must run inline.
+        assert marshal(lambda: "ok") == "ok"
+        assert dispatcher.calls == []
+
+    def test_dispatches_from_worker_thread(self) -> None:
+        dispatcher = _FakeDispatcher()
+        marshal = _make_marshaller(dispatcher)
+        result: List[Any] = []
+
+        def worker() -> None:
+            result.append(marshal(lambda: "marshalled"))
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert result == ["marshalled"]
+        assert dispatcher.calls == ["qt_ui_inspector"]
+
+    def test_degrades_to_inline_when_dispatch_raises(self) -> None:
+        class _BoomDispatcher:
+            def dispatch_callable(self, func: Callable[[], Any], **kwargs: Any) -> Any:
+                raise RuntimeError("queue closed")
+
+        marshal = _make_marshaller(_BoomDispatcher())
+        result: List[Any] = []
+
+        def worker() -> None:
+            result.append(marshal(lambda: "fallback"))
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert result == ["fallback"]
+
+
+class TestProxy:
+    def test_proxy_wraps_register_handler(self) -> None:
+        registered = {}
+
+        class _Inner:
+            registry = object()
+
+            def register_handler(self, name: str, handler: Callable[[Any], Any]) -> None:
+                registered[name] = handler
+
+        dispatcher = _FakeDispatcher()
+        proxy = _MainThreadHandlerProxy(_Inner(), _make_marshaller(dispatcher))
+        assert proxy.registry is _Inner.registry
+
+        proxy.register_handler("t", lambda params: {"params": params})
+        # The wrapped handler must still produce the original result.
+        out = registered["t"]({"a": 1})
+        assert out == {"params": {"a": 1}}
+
+
+class TestRegistrationWithFakeCore:
+    def test_registers_via_core_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_QT_UI_INSPECTOR, raising=False)
+
+        captured = {}
+
+        def _fake_register(server: Any, *, dcc_name: str = "dcc") -> None:
+            captured["server"] = server
+            captured["dcc_name"] = dcc_name
+
+        import sys
+        import types
+
+        mod = types.ModuleType("dcc_mcp_core.skills.qt_ui_inspector")
+        mod.register_qt_ui_inspector = _fake_register
+        monkeypatch.setitem(sys.modules, "dcc_mcp_core.skills.qt_ui_inspector", mod)
+
+        class _Inner:
+            registry = object()
+
+            def register_handler(self, name, handler):
+                pass
+
+        class _Server:
+            _server = _Inner()
+            _houdini_dispatcher = _FakeDispatcher()
+
+        ok = register_houdini_qt_ui_inspector(_Server(), dcc_name="houdini")
+        assert ok is True
+        assert captured["dcc_name"] == "houdini"
+        assert isinstance(captured["server"], _MainThreadHandlerProxy)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,220 @@
+"""Unit tests for the Houdini resource publisher.
+
+Covers the ``houdini-help://`` producer degradation, the binder bind/unbind
+lifecycle, and the trailing-edge throttling — all without a live Houdini.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Callable, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from dcc_mcp_houdini._resources import (
+    DEFAULT_SCENE_THROTTLE_SECS,
+    ENV_RESOURCES,
+    SCHEME_HOUDINI_HELP,
+    HoudiniResourceBinder,
+    _houdini_help_producer,
+    _parse_path_uri,
+    install_resources,
+    resolve_enabled,
+)
+
+
+class TestResolveEnabled:
+    def test_default_is_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_RESOURCES, raising=False)
+        assert resolve_enabled() is True
+
+    def test_zero_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_RESOURCES, "0")
+        assert resolve_enabled() is False
+
+    def test_explicit_argument_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_RESOURCES, "0")
+        assert resolve_enabled(True) is True
+
+
+class TestParsePathUri:
+    def test_strips_scheme_and_splits(self) -> None:
+        assert _parse_path_uri("houdini-help://Sop/box", scheme=SCHEME_HOUDINI_HELP) == ["Sop", "box"]
+
+    def test_returns_none_when_scheme_mismatches(self) -> None:
+        assert _parse_path_uri("scene://current", scheme=SCHEME_HOUDINI_HELP) is None
+
+
+class TestHelpProducerWithoutHoudini:
+    def test_help_returns_unavailable_envelope(self) -> None:
+        out = _houdini_help_producer("houdini-help://Sop/box")
+        assert out["mimeType"] == "application/json"
+        body = json.loads(out["text"])
+        assert body["status"] == "houdini_unavailable"
+
+    def test_help_invalid_uri(self) -> None:
+        out = _houdini_help_producer("houdini-help://")
+        body = json.loads(out["text"])
+        assert body["status"] == "invalid_uri"
+
+
+class _RecordingResourceHandle:
+    def __init__(self) -> None:
+        self.scenes: List[Any] = []
+        self.producers: Dict[str, Callable[[str], Dict[str, Any]]] = {}
+
+    def set_scene(self, value: Any) -> None:
+        self.scenes.append(value)
+
+    def register_producer(self, scheme: str, callable_: Callable[[str], Dict[str, Any]]) -> None:
+        self.producers[scheme] = callable_
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.resource_handle = _RecordingResourceHandle()
+        inner = MagicMock()
+        inner.resources.return_value = self.resource_handle
+        self._server = inner
+
+
+class TestBinderBind:
+    def test_bind_publishes_initial_snapshot_and_registers_producers(self) -> None:
+        server = _FakeServer()
+        snapshots: List[Dict[str, Any]] = []
+
+        def provider() -> Dict[str, Any]:
+            snap = {"dcc": "houdini", "scene": f"snap-{len(snapshots)}"}
+            snapshots.append(snap)
+            return snap
+
+        binder = HoudiniResourceBinder(snapshot_provider=provider, event_installer=lambda cb: [])
+        assert binder.bind(server) is True
+        assert binder.handle is server.resource_handle
+        assert binder.scene_publish_count == 1
+        assert server.resource_handle.scenes == [{"dcc": "houdini", "scene": "snap-0"}]
+        assert binder.registered_producers == [SCHEME_HOUDINI_HELP]
+
+    def test_bind_without_snapshot_provider_skips_initial_publish(self) -> None:
+        server = _FakeServer()
+        binder = HoudiniResourceBinder()
+        assert binder.bind(server) is True
+        assert binder.scene_publish_count == 0
+
+    def test_bind_is_idempotent(self) -> None:
+        server = _FakeServer()
+        binder = HoudiniResourceBinder(snapshot_provider=lambda: {"k": "v"})
+        binder.bind(server)
+        binder.bind(server)
+        assert len(server.resource_handle.producers) == 1
+        assert binder.scene_publish_count == 1
+
+    def test_bind_returns_false_when_resources_unavailable(self) -> None:
+        server = MagicMock()
+        server._server.resources.side_effect = RuntimeError("not enabled")
+        binder = HoudiniResourceBinder()
+        assert binder.bind(server) is False
+        assert binder.handle is None
+
+    def test_install_scene_events_uses_injected_installer(self) -> None:
+        server = _FakeServer()
+        installed: List[Any] = []
+
+        def installer(callback: Callable[[], None]) -> List[Any]:
+            installed.append(callback)
+            return ["handle-1"]
+
+        binder = HoudiniResourceBinder(event_installer=installer)
+        binder.bind(server)
+        handles = binder.install_scene_events()
+        assert handles == ["handle-1"]
+        assert binder.scene_event_handles == ["handle-1"]
+        assert installed
+
+    def test_unbind_is_idempotent_and_clears_state(self) -> None:
+        removed: List[Any] = []
+        server = _FakeServer()
+        binder = HoudiniResourceBinder(
+            event_installer=lambda cb: [1, 2],
+            event_remover=lambda handles: removed.extend(handles),
+        )
+        binder.bind(server)
+        binder.install_scene_events()
+        binder.unbind()
+        binder.unbind()
+        assert binder.scene_event_handles == []
+        assert removed == [1, 2]
+
+
+class TestThrottling:
+    def test_event_after_throttle_window_publishes_immediately(self) -> None:
+        server = _FakeServer()
+        binder = HoudiniResourceBinder(
+            snapshot_provider=lambda: {"event": "tick"},
+            event_installer=lambda cb: [],
+            throttle_secs=0.05,
+        )
+        binder.bind(server)
+        baseline = binder.scene_publish_count
+        time.sleep(0.1)
+        binder._on_scene_event()
+        assert binder.scene_publish_count == baseline + 1
+
+    def test_burst_collapses_to_one_trailing_publish(self) -> None:
+        server = _FakeServer()
+        binder = HoudiniResourceBinder(
+            snapshot_provider=lambda: {"event": "tick"},
+            event_installer=lambda cb: [],
+            throttle_secs=0.05,
+        )
+        binder.bind(server)
+        baseline = binder.scene_publish_count
+        for _ in range(50):
+            binder._on_scene_event()
+        assert binder.scene_publish_count == baseline
+        time.sleep(0.2)
+        assert binder.scene_publish_count == baseline + 1
+        binder.unbind()
+
+    def test_scene_events_drop_while_executor_busy(self) -> None:
+        server = _FakeServer()
+        busy = {"value": True}
+        binder = HoudiniResourceBinder(
+            snapshot_provider=lambda: {"event": "tick"},
+            event_installer=lambda cb: [],
+            busy_checker=lambda: busy["value"],
+            throttle_secs=0.0,
+        )
+        binder.bind(server)
+        baseline = binder.scene_publish_count
+        binder._on_scene_event()
+        assert binder.scene_publish_count == baseline
+        busy["value"] = False
+        binder._on_scene_event()
+        assert binder.scene_publish_count == baseline + 1
+
+
+class TestInstallResources:
+    def test_returns_none_when_disabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_RESOURCES, "0")
+        server = _FakeServer()
+        assert install_resources(server) is None
+
+    def test_returns_binder_with_producers_wired(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_RESOURCES, raising=False)
+        server = _FakeServer()
+        binder = install_resources(
+            server,
+            snapshot_provider=lambda: {"dcc": "houdini"},
+            install_scene_events=False,
+        )
+        assert binder is not None
+        assert binder.handle is server.resource_handle
+        assert binder.scene_publish_count == 1
+
+
+class TestModuleExports:
+    def test_default_throttle_is_positive(self) -> None:
+        assert DEFAULT_SCENE_THROTTLE_SECS > 0

--- a/tests/test_semantic_index.py
+++ b/tests/test_semantic_index.py
@@ -1,0 +1,125 @@
+"""Morphology-aware semantic skill recall tests for Houdini.
+
+These exercise :mod:`dcc_mcp_houdini._semantic_index` directly (no live server
+/ Houdini needed).  The vector backend ships in ``dcc-mcp-core>=0.17.38``;
+tests skip cleanly on older cores.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+import pytest
+
+from dcc_mcp_houdini import _semantic_index
+
+pytestmark = pytest.mark.skipif(
+    _semantic_index.HoudiniSemanticIndex.build(embedder_kind="hashed") is None,
+    reason="dcc-mcp-core lacks VectorSkillIndex (needs >=0.17.38)",
+)
+
+
+@dataclass
+class _FakeSummary:
+    name: str
+    description: str = ""
+    search_hint: str = ""
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+    dcc: str = "houdini"
+    version: str = "1.0.0"
+
+
+def _catalog() -> List[_FakeSummary]:
+    return [
+        _FakeSummary("houdini-render", description="render the active frame and write images to disk"),
+        _FakeSummary("houdini-nodes", description="create and connect SOP nodes in the network"),
+        _FakeSummary("houdini-automation", description="set frame range and save the hip file"),
+        _FakeSummary("houdini-materials", description="create and assign materials"),
+    ]
+
+
+class TestGating:
+    def test_disabled_by_default(self):
+        assert _semantic_index.resolve_semantic_index_enabled({}) is False
+
+    @pytest.mark.parametrize("token", ["1", "true", "YES", "on"])
+    def test_enabled_truthy_tokens(self, token: str):
+        env = {_semantic_index.ENV_SEMANTIC_INDEX: token}
+        assert _semantic_index.resolve_semantic_index_enabled(env) is True
+
+    def test_build_semantic_index_none_when_disabled(self, monkeypatch):
+        monkeypatch.delenv(_semantic_index.ENV_SEMANTIC_INDEX, raising=False)
+        assert _semantic_index.build_semantic_index() is None
+
+    def test_build_semantic_index_present_when_enabled(self, monkeypatch):
+        monkeypatch.setenv(_semantic_index.ENV_SEMANTIC_INDEX, "1")
+        index = _semantic_index.build_semantic_index()
+        assert index is not None
+        assert index.embedder_kind == "hashed"
+
+    def test_embedder_kind_resolution(self):
+        assert _semantic_index.resolve_embedder_kind({}) == "hashed"
+        assert _semantic_index.resolve_embedder_kind({_semantic_index.ENV_SEMANTIC_EMBEDDER: "onnx"}) == "onnx"
+
+
+class TestMorphologyRecall:
+    def _index(self):
+        idx = _semantic_index.HoudiniSemanticIndex.build(embedder_kind="hashed")
+        assert idx is not None
+        return idx
+
+    def test_inflected_query_recovers_skill_missed_by_lexical(self):
+        idx = self._index()
+        catalog = _catalog()
+        fused = idx.augment(base=[], query="rendering the current frame", all_summaries=catalog)
+        names = [s.name for s in fused]
+        assert "houdini-render" in names
+
+    def test_base_results_are_never_demoted(self):
+        idx = self._index()
+        catalog = _catalog()
+        base = [catalog[2], catalog[3]]  # automation, materials (canonical order)
+        fused = idx.augment(base=base, query="rendering", all_summaries=catalog)
+        assert [s.name for s in fused[:2]] == ["houdini-automation", "houdini-materials"]
+
+    def test_no_duplicates_when_recall_overlaps_base(self):
+        idx = self._index()
+        catalog = _catalog()
+        base = [catalog[0]]  # houdini-render already present
+        fused = idx.augment(base=base, query="rendering", all_summaries=catalog)
+        assert [s.name for s in fused].count("houdini-render") == 1
+
+    def test_empty_query_returns_base_unchanged(self):
+        idx = self._index()
+        catalog = _catalog()
+        base = [catalog[1]]
+        assert idx.augment(base=base, query="", all_summaries=catalog) == base
+        assert idx.augment(base=base, query=None, all_summaries=catalog) == base
+
+    def test_limit_truncates_fused_result(self):
+        idx = self._index()
+        catalog = _catalog()
+        fused = idx.augment(base=list(catalog), query="rendering", all_summaries=catalog, limit=2)
+        assert len(fused) == 2
+
+    def test_augment_accepts_dict_summaries(self):
+        """find_skills returns dicts; the index must handle dict summaries too."""
+        idx = self._index()
+        catalog = [
+            {"name": "houdini-render", "description": "render the active frame"},
+            {"name": "houdini-nodes", "description": "create SOP nodes"},
+        ]
+        fused = idx.augment(base=[], query="rendering", all_summaries=catalog)
+        names = [_semantic_index._summary_name(s) for s in fused]
+        assert "houdini-render" in names
+
+    def test_rebuild_is_cached_until_catalog_changes(self):
+        idx = self._index()
+        catalog = _catalog()
+        idx.rebuild(catalog)
+        sig = idx._signature
+        idx.rebuild(catalog)
+        assert idx._signature == sig
+        idx.rebuild(catalog + [_FakeSummary("houdini-new", description="brand new skill")])
+        assert idx._signature != sig

--- a/tests/test_server_integrations.py
+++ b/tests/test_server_integrations.py
@@ -1,0 +1,93 @@
+"""Server-level wiring tests for the core integrations.
+
+These build a real :class:`HoudiniMcpServer` (no live Houdini, no started HTTP
+listener) and confirm :meth:`register_builtin_actions` attaches the optional
+core integrations and that they degrade gracefully under env opt-outs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_houdini import HoudiniMcpServer
+from dcc_mcp_houdini._env import ENV_PROJECT_TOOLS, ENV_RESOURCES
+
+
+def _make_server() -> HoudiniMcpServer:
+    return HoudiniMcpServer(port=0, gateway_port=0, enable_gateway_failover=False, job_storage_path="")
+
+
+def test_register_builtin_actions_wires_resources_and_project_tools() -> None:
+    server = _make_server()
+    try:
+        server.register_builtin_actions(include_bundled=True)
+        assert server._resources is not None
+        assert server._resources.handle is not None
+        assert server._project_tools is not None
+    finally:
+        try:
+            server.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def test_build_capability_manifest_returns_payload() -> None:
+    server = _make_server()
+    try:
+        server.register_builtin_actions(include_bundled=True)
+        payload = server.build_capability_manifest()
+        assert payload["dcc_type"] == "houdini"
+        assert payload["schema_version"] == "1"
+        assert set(payload["totals"]) >= {"actions", "loaded_actions", "unloaded_actions"}
+        assert isinstance(payload["capabilities"], list)
+        assert payload["capabilities"], "expected at least one capability record"
+        for record in payload["capabilities"]:
+            assert "backend_tool" in record
+            assert "tool_slug" in record
+            assert "loaded" in record
+    finally:
+        try:
+            server.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def test_resources_disabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_RESOURCES, "0")
+    server = _make_server()
+    try:
+        server.register_builtin_actions(include_bundled=True)
+        assert server._resources is None
+    finally:
+        try:
+            server.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def test_project_tools_disabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_PROJECT_TOOLS, "0")
+    server = _make_server()
+    try:
+        server.register_builtin_actions(include_bundled=True)
+        assert server._project_tools is None
+    finally:
+        try:
+            server.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def test_capability_manifest_loaded_only_filters() -> None:
+    server = _make_server()
+    try:
+        server.register_builtin_actions(include_bundled=True)
+        full = server.build_capability_manifest()
+        loaded = server.build_capability_manifest(loaded_only=True)
+        assert loaded["totals"]["actions"] <= full["totals"]["actions"]
+        assert all(c.get("loaded", False) for c in loaded["capabilities"])
+    finally:
+        try:
+            server.stop()
+        except Exception:  # noqa: BLE001
+            pass


### PR DESCRIPTION
## Summary

Brings the Houdini adapter to parity with the Maya adapter's latest `dcc-mcp-core` interface wiring, and adds an agent-facing install path.

### Server wiring
All integrations are wired in `HoudiniMcpServer.register_builtin_actions` after `super()`, each guarded by `try/except` so a missing optional core API never breaks startup. Every surface has a `DCC_MCP_HOUDINI_*` opt-out.

- Per-action capability manifest + `dcc_capability_manifest` MCP tool + `build_capability_manifest()`
- Context snapshot provider (gateway metadata, driven by `hou.hipFile.path()` / frame / playbar)
- MCP resources: `scene://current` + `houdini-help://`
- Project tools: `project_save/load/resume/status`
- Qt UI inspector (`qt_ui_inspector__*`, main-thread routed)
- Opt-in morphology-aware semantic skill recall augmenting `search_skills`
- `introspect` / `feedback` / `recipes` / `skill-reference-docs` core tools

### Agent install
- `install.md` + `skills/dcc-mcp-houdini-setup/` (SKILL.md + `setup_dcc_mcp_houdini.py`)
- README "Agent install (recommended)" section (trigger: `帮我参考 loonghao/dcc-mcp-houdini/install.md 去安装`)

## Test plan
- [x] `python -m pytest tests -q` → 135 passed, 1 skipped (live-Houdini), 1 deselected
- [x] New unit tests for every integration; none require a live Houdini
- [x] `setup_dcc_mcp_houdini.py` compiles; `--help` works; clean SystemExit when hython is absent
