### PR TITLE
feat(skills): add Houdini scene-edit and object-ops skills (#11)

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -21,8 +21,13 @@ STAGES: Tuple[str, ...] = (
 # Map stage → bundled skill names (extend as new skills land).
 STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "bootstrap": ("houdini-scripting",),
-    "scene": ("houdini-scene",),
-    "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
+    "scene": ("houdini-scene", "houdini-scene-edit"),
+    "authoring": (
+        "houdini-nodes",
+        "houdini-object-ops",
+        "houdini-materials",
+        "houdini-hda",
+    ),
     "interchange": (),
     "pipeline": ("houdini-automation",),
 }

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -5,8 +5,8 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Stage | Skills | Default loaded |
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
-| `scene` | `houdini-scene` | yes |
-| `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
+| `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
+| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-materials`, `houdini-hda` | no |
 | `interchange` | _(planned: USD, FBX, Alembic)_ | no |
 | `pipeline` | `houdini-automation` | no |
 
@@ -16,6 +16,9 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |------|-------|
 | Verify MCP session | `houdini_scripting__get_session_info` |
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
+| Scene lifecycle | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__open_scene` / `houdini_scene_edit__save_scene` |
+| Select & frame | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__find_nodes` → `houdini_scene_edit__set_selection` → `houdini_scene_edit__get_bounding_box` |
+| Edit existing object | `load_skill("houdini-object-ops")` → `houdini_object_ops__get_transform` → `houdini_object_ops__set_transform` → `houdini_object_ops__set_node_flags` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: houdini-object-ops
+description: >-
+  Authoring skill — object-level Houdini mutations: rename, duplicate, reparent,
+  set display/render/template/bypass flags, hard-lock/unlock, and read/set
+  translate-rotate-scale transforms. Use these typed tools instead of arbitrary
+  Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
+  or scene lifecycle/selection (use houdini-scene-edit).
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, object, transform, rename, parent, flags, authoring]
+    search-hint: "rename node, duplicate node, reparent, move node, set flags, lock node, get transform, set transform, translate rotate scale"
+    tools: tools.yaml
+---
+
+# houdini-object-ops
+
+Typed object-level edit tools for agents. All tools are `affinity: main` because
+they call `hou`. Prefer these over `houdini-scripting.execute_python` when
+editing nodes that already exist.
+
+## Tool groups
+
+- **`object-edit`:** `rename_node`, `duplicate_node`, `parent_node`,
+  `set_node_flags`, `set_node_lock`.
+- **`object-transform`:** `get_transform`, `set_transform` (operate on OBJ-level
+  `t`/`r`/`s` parm tuples).
+
+## Suggested flow
+
+1. Find/select with `houdini-scene-edit` (`find_nodes` → `set_selection`)
+2. `get_transform` → `set_transform` to position an object
+3. `set_node_flags` / `set_node_lock` to control display and freeze state
+
+For creating new nodes use `houdini-nodes`. On failure, load `houdini-scripting`
+and call `get_session_info`, or use gateway diagnostics when available.

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/_object_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/_object_common.py
@@ -1,0 +1,40 @@
+"""Shared helpers for Houdini object-operation skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def read_parm_tuple(node: Any, name: str):
+    """Return a parm-tuple value as a list of floats, or ``None`` if absent."""
+    parm_tuple = node.parmTuple(name)
+    if parm_tuple is None:
+        return None
+    return [float(v) for v in parm_tuple.eval()]
+
+
+def set_parm_tuple(node: Any, name: str, values) -> bool:
+    """Set a parm-tuple value; return ``True`` when the tuple exists."""
+    parm_tuple = node.parmTuple(name)
+    if parm_tuple is None:
+        return False
+    parm_tuple.set(tuple(values))
+    return True

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/duplicate_node.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/duplicate_node.py
@@ -1,0 +1,53 @@
+"""Duplicate a Houdini node within its parent network."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node, node_summary  # noqa: E402
+
+
+def duplicate_node(node_path: str, new_name: Optional[str] = None) -> dict:
+    """Copy the node at *node_path* into its parent and optionally rename it."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        parent = node.parent()
+        if parent is None:
+            return skill_error("Cannot duplicate", "Node has no parent network")
+        copies = parent.copyItems([node])
+        if not copies:
+            return skill_error("Duplicate failed", "Houdini returned no copied items")
+        new_node = copies[0]
+        if new_name:
+            new_node.setName(new_name, unique_name=True)
+        return skill_success(
+            "Duplicated node",
+            source_path=node.path(),
+            node=node_summary(new_node),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to duplicate node")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return duplicate_node(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/get_transform.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/get_transform.py
@@ -1,0 +1,58 @@
+"""Read the local transform (translate/rotate/scale) of an OBJ node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node, read_parm_tuple  # noqa: E402
+
+
+def get_transform(node_path: str) -> dict:
+    """Return translate/rotate/scale parm values for *node_path*.
+
+    Works on OBJ-level nodes that expose ``t``, ``r``, and ``s`` parm tuples.
+    Missing tuples are returned as ``None`` rather than failing.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        translate = read_parm_tuple(node, "t")
+        rotate = read_parm_tuple(node, "r")
+        scale = read_parm_tuple(node, "s")
+        if translate is None and rotate is None and scale is None:
+            return skill_error(
+                "No transform parameters",
+                "Node has no t/r/s parm tuples: {}".format(node_path),
+                possible_solutions=["Target an OBJ-level transformable node"],
+            )
+        return skill_success(
+            "Read transform",
+            node_path=node.path(),
+            translate=translate,
+            rotate=rotate,
+            scale=scale,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read transform")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_transform(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/parent_node.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/parent_node.py
@@ -1,0 +1,47 @@
+"""Move a Houdini node into a different parent network."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node, node_summary  # noqa: E402
+
+
+def parent_node(node_path: str, new_parent_path: str) -> dict:
+    """Reparent *node_path* under *new_parent_path* using ``hou.moveNodesTo``."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        new_parent = get_node(hou, new_parent_path)
+        moved = hou.moveNodesTo([node], new_parent)
+        result_node = moved[0] if moved else None
+        summary = node_summary(result_node) if result_node is not None else None
+        return skill_success(
+            "Reparented node",
+            new_parent_path=new_parent.path(),
+            node=summary,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to reparent node")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return parent_node(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/rename_node.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/rename_node.py
@@ -1,0 +1,45 @@
+"""Rename a Houdini node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node, node_summary  # noqa: E402
+
+
+def rename_node(node_path: str, new_name: str, unique_name: bool = True) -> dict:
+    """Rename the node at *node_path* to *new_name*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        old_path = node.path()
+        node.setName(new_name, unique_name=unique_name)
+        return skill_success(
+            "Renamed node",
+            old_path=old_path,
+            node=node_summary(node),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to rename node")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return rename_node(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_node_flags.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_node_flags.py
@@ -1,0 +1,84 @@
+"""Set display / render / template / bypass flags on a Houdini node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node  # noqa: E402
+
+# Flag name -> setter method on the node. Only applied when the node exposes the
+# setter and the caller passed a value for that flag.
+_FLAG_SETTERS = {
+    "display": "setDisplayFlag",
+    "render": "setRenderFlag",
+    "template": "setTemplateFlag",
+    "bypass": "bypass",
+}
+
+
+def set_node_flags(
+    node_path: str,
+    display: Optional[bool] = None,
+    render: Optional[bool] = None,
+    template: Optional[bool] = None,
+    bypass: Optional[bool] = None,
+) -> dict:
+    """Apply the supplied node flags. Unspecified (None) flags are left alone."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        requested = {
+            "display": display,
+            "render": render,
+            "template": template,
+            "bypass": bypass,
+        }
+        applied = {}
+        unsupported = []
+        for flag, value in requested.items():
+            if value is None:
+                continue
+            setter_name = _FLAG_SETTERS[flag]
+            setter = getattr(node, setter_name, None)
+            if setter is None:
+                unsupported.append(flag)
+                continue
+            setter(bool(value))
+            applied[flag] = bool(value)
+        if not applied and unsupported:
+            return skill_error(
+                "No flags applied",
+                "None of the requested flags are supported on this node",
+                unsupported=unsupported,
+            )
+        return skill_success(
+            "Updated node flags",
+            node_path=node.path(),
+            applied=applied,
+            unsupported=unsupported,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set node flags")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_node_flags(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_node_lock.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_node_lock.py
@@ -1,0 +1,55 @@
+"""Lock or unlock a Houdini node's cooked contents."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node  # noqa: E402
+
+
+def set_node_lock(node_path: str, locked: bool) -> dict:
+    """Hard-lock (freeze) or unlock the node at *node_path*.
+
+    Uses ``setHardLocked`` when the node supports it (SOP-style nodes); returns
+    a structured error otherwise so the caller can choose a different node.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        setter = getattr(node, "setHardLocked", None)
+        if setter is None:
+            return skill_error(
+                "Lock unsupported",
+                "Node type does not support hard locking: {}".format(node_path),
+                possible_solutions=["Target a SOP node that supports setHardLocked"],
+            )
+        setter(bool(locked))
+        return skill_success(
+            "Updated node lock",
+            node_path=node.path(),
+            locked=bool(locked),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set node lock")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_node_lock(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_transform.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_transform.py
@@ -1,0 +1,70 @@
+"""Set the local transform (translate/rotate/scale) of an OBJ node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _object_common import get_node, set_parm_tuple  # noqa: E402
+
+
+def set_transform(
+    node_path: str,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    scale: Optional[List[float]] = None,
+) -> dict:
+    """Set the ``t``/``r``/``s`` parm tuples for *node_path*.
+
+    Only the supplied components are written. Components whose parm tuple is
+    absent on the node are reported under ``unsupported``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        requested = {"t": translate, "r": rotate, "s": scale}
+        applied = {}
+        unsupported = []
+        for parm_name, values in requested.items():
+            if values is None:
+                continue
+            if set_parm_tuple(node, parm_name, values):
+                applied[parm_name] = [float(v) for v in values]
+            else:
+                unsupported.append(parm_name)
+        if not applied:
+            return skill_error(
+                "No transform applied",
+                "Provide translate, rotate, and/or scale for a transformable node",
+                unsupported=unsupported,
+            )
+        return skill_success(
+            "Set transform",
+            node_path=node.path(),
+            applied=applied,
+            unsupported=unsupported,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set transform")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_transform(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/tools.yaml
@@ -1,0 +1,194 @@
+tools:
+  - name: rename_node
+    description: >-
+      Rename a node, optionally enforcing a unique name within its parent.
+    source_file: scripts/rename_node.py
+    execution: sync
+    affinity: main
+    group: object-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, new_name]
+      properties:
+        node_path:
+          type: string
+          description: Node to rename.
+        new_name:
+          type: string
+          description: New node name.
+        unique_name:
+          type: boolean
+          default: true
+          description: Let Houdini disambiguate the name if it collides.
+  - name: duplicate_node
+    description: >-
+      Copy a node into its parent network and optionally rename the copy.
+    source_file: scripts/duplicate_node.py
+    execution: sync
+    affinity: main
+    group: object-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Node to duplicate.
+        new_name:
+          type: string
+          description: Optional name for the duplicated node.
+  - name: parent_node
+    description: >-
+      Move a node into a different parent network using hou.moveNodesTo.
+    source_file: scripts/parent_node.py
+    execution: sync
+    affinity: main
+    group: object-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [node_path, new_parent_path]
+      properties:
+        node_path:
+          type: string
+          description: Node to reparent.
+        new_parent_path:
+          type: string
+          description: Destination parent network path.
+  - name: set_node_flags
+    description: >-
+      Set display, render, template, and/or bypass flags on a node. Unspecified
+      flags are left unchanged.
+    source_file: scripts/set_node_flags.py
+    execution: sync
+    affinity: main
+    group: object-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Node whose flags to update.
+        display:
+          type: boolean
+          description: Set the display flag.
+        render:
+          type: boolean
+          description: Set the render flag.
+        template:
+          type: boolean
+          description: Set the template flag.
+        bypass:
+          type: boolean
+          description: Set the bypass flag.
+  - name: set_node_lock
+    description: >-
+      Hard-lock (freeze cooked geometry) or unlock a SOP-style node.
+    source_file: scripts/set_node_lock.py
+    execution: sync
+    affinity: main
+    group: object-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, locked]
+      properties:
+        node_path:
+          type: string
+          description: Node to lock or unlock.
+        locked:
+          type: boolean
+          description: True to hard-lock, false to unlock.
+  - name: get_transform
+    description: >-
+      Read translate/rotate/scale parm tuples (t/r/s) for an OBJ-level node.
+      Read-only.
+    source_file: scripts/get_transform.py
+    execution: sync
+    affinity: main
+    group: object-transform
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: OBJ-level node to inspect.
+  - name: set_transform
+    description: >-
+      Set translate/rotate/scale parm tuples (t/r/s) for an OBJ-level node.
+      Only the supplied components are written.
+    source_file: scripts/set_transform.py
+    execution: sync
+    affinity: main
+    group: object-transform
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: OBJ-level node to transform.
+        translate:
+          type: array
+          items:
+            type: number
+          description: World translate [tx, ty, tz].
+        rotate:
+          type: array
+          items:
+            type: number
+          description: Rotate [rx, ry, rz] in degrees.
+        scale:
+          type: array
+          items:
+            type: number
+          description: Scale [sx, sy, sz].

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: houdini-scene-edit
+description: >-
+  Scene-management skill — typed Houdini scene lifecycle (new/open/save with
+  dirty-scene safeguards), selection (get/set/find), camera discovery, and
+  bounding-box queries. Use these atomic tools instead of arbitrary Python for
+  everyday scene navigation and file operations. Not for node authoring (use
+  houdini-nodes) or geometry/transform edits (use houdini-object-ops).
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: scene
+    version: "1.0.0"
+    tags: [houdini, scene, hip, selection, camera, bounds]
+    search-hint: "new scene, open hip, save hip, get selection, set selection, find nodes, list cameras, bounding box"
+    tools: tools.yaml
+---
+
+# houdini-scene-edit
+
+Typed scene-management tools for agents. All tools are `affinity: main` because
+they call `hou`. Prefer these over `houdini-scripting.execute_python` for scene
+lifecycle and navigation.
+
+## When to use
+
+- **Lifecycle:** `new_scene`, `open_scene`, `save_scene` — each guards against
+  silently discarding unsaved changes (pass `force=true` to override).
+- **Selection & discovery:** `get_selection`, `set_selection`, `find_nodes`,
+  `list_cameras`, `get_bounding_box`.
+
+## Suggested flow
+
+1. `find_nodes` (by name glob or type substring) → `set_selection`
+2. `get_bounding_box` to frame or measure a result
+3. `save_scene` to persist
+
+For node creation/connection use `houdini-nodes`; for rename/parent/flags and
+transforms use `houdini-object-ops`. On failure, load `houdini-scripting` and
+call `get_session_info`, or use gateway diagnostics when available.

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/_scene_edit_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/_scene_edit_common.py
@@ -1,0 +1,39 @@
+"""Shared helpers for Houdini scene-edit skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def iter_nodes(root: Any, recursive: bool) -> list:
+    """Return the children (or all descendants) of *root*."""
+    if recursive and hasattr(root, "allSubChildren"):
+        return list(root.allSubChildren())
+    return list(root.children())
+
+
+def vec_to_list(vec: Any) -> list:
+    """Convert a HOM vector/tuple-like object to a plain list of floats."""
+    try:
+        return [float(component) for component in vec]
+    except TypeError:
+        # Some HOM vectors expose explicit accessors only.
+        return [float(vec[i]) for i in range(len(vec))]

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/find_nodes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/find_nodes.py
@@ -1,0 +1,68 @@
+"""Find Houdini nodes by name pattern and/or node type."""
+
+from __future__ import annotations
+
+import fnmatch
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _scene_edit_common import get_node, iter_nodes, node_summary  # noqa: E402
+
+
+def find_nodes(
+    name_pattern: Optional[str] = None,
+    type_filter: Optional[str] = None,
+    root_path: str = "/obj",
+    recursive: bool = True,
+    max_results: int = 200,
+) -> dict:
+    """Search under *root_path* for nodes matching the given criteria.
+
+    ``name_pattern`` is a glob (``fnmatch``) on the node name; ``type_filter``
+    is a case-insensitive substring of the node type name. At least one of the
+    two should be provided to be useful, but neither is required.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        root = get_node(hou, root_path)
+        matches = []
+        for node in iter_nodes(root, recursive):
+            if name_pattern and not fnmatch.fnmatch(node.name(), name_pattern):
+                continue
+            type_name = node.type().name()
+            if type_filter and type_filter.lower() not in type_name.lower():
+                continue
+            matches.append(node_summary(node))
+            if len(matches) >= max_results:
+                break
+        return skill_success(
+            "Found matching nodes",
+            nodes=matches,
+            count=len(matches),
+            truncated=len(matches) >= max_results,
+            root_path=root_path,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to find nodes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return find_nodes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/get_bounding_box.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/get_bounding_box.py
@@ -1,0 +1,68 @@
+"""Return the geometry bounding box of a Houdini node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _scene_edit_common import get_node, vec_to_list  # noqa: E402
+
+
+def _resolve_geometry(node):
+    """Return geometry for a SOP node or an OBJ geo's display node."""
+    geo = None
+    if hasattr(node, "geometry"):
+        geo = node.geometry()
+    if geo is None and hasattr(node, "displayNode"):
+        display = node.displayNode()
+        if display is not None and hasattr(display, "geometry"):
+            geo = display.geometry()
+    return geo
+
+
+def get_bounding_box(node_path: str) -> dict:
+    """Compute the world/local bounding box of *node_path*'s geometry."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        geo = _resolve_geometry(node)
+        if geo is None:
+            return skill_error(
+                "No geometry to measure",
+                "Node has no cookable geometry: {}".format(node_path),
+                possible_solutions=[
+                    "Point at a SOP node or an OBJ geo with a display node",
+                ],
+            )
+        bbox = geo.boundingBox()
+        return skill_success(
+            "Computed bounding box",
+            node_path=node.path(),
+            min=vec_to_list(bbox.minvec()),
+            max=vec_to_list(bbox.maxvec()),
+            size=vec_to_list(bbox.sizevec()),
+            center=vec_to_list(bbox.center()),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to compute bounding box")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_bounding_box(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/get_selection.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/get_selection.py
@@ -1,0 +1,39 @@
+"""Return the currently selected Houdini nodes."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _scene_edit_common import node_summary  # noqa: E402
+
+
+def get_selection() -> dict:
+    """List the nodes Houdini currently reports as selected."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        nodes = [node_summary(n) for n in hou.selectedNodes()]
+        return skill_success("Read current selection", nodes=nodes, count=len(nodes))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read selection")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_selection(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/list_cameras.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/list_cameras.py
@@ -1,0 +1,50 @@
+"""List camera object nodes in the scene."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _scene_edit_common import get_node, iter_nodes, node_summary  # noqa: E402
+
+
+def list_cameras(root_path: str = "/obj", recursive: bool = True) -> dict:
+    """List object-level camera nodes (type name contains ``cam``)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        root = get_node(hou, root_path)
+        cameras = []
+        for node in iter_nodes(root, recursive):
+            type_name = node.type().name()
+            # Match 'cam' but skip 'camera switcher'-style helpers via exact-ish check.
+            if type_name == "cam" or type_name.startswith("cam"):
+                cameras.append(node_summary(node))
+        return skill_success(
+            "Listed cameras",
+            cameras=cameras,
+            count=len(cameras),
+            root_path=root_path,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list cameras")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_cameras(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/new_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/new_scene.py
@@ -1,0 +1,42 @@
+"""Start a new (empty) Houdini scene with a dirty-scene safeguard."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def new_scene(force: bool = False) -> dict:
+    """Clear the current hip file.
+
+    Refuses to discard unsaved changes unless ``force`` is ``True``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not force and hou.hipFile.hasUnsavedChanges():
+            return skill_error(
+                "Scene has unsaved changes",
+                "Refusing to clear the scene; save first or call with force=true",
+                possible_solutions=[
+                    "Call houdini_scene_edit__save_scene first",
+                    "Re-run new_scene with force=true to discard changes",
+                ],
+            )
+        hou.hipFile.clear(suppress_save_prompt=True)
+        return skill_success("Started a new scene", forced=bool(force))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to start a new scene")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return new_scene(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/open_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/open_scene.py
@@ -1,0 +1,50 @@
+"""Open an existing Houdini hip file with a dirty-scene safeguard."""
+
+from __future__ import annotations
+
+import os
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def open_scene(file_path: str, force: bool = False) -> dict:
+    """Load *file_path* into the current session.
+
+    Refuses to discard unsaved changes unless ``force`` is ``True``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not os.path.isfile(file_path):
+            return skill_error("Hip file not found", "No file at: {}".format(file_path))
+        if not force and hou.hipFile.hasUnsavedChanges():
+            return skill_error(
+                "Scene has unsaved changes",
+                "Refusing to load over unsaved changes; save first or call with force=true",
+                possible_solutions=[
+                    "Call houdini_scene_edit__save_scene first",
+                    "Re-run open_scene with force=true to discard changes",
+                ],
+            )
+        hou.hipFile.load(file_path, suppress_save_prompt=True, ignore_load_warnings=False)
+        return skill_success(
+            "Opened hip file",
+            file_path=hou.hipFile.path(),
+            forced=bool(force),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to open hip file")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return open_scene(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/save_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/save_scene.py
@@ -1,0 +1,45 @@
+"""Save the current Houdini hip file."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def save_scene(file_path: Optional[str] = None) -> dict:
+    """Save the scene.
+
+    With no ``file_path`` the current hip path is reused (must already be
+    saved at least once); otherwise the scene is saved to ``file_path``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if file_path:
+            hou.hipFile.save(file_name=file_path)
+        else:
+            if not hou.hipFile.hasFile():
+                return skill_error(
+                    "Scene has never been saved",
+                    "No hip path is set; pass file_path to choose a destination",
+                    possible_solutions=["Call save_scene with an explicit file_path"],
+                )
+            hou.hipFile.save()
+        return skill_success("Saved hip file", file_path=hou.hipFile.path())
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to save hip file")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return save_scene(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/set_selection.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/set_selection.py
@@ -1,0 +1,65 @@
+"""Replace the current Houdini node selection."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _scene_edit_common import node_summary  # noqa: E402
+
+
+def set_selection(node_paths: List[str], clear_existing: bool = True) -> dict:
+    """Select the nodes at *node_paths*.
+
+    When ``clear_existing`` is ``True`` the previous selection is cleared
+    first. Unknown paths are reported in ``missing`` without aborting.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if clear_existing:
+            hou.clearAllSelected()
+        selected = []
+        missing = []
+        for path in node_paths:
+            node = hou.node(path)
+            if node is None:
+                missing.append(path)
+                continue
+            node.setSelected(True)
+            selected.append(node_summary(node))
+        if not selected and missing:
+            return skill_error(
+                "No nodes selected",
+                "None of the requested paths exist",
+                missing=missing,
+            )
+        return skill_success(
+            "Updated selection",
+            selected=selected,
+            count=len(selected),
+            missing=missing,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set selection")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_selection(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/tools.yaml
@@ -1,0 +1,212 @@
+tools:
+  - name: new_scene
+    description: >-
+      Clear the current hip file and start an empty scene. Refuses to discard
+      unsaved changes unless force is true.
+    source_file: scripts/new_scene.py
+    execution: sync
+    affinity: main
+    group: scene-lifecycle
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    input_schema:
+      type: object
+      properties:
+        force:
+          type: boolean
+          default: false
+          description: Discard unsaved changes without prompting.
+    next-tools:
+      on-failure:
+        - houdini_scene_edit__save_scene
+  - name: open_scene
+    description: >-
+      Load an existing hip file. Refuses to discard unsaved changes unless
+      force is true; returns a structured error when the file is missing.
+    source_file: scripts/open_scene.py
+    execution: sync
+    affinity: main
+    group: scene-lifecycle
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [file_path]
+      properties:
+        file_path:
+          type: string
+          description: Absolute path to the .hip/.hipnc/.hiplc file to load.
+        force:
+          type: boolean
+          default: false
+          description: Discard unsaved changes without prompting.
+    next-tools:
+      on-success:
+        - houdini_scene__get_scene_info
+      on-failure:
+        - houdini_scene_edit__save_scene
+  - name: save_scene
+    description: >-
+      Save the current scene. With no file_path the existing hip path is reused
+      (must have been saved at least once); otherwise saves to file_path.
+    source_file: scripts/save_scene.py
+    execution: sync
+    affinity: main
+    group: scene-lifecycle
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        file_path:
+          type: string
+          description: Optional destination path; reuses the current hip path when omitted.
+  - name: get_selection
+    description: >-
+      Return the nodes Houdini currently reports as selected, with path, name,
+      and type. Does not modify the scene.
+    source_file: scripts/get_selection.py
+    execution: sync
+    affinity: main
+    group: scene-selection
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties: {}
+  - name: set_selection
+    description: >-
+      Replace (or extend) the node selection from a list of node paths. Missing
+      paths are reported without aborting.
+    source_file: scripts/set_selection.py
+    execution: sync
+    affinity: main
+    group: scene-selection
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_paths]
+      properties:
+        node_paths:
+          type: array
+          items:
+            type: string
+          description: Node paths to select.
+        clear_existing:
+          type: boolean
+          default: true
+          description: Clear the prior selection before selecting the given nodes.
+  - name: find_nodes
+    description: >-
+      Search under a root path for nodes matching a name glob and/or a node
+      type substring. Read-only discovery for selection and inspection.
+    source_file: scripts/find_nodes.py
+    execution: sync
+    affinity: main
+    group: scene-selection
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        name_pattern:
+          type: string
+          description: Glob pattern matched against node names (e.g. "geo*").
+        type_filter:
+          type: string
+          description: Case-insensitive substring of the node type name.
+        root_path:
+          type: string
+          default: "/obj"
+          description: Network path to search beneath.
+        recursive:
+          type: boolean
+          default: true
+          description: Traverse all descendants when true.
+        max_results:
+          type: integer
+          minimum: 1
+          default: 200
+          description: Cap on returned matches.
+    next-tools:
+      on-success:
+        - houdini_scene_edit__set_selection
+        - houdini_scene__get_node_info
+  - name: list_cameras
+    description: >-
+      List object-level camera nodes (type name starting with "cam"). Read-only.
+    source_file: scripts/list_cameras.py
+    execution: sync
+    affinity: main
+    group: scene-selection
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        root_path:
+          type: string
+          default: "/obj"
+          description: Network path to search beneath.
+        recursive:
+          type: boolean
+          default: true
+          description: Traverse all descendants when true.
+  - name: get_bounding_box
+    description: >-
+      Return the geometry bounding box (min, max, size, center) of a SOP node or
+      an OBJ geo's display node. Read-only query.
+    source_file: scripts/get_bounding_box.py
+    execution: sync
+    affinity: main
+    group: scene-selection
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Node path whose geometry bounds should be measured.

--- a/tests/test_scene_transform_skills.py
+++ b/tests/test_scene_transform_skills.py
@@ -1,0 +1,262 @@
+"""Unit tests for houdini-scene-edit and houdini-object-ops skills (issue #11).
+
+No live Houdini is required; the HOM ``hou`` module is mocked per test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(skill_name: str, script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / skill_name / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"skill_{skill_name}_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _mock_node(path: str, name: str, type_name: str) -> MagicMock:
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = type_name
+    return node
+
+
+class TestSceneLifecycle:
+    def test_new_scene_blocks_on_unsaved_changes(self) -> None:
+        mod = _load_script("houdini-scene-edit", "new_scene.py")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.new_scene(force=False)
+
+        assert result["success"] is False
+        mock_hou.hipFile.clear.assert_not_called()
+
+    def test_new_scene_force_clears(self) -> None:
+        mod = _load_script("houdini-scene-edit", "new_scene.py")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.new_scene(force=True)
+
+        assert result["success"] is True
+        mock_hou.hipFile.clear.assert_called_once()
+
+    def test_save_scene_requires_path_when_never_saved(self) -> None:
+        mod = _load_script("houdini-scene-edit", "save_scene.py")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.hasFile.return_value = False
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.save_scene()
+
+        assert result["success"] is False
+        mock_hou.hipFile.save.assert_not_called()
+
+    def test_save_scene_with_path(self) -> None:
+        mod = _load_script("houdini-scene-edit", "save_scene.py")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.path.return_value = "/tmp/out.hip"
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.save_scene(file_path="/tmp/out.hip")
+
+        assert result["success"] is True
+        mock_hou.hipFile.save.assert_called_once_with(file_name="/tmp/out.hip")
+
+
+class TestSelectionAndDiscovery:
+    def test_set_selection_reports_missing(self) -> None:
+        mod = _load_script("houdini-scene-edit", "set_selection.py")
+        good = _mock_node("/obj/geo1", "geo1", "geo")
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: good if path == "/obj/geo1" else None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_selection(["/obj/geo1", "/obj/missing"])
+
+        assert result["success"] is True
+        mock_hou.clearAllSelected.assert_called_once()
+        good.setSelected.assert_called_once_with(True)
+        assert result["context"]["count"] == 1
+        assert result["context"]["missing"] == ["/obj/missing"]
+
+    def test_find_nodes_by_name_and_type(self) -> None:
+        mod = _load_script("houdini-scene-edit", "find_nodes.py")
+        box = _mock_node("/obj/geo1/box1", "box1", "box")
+        sphere = _mock_node("/obj/geo1/sphere1", "sphere1", "sphere")
+        root = MagicMock()
+        root.allSubChildren.return_value = [box, sphere]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = root
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.find_nodes(name_pattern="box*", type_filter="box")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["nodes"][0]["path"] == "/obj/geo1/box1"
+
+    def test_list_cameras(self) -> None:
+        mod = _load_script("houdini-scene-edit", "list_cameras.py")
+        cam = _mock_node("/obj/cam1", "cam1", "cam")
+        geo = _mock_node("/obj/geo1", "geo1", "geo")
+        root = MagicMock()
+        root.allSubChildren.return_value = [cam, geo]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = root
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_cameras()
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["cameras"][0]["name"] == "cam1"
+
+    def test_get_bounding_box(self) -> None:
+        mod = _load_script("houdini-scene-edit", "get_bounding_box.py")
+        bbox = MagicMock()
+        bbox.minvec.return_value = [0.0, 0.0, 0.0]
+        bbox.maxvec.return_value = [1.0, 2.0, 3.0]
+        bbox.sizevec.return_value = [1.0, 2.0, 3.0]
+        bbox.center.return_value = [0.5, 1.0, 1.5]
+        geo = MagicMock()
+        geo.boundingBox.return_value = bbox
+        node = _mock_node("/obj/geo1/box1", "box1", "box")
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_bounding_box("/obj/geo1/box1")
+
+        assert result["success"] is True
+        assert result["context"]["max"] == [1.0, 2.0, 3.0]
+        assert result["context"]["center"] == [0.5, 1.0, 1.5]
+
+
+class TestObjectEdits:
+    def test_rename_node(self) -> None:
+        mod = _load_script("houdini-object-ops", "rename_node.py")
+        node = _mock_node("/obj/geo1", "geo1", "geo")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.rename_node("/obj/geo1", "hero")
+
+        assert result["success"] is True
+        node.setName.assert_called_once_with("hero", unique_name=True)
+
+    def test_duplicate_node(self) -> None:
+        mod = _load_script("houdini-object-ops", "duplicate_node.py")
+        node = _mock_node("/obj/geo1", "geo1", "geo")
+        copy = _mock_node("/obj/geo2", "geo2", "geo")
+        parent = MagicMock()
+        parent.copyItems.return_value = [copy]
+        node.parent.return_value = parent
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.duplicate_node("/obj/geo1", new_name="clone")
+
+        assert result["success"] is True
+        parent.copyItems.assert_called_once_with([node])
+        copy.setName.assert_called_once_with("clone", unique_name=True)
+
+    def test_parent_node(self) -> None:
+        mod = _load_script("houdini-object-ops", "parent_node.py")
+        node = _mock_node("/obj/geo1", "geo1", "geo")
+        new_parent = _mock_node("/obj/subnet1", "subnet1", "subnet")
+        moved = _mock_node("/obj/subnet1/geo1", "geo1", "geo")
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {"/obj/geo1": node, "/obj/subnet1": new_parent}.get(path)
+        mock_hou.moveNodesTo.return_value = [moved]
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.parent_node("/obj/geo1", "/obj/subnet1")
+
+        assert result["success"] is True
+        mock_hou.moveNodesTo.assert_called_once_with([node], new_parent)
+        assert result["context"]["node"]["path"] == "/obj/subnet1/geo1"
+
+    def test_set_node_flags(self) -> None:
+        mod = _load_script("houdini-object-ops", "set_node_flags.py")
+        node = _mock_node("/obj/geo1/box1", "box1", "box")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_node_flags("/obj/geo1/box1", display=True, bypass=False)
+
+        assert result["success"] is True
+        node.setDisplayFlag.assert_called_once_with(True)
+        node.bypass.assert_called_once_with(False)
+        assert result["context"]["applied"] == {"display": True, "bypass": False}
+
+    def test_set_node_lock(self) -> None:
+        mod = _load_script("houdini-object-ops", "set_node_lock.py")
+        node = _mock_node("/obj/geo1/box1", "box1", "box")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_node_lock("/obj/geo1/box1", locked=True)
+
+        assert result["success"] is True
+        node.setHardLocked.assert_called_once_with(True)
+
+
+class TestTransforms:
+    def test_get_transform(self) -> None:
+        mod = _load_script("houdini-object-ops", "get_transform.py")
+        node = _mock_node("/obj/geo1", "geo1", "geo")
+
+        def _parm_tuple(name):
+            values = {"t": [1.0, 2.0, 3.0], "r": [0.0, 90.0, 0.0], "s": [1.0, 1.0, 1.0]}
+            if name not in values:
+                return None
+            pt = MagicMock()
+            pt.eval.return_value = values[name]
+            return pt
+
+        node.parmTuple.side_effect = _parm_tuple
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_transform("/obj/geo1")
+
+        assert result["success"] is True
+        assert result["context"]["translate"] == [1.0, 2.0, 3.0]
+        assert result["context"]["rotate"] == [0.0, 90.0, 0.0]
+
+    def test_set_transform(self) -> None:
+        mod = _load_script("houdini-object-ops", "set_transform.py")
+        node = _mock_node("/obj/geo1", "geo1", "geo")
+        t_tuple = MagicMock()
+        node.parmTuple.side_effect = lambda name: t_tuple if name == "t" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_transform("/obj/geo1", translate=[5, 0, 0], rotate=[0, 0, 0])
+
+        assert result["success"] is True
+        t_tuple.set.assert_called_once_with((5, 0, 0))
+        assert result["context"]["applied"]["t"] == [5.0, 0.0, 0.0]
+        assert result["context"]["unsupported"] == ["r"]


### PR DESCRIPTION
## Summary

Implements **#11** (parent **#10**): expands Houdini's bundled, discoverable skill coverage with two typed, load-on-demand skill packages so everyday scene-management and object-editing no longer require `execute_python`.

### `houdini-scene-edit` (stage: `scene`)
- **Lifecycle:** `new_scene`, `open_scene`, `save_scene` — each guards against discarding unsaved changes (`force=true` to override) and returns structured errors (missing file, never-saved scene).
- **Selection & discovery:** `get_selection`, `set_selection` (reports missing paths), `find_nodes` (name glob + type substring), `list_cameras`, `get_bounding_box`.

### `houdini-object-ops` (stage: `authoring`)
- **Object edits:** `rename_node`, `duplicate_node`, `parent_node` (reparent via `hou.moveNodesTo`), `set_node_flags` (display/render/template/bypass), `set_node_lock` (hard lock).
- **Transforms:** `get_transform` / `set_transform` over `t`/`r`/`s` parm tuples.

## Acceptance criteria (#11)

- [x] Native scene lifecycle with dirty-scene safeguards and structured errors.
- [x] Selection/discovery: get/set selection, find by name pattern, select by type (via `find_nodes` + `set_selection`), list cameras, bounding boxes.
- [x] Object mutations: rename, duplicate, parent/reparent, set flags, lock/unlock, set/get transforms.
- [x] Accurate read-only vs mutating side-effect annotations + `affinity: main`.
- [x] Skill docs explain when to use typed tools vs node creation / raw Python.
- [x] Tests validate schemas, representative HOM calls with stubs, skill linting, and packaged skill inclusion.

Both skills are bundled by default but only loaded on demand — minimal startup is unchanged. Wired into `_skill_loader.STAGE_SKILLS` and `SKILLS_INDEX.md`.

## Test plan

- [x] `pytest tests/test_scene_transform_skills.py tests/test_skills.py` → 48 passed (15 new mock-hou unit tests + skill-lint/tools.yaml contract over all skills).
- [x] Full suite: `pytest` → 154 passed, 1 skipped.
