### PR TITLE
feat: Houdini SOP geometry inspection + mesh operation skills (#13)

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -22,7 +22,13 @@ STAGES: Tuple[str, ...] = (
 STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "bootstrap": ("houdini-scripting",),
     "scene": ("houdini-scene",),
-    "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
+    "authoring": (
+        "houdini-nodes",
+        "houdini-geometry",
+        "houdini-mesh-ops",
+        "houdini-materials",
+        "houdini-hda",
+    ),
     "interchange": (),
     "pipeline": ("houdini-automation",),
 }

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,7 +6,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene` | yes |
-| `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
+| `authoring` | `houdini-nodes`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-materials`, `houdini-hda` | no |
 | `interchange` | _(planned: USD, FBX, Alembic)_ | no |
 | `pipeline` | `houdini-automation` | no |
 
@@ -17,6 +17,8 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Verify MCP session | `houdini_scripting__get_session_info` |
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
+| Create & inspect geometry | `load_skill("houdini-geometry")` → `houdini_geometry__create_primitive` → `houdini_geometry__get_geometry_info` → `houdini_geometry__list_attributes` / `houdini_geometry__list_groups` |
+| Edit a mesh procedurally | `load_skill("houdini-mesh-ops")` → `houdini_mesh_ops__transform_geometry` / `merge_geometry` / `blast_geometry` / `group_geometry` / `add_normals` / `triangulate_geometry` / `convert_geometry` → `houdini_geometry__get_cook_status` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: houdini-geometry
+description: >-
+  Authoring skill — create common SOP primitives and inspect SOP geometry:
+  point/prim/vertex counts, bounds, attributes, groups, and cook errors. Use
+  these typed tools to query and seed geometry before falling back to custom
+  scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, geometry, sop, attributes, groups, primitives, authoring]
+    search-hint: "create box sphere grid tube curve, geometry info, point count, attributes, groups, cook errors"
+    tools: tools.yaml
+---
+
+# houdini-geometry
+
+Typed SOP creation and inspection tools for agents. All tools are `affinity:
+main` because they call `hou`. Prefer these over
+`houdini-scripting.execute_python` for seeding and querying geometry.
+
+## Tool groups
+
+- **`geometry-create`:** `create_primitive` (box/sphere/grid/tube/curve/null/output).
+- **`geometry-query`** (read-only except cook): `get_geometry_info`,
+  `list_attributes`, `list_groups`, `get_cook_status`.
+
+## Tracer-bullet flow
+
+1. `create_primitive(parent_path="/obj/geo1", primitive="box")`
+2. `get_geometry_info` → counts and bounds
+3. edit with `houdini-mesh-ops` (transform/merge/blast/group/normal/convert)
+4. `get_cook_status` → verify no cook errors
+
+`get_cook_status` is `async` with a timeout hint because heavy SOP graphs can
+cook slowly.

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/_geo_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/_geo_common.py
@@ -1,0 +1,71 @@
+"""Shared helpers for Houdini geometry-inspection skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def cooked_geometry(node: Any) -> Any:
+    """Return the node's geometry, cooking on demand. Raises when unavailable."""
+    geo = node.geometry() if hasattr(node, "geometry") else None
+    if geo is None:
+        raise ValueError("Node has no SOP geometry: {}".format(node.path()))
+    return geo
+
+
+def attrib_entries(attribs) -> list:
+    """Summarise a sequence of HOM attributes as name/type/size dicts."""
+    entries = []
+    for attrib in attribs:
+        entry = {"name": _safe(attrib, "name")}
+        data_type = getattr(attrib, "dataType", None)
+        if callable(data_type):
+            try:
+                entry["data_type"] = str(attrib.dataType())
+            except Exception:  # noqa: BLE001
+                entry["data_type"] = None
+        size = getattr(attrib, "size", None)
+        if callable(size):
+            try:
+                entry["size"] = int(attrib.size())
+            except Exception:  # noqa: BLE001
+                entry["size"] = None
+        entries.append(entry)
+    return entries
+
+
+def group_entries(groups, counter: str) -> list:
+    """Summarise a sequence of HOM groups as name/count dicts.
+
+    ``counter`` is the membership accessor for the group class
+    (``"points"`` / ``"prims"`` / ``"edges"``).
+    """
+    entries = []
+    for group in groups:
+        entry = {"name": _safe(group, "name"), "count": None}
+        fn = getattr(group, counter, None)
+        if callable(fn):
+            try:
+                entry["count"] = len(fn())
+            except Exception:  # noqa: BLE001
+                entry["count"] = None
+        entries.append(entry)
+    return entries
+
+
+def _safe(obj: Any, method: str):
+    fn = getattr(obj, method, None)
+    if not callable(fn):
+        return None
+    try:
+        return fn()
+    except Exception:  # noqa: BLE001
+        return None

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/create_primitive.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/create_primitive.py
@@ -1,0 +1,73 @@
+"""Create a common SOP primitive inside a SOP network."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _geo_common import get_node  # noqa: E402
+
+# Friendly primitive name -> SOP node type name.
+_PRIMITIVES = {
+    "box": "box",
+    "sphere": "sphere",
+    "grid": "grid",
+    "tube": "tube",
+    "curve": "curve",
+    "null": "null",
+    "output": "output",
+}
+
+
+def create_primitive(
+    parent_path: str,
+    primitive: str,
+    node_name: Optional[str] = None,
+    set_display: bool = True,
+) -> dict:
+    """Create a ``primitive`` SOP under *parent_path* (a SOP network)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    sop_type = _PRIMITIVES.get(primitive.lower())
+    if sop_type is None:
+        return skill_error(
+            "Unsupported primitive",
+            "primitive must be one of: {}".format(", ".join(sorted(_PRIMITIVES))),
+            requested=primitive,
+        )
+    try:
+        parent = get_node(hou, parent_path)
+        node = parent.createNode(sop_type, node_name=node_name)
+        if set_display and hasattr(node, "setDisplayFlag"):
+            node.setDisplayFlag(True)
+        return skill_success(
+            "Created SOP primitive",
+            parent_path=parent.path(),
+            node_path=node.path(),
+            node_name=node.name(),
+            primitive=primitive.lower(),
+            sop_type=sop_type,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create SOP primitive")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_primitive(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_cook_status.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_cook_status.py
@@ -1,0 +1,53 @@
+"""Cook a SOP node and report errors/warnings."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _geo_common import get_node  # noqa: E402
+
+
+def get_cook_status(node_path: str, force: bool = False) -> dict:
+    """Cook *node_path* and return any cook errors and warnings."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        cook_error = None
+        try:
+            node.cook(force=force)
+        except Exception as exc:  # noqa: BLE001 - surface cook failure as data
+            cook_error = str(exc)
+        errors = list(node.errors()) if hasattr(node, "errors") else []
+        warnings = list(node.warnings()) if hasattr(node, "warnings") else []
+        return skill_success(
+            "Cooked node",
+            node_path=node.path(),
+            cooked=cook_error is None,
+            cook_error=cook_error,
+            errors=errors,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cook node")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_cook_status(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_geometry_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_geometry_info.py
@@ -1,0 +1,68 @@
+"""Return point/primitive/vertex counts and bounds for a SOP node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _geo_common import cooked_geometry, get_node  # noqa: E402
+
+
+def _vec(value) -> list:
+    try:
+        return [float(v) for v in value]
+    except TypeError:
+        return [float(value[i]) for i in range(len(value))]
+
+
+def get_geometry_info(node_path: str) -> dict:
+    """Summarise geometry counts and bounds for *node_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        geo = cooked_geometry(node)
+        point_count = len(geo.points()) if hasattr(geo, "points") else None
+        prim_count = len(geo.prims()) if hasattr(geo, "prims") else None
+        vertex_count = None
+        if hasattr(geo, "iterVertices"):
+            try:
+                vertex_count = sum(1 for _ in geo.iterVertices())
+            except Exception:  # noqa: BLE001
+                vertex_count = None
+        context = {
+            "node_path": node.path(),
+            "point_count": point_count,
+            "primitive_count": prim_count,
+            "vertex_count": vertex_count,
+        }
+        try:
+            bbox = geo.boundingBox()
+            context["bounds_min"] = _vec(bbox.minvec())
+            context["bounds_max"] = _vec(bbox.maxvec())
+            context["bounds_size"] = _vec(bbox.sizevec())
+        except Exception:  # noqa: BLE001
+            pass
+        return skill_success("Read geometry info", **context)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read geometry info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_geometry_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/list_attributes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/list_attributes.py
@@ -1,0 +1,50 @@
+"""List point/primitive/vertex/detail attributes for a SOP node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _geo_common import attrib_entries, cooked_geometry, get_node  # noqa: E402
+
+
+def list_attributes(node_path: str) -> dict:
+    """Return attribute names/types grouped by class (point/prim/vertex/detail)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        geo = cooked_geometry(node)
+        attribs = {
+            "point": attrib_entries(geo.pointAttribs()) if hasattr(geo, "pointAttribs") else [],
+            "primitive": attrib_entries(geo.primAttribs()) if hasattr(geo, "primAttribs") else [],
+            "vertex": attrib_entries(geo.vertexAttribs()) if hasattr(geo, "vertexAttribs") else [],
+            "detail": attrib_entries(geo.globalAttribs()) if hasattr(geo, "globalAttribs") else [],
+        }
+        return skill_success(
+            "Listed attributes",
+            node_path=node.path(),
+            attributes=attribs,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list attributes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_attributes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/list_groups.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/list_groups.py
@@ -1,0 +1,49 @@
+"""List point/primitive/edge groups for a SOP node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _geo_common import cooked_geometry, get_node, group_entries  # noqa: E402
+
+
+def list_groups(node_path: str) -> dict:
+    """Return group names/counts grouped by class (point/primitive/edge)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        geo = cooked_geometry(node)
+        groups = {
+            "point": group_entries(geo.pointGroups(), "points") if hasattr(geo, "pointGroups") else [],
+            "primitive": group_entries(geo.primGroups(), "prims") if hasattr(geo, "primGroups") else [],
+            "edge": group_entries(geo.edgeGroups(), "edges") if hasattr(geo, "edgeGroups") else [],
+        }
+        return skill_success(
+            "Listed groups",
+            node_path=node.path(),
+            groups=groups,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list groups")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_groups(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/tools.yaml
@@ -1,0 +1,128 @@
+tools:
+  - name: create_primitive
+    description: >-
+      Create a common SOP primitive (box, sphere, grid, tube, curve, null,
+      output) under an explicit SOP network path.
+    source_file: scripts/create_primitive.py
+    execution: sync
+    affinity: main
+    group: geometry-create
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [parent_path, primitive]
+      properties:
+        parent_path:
+          type: string
+          description: SOP network path to create inside (e.g. /obj/geo1).
+        primitive:
+          type: string
+          enum: [box, sphere, grid, tube, curve, null, output]
+          description: Primitive/utility SOP to create.
+        node_name:
+          type: string
+          description: Optional node name.
+        set_display:
+          type: boolean
+          default: true
+          description: Set the display flag on the new node.
+    next-tools:
+      on-success:
+        - houdini_geometry__get_geometry_info
+  - name: get_geometry_info
+    description: >-
+      Cook and summarise point/primitive/vertex counts and bounds for a SOP
+      node. Read-only.
+    source_file: scripts/get_geometry_info.py
+    execution: sync
+    affinity: main
+    group: geometry-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: SOP node to inspect.
+  - name: list_attributes
+    description: >-
+      List point/primitive/vertex/detail attributes (name, data type, size) for
+      a SOP node. Read-only.
+    source_file: scripts/list_attributes.py
+    execution: sync
+    affinity: main
+    group: geometry-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: SOP node to inspect.
+  - name: list_groups
+    description: >-
+      List point/primitive/edge groups (name, count) for a SOP node. Read-only.
+    source_file: scripts/list_groups.py
+    execution: sync
+    affinity: main
+    group: geometry-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: SOP node to inspect.
+  - name: get_cook_status
+    description: >-
+      Cook a SOP node and return cook success plus any errors and warnings.
+    source_file: scripts/get_cook_status.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 120
+    group: geometry-query
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: SOP node to cook.
+        force:
+          type: boolean
+          default: false
+          description: Force a recook even when the node is already cooked.

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: houdini-mesh-ops
+description: >-
+  Authoring skill — lightweight SOP mesh operations that append standard SOPs
+  downstream of an input: transform, merge, blast/delete, group create, normals,
+  triangulate, and convert. Each tool wires the new node into the network and
+  returns its path for chaining. Use with houdini-geometry for inspection.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, sop, mesh, transform, merge, blast, group, normal, convert, authoring]
+    search-hint: "transform merge blast delete group normals triangulate convert mesh sop edit"
+    tools: tools.yaml
+---
+
+# houdini-mesh-ops
+
+Typed mesh-edit tools that build procedural SOP networks. Every tool creates a
+standard SOP downstream of the provided `input_path`, wires input 0, sets the
+display flag, and returns the new node path so calls chain naturally.
+
+All tools are `affinity: main` (they call `hou`).
+
+## Tool group
+
+- **`mesh-edit`:** `transform_geometry`, `merge_geometry`, `blast_geometry`
+  (destructive), `group_geometry`, `add_normals`, `triangulate_geometry`,
+  `convert_geometry`.
+
+## Tracer-bullet flow
+
+1. `houdini_geometry__create_primitive(parent_path="/obj/geo1", primitive="box")`
+2. `transform_geometry(input_path=".../box1", translate=[2,0,0])`
+3. `merge_geometry(input_paths=[".../xform1", ".../sphere1"])`
+4. `add_normals(input_path=".../merge1")`
+5. `houdini_geometry__get_cook_status(node_path=".../normal1")` → verify result
+
+`blast_geometry` is flagged `destructive` because it removes geometry; pass
+`delete_non_selected=true` to invert the selection (keep the group).

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
@@ -1,0 +1,55 @@
+"""Shared helpers for Houdini mesh-operation skills."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def make_downstream_sop(input_node: Any, optype: str, name: Optional[str] = None) -> Any:
+    """Create *optype* in the input's parent, wired to the input's output 0."""
+    parent = input_node.parent()
+    if parent is None:
+        raise ValueError("Input node has no parent network: {}".format(input_node.path()))
+    new_node = parent.createNode(optype, node_name=name)
+    new_node.setInput(0, input_node)
+    if hasattr(new_node, "moveToGoodPosition"):
+        try:
+            new_node.moveToGoodPosition()
+        except Exception:  # noqa: BLE001
+            pass
+    if hasattr(new_node, "setDisplayFlag"):
+        new_node.setDisplayFlag(True)
+    return new_node
+
+
+def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
+    """Set a scalar/tuple parm only when it exists. Return whether it was set."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            return False
+        parm_tuple.set(tuple(value))
+        return True
+    parm = node.parm(name)
+    if parm is None:
+        return False
+    parm.set(value)
+    return True
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_normals.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_normals.py
@@ -1,0 +1,56 @@
+"""Append a Normal SOP to compute geometry normals."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
+
+# normal 'type' menu indices: 0=point, 1=vertex, 2=primitive, 3=detail.
+_NORMAL_TYPE = {"point": 0, "vertex": 1, "primitive": 2, "detail": 3}
+
+
+def add_normals(
+    input_path: str,
+    attribute_class: str = "point",
+    node_name: Optional[str] = None,
+) -> dict:
+    """Create a Normal SOP downstream of *input_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        source = get_node(hou, input_path)
+        normal = make_downstream_sop(source, "normal", node_name)
+        type_index = _NORMAL_TYPE.get(attribute_class.lower())
+        if type_index is not None:
+            set_parm_if_exists(normal, "type", type_index)
+        return skill_success(
+            "Created normal SOP",
+            input_path=source.path(),
+            node=node_summary(normal),
+            attribute_class=attribute_class.lower(),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create normal SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return add_normals(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/blast_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/blast_geometry.py
@@ -1,0 +1,71 @@
+"""Append a Blast SOP to delete (or keep) a selected group."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
+
+# Blast 'grouptype' menu indices (Houdini 18.5+).
+_GROUP_TYPE = {
+    "guess": 0,
+    "breakpoints": 1,
+    "edges": 2,
+    "points": 3,
+    "prims": 4,
+    "primitives": 4,
+    "vertices": 5,
+}
+
+
+def blast_geometry(
+    input_path: str,
+    group: str,
+    group_type: str = "prims",
+    delete_non_selected: bool = False,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Create a Blast SOP that deletes (or keeps) *group* downstream of input."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        source = get_node(hou, input_path)
+        blast = make_downstream_sop(source, "blast", node_name)
+        set_parm_if_exists(blast, "group", group)
+        type_index = _GROUP_TYPE.get(group_type.lower())
+        if type_index is not None:
+            set_parm_if_exists(blast, "grouptype", type_index)
+        # negate=1 keeps the selection and deletes everything else.
+        set_parm_if_exists(blast, "negate", 1 if delete_non_selected else 0)
+        return skill_success(
+            "Created blast SOP",
+            input_path=source.path(),
+            node=node_summary(blast),
+            group=group,
+            group_type=group_type.lower(),
+            delete_non_selected=bool(delete_non_selected),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create blast SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return blast_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/convert_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/convert_geometry.py
@@ -1,0 +1,69 @@
+"""Append a Convert SOP to change the geometry primitive type."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
+
+# Friendly target type -> convert SOP 'totype' menu token.
+_TO_TYPE = {
+    "polygons": "poly",
+    "poly": "poly",
+    "mesh": "mesh",
+    "nurbs": "nurbs",
+    "bezier": "bezier",
+    "subdivision": "subdiv",
+    "subdiv": "subdiv",
+}
+
+
+def convert_geometry(
+    input_path: str,
+    to_type: str = "polygons",
+    node_name: Optional[str] = None,
+) -> dict:
+    """Create a Convert SOP downstream of *input_path* set to ``to_type``."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    token = _TO_TYPE.get(to_type.lower())
+    if token is None:
+        return skill_error(
+            "Unsupported target type",
+            "to_type must be one of: {}".format(", ".join(sorted(set(_TO_TYPE)))),
+            requested=to_type,
+        )
+    try:
+        source = get_node(hou, input_path)
+        convert = make_downstream_sop(source, "convert", node_name)
+        set_parm_if_exists(convert, "totype", token)
+        return skill_success(
+            "Created convert SOP",
+            input_path=source.path(),
+            node=node_summary(convert),
+            to_type=token,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create convert SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return convert_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/group_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/group_geometry.py
@@ -1,0 +1,70 @@
+"""Append a Group Create SOP to define a point/primitive/edge group."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
+
+# groupcreate 'grouptype' menu indices.
+_GROUP_TYPE = {
+    "points": 0,
+    "prims": 1,
+    "primitives": 1,
+    "edges": 2,
+    "vertices": 3,
+}
+
+
+def group_geometry(
+    input_path: str,
+    group_name: str,
+    group_type: str = "prims",
+    pattern: Optional[str] = None,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Create a Group Create SOP downstream of *input_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        source = get_node(hou, input_path)
+        group_node = make_downstream_sop(source, "groupcreate", node_name)
+        set_parm_if_exists(group_node, "groupname", group_name)
+        type_index = _GROUP_TYPE.get(group_type.lower())
+        if type_index is not None:
+            set_parm_if_exists(group_node, "grouptype", type_index)
+        if pattern:
+            # Enable base-group pattern selection when supported.
+            set_parm_if_exists(group_node, "groupbase", 1)
+            set_parm_if_exists(group_node, "basegroup", pattern)
+        return skill_success(
+            "Created group SOP",
+            input_path=source.path(),
+            node=node_summary(group_node),
+            group_name=group_name,
+            group_type=group_type.lower(),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create group SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return group_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/merge_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/merge_geometry.py
@@ -1,0 +1,61 @@
+"""Append a Merge SOP joining multiple input SOP streams."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, node_summary  # noqa: E402
+
+
+def merge_geometry(input_paths: List[str], node_name: Optional[str] = None) -> dict:
+    """Create a Merge SOP in the first input's parent, wiring all inputs."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if not input_paths:
+        return skill_error("No inputs", "Provide at least one input node path")
+
+    try:
+        sources = [get_node(hou, p) for p in input_paths]
+        parent = sources[0].parent()
+        if parent is None:
+            return skill_error("No parent network", "First input has no parent network")
+        merge = parent.createNode("merge", node_name=node_name)
+        for index, source in enumerate(sources):
+            merge.setInput(index, source)
+        if hasattr(merge, "moveToGoodPosition"):
+            try:
+                merge.moveToGoodPosition()
+            except Exception:  # noqa: BLE001
+                pass
+        if hasattr(merge, "setDisplayFlag"):
+            merge.setDisplayFlag(True)
+        return skill_success(
+            "Created merge SOP",
+            input_paths=[s.path() for s in sources],
+            node=node_summary(merge),
+            input_count=len(sources),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create merge SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return merge_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/transform_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/transform_geometry.py
@@ -1,0 +1,59 @@
+"""Append a Transform (xform) SOP to translate/rotate/scale geometry."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
+
+
+def transform_geometry(
+    input_path: str,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    scale: Optional[List[float]] = None,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Create a Transform SOP downstream of *input_path* and set t/r/s."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        source = get_node(hou, input_path)
+        xform = make_downstream_sop(source, "xform", node_name)
+        applied = {}
+        if translate is not None and set_parm_if_exists(xform, "t", translate):
+            applied["t"] = list(translate)
+        if rotate is not None and set_parm_if_exists(xform, "r", rotate):
+            applied["r"] = list(rotate)
+        if scale is not None and set_parm_if_exists(xform, "s", scale):
+            applied["s"] = list(scale)
+        return skill_success(
+            "Created transform SOP",
+            input_path=source.path(),
+            node=node_summary(xform),
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create transform SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return transform_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/triangulate_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/triangulate_geometry.py
@@ -1,0 +1,48 @@
+"""Append a Divide SOP configured to triangulate (convex) polygons."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
+
+
+def triangulate_geometry(input_path: str, node_name: Optional[str] = None) -> dict:
+    """Create a Divide SOP downstream of *input_path* set to convex triangles."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        source = get_node(hou, input_path)
+        divide = make_downstream_sop(source, "divide", node_name)
+        # Convex polygons into triangles (max 3 sides).
+        set_parm_if_exists(divide, "convex", 1)
+        set_parm_if_exists(divide, "numsides", 3)
+        return skill_success(
+            "Created triangulate (divide) SOP",
+            input_path=source.path(),
+            node=node_summary(divide),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create triangulate SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return triangulate_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/tools.yaml
@@ -1,0 +1,199 @@
+tools:
+  - name: transform_geometry
+    description: >-
+      Append a Transform (xform) SOP downstream of an input SOP and set
+      translate/rotate/scale.
+    source_file: scripts/transform_geometry.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path]
+      properties:
+        input_path:
+          type: string
+          description: Upstream SOP node path.
+        translate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        rotate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        scale:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        node_name:
+          type: string
+  - name: merge_geometry
+    description: Append a Merge SOP joining several upstream SOP streams.
+    source_file: scripts/merge_geometry.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_paths]
+      properties:
+        input_paths:
+          type: array
+          items: {type: string}
+          minItems: 1
+          description: Upstream SOP node paths to merge in order.
+        node_name:
+          type: string
+  - name: blast_geometry
+    description: >-
+      Append a Blast SOP that deletes a group (or keeps it and deletes the
+      rest when delete_non_selected is true).
+    source_file: scripts/blast_geometry.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: true
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path, group]
+      properties:
+        input_path:
+          type: string
+        group:
+          type: string
+          description: Group name or pattern to blast.
+        group_type:
+          type: string
+          enum: [guess, points, prims, primitives, edges, vertices, breakpoints]
+          default: prims
+        delete_non_selected:
+          type: boolean
+          default: false
+          description: Keep the selection and delete everything else.
+        node_name:
+          type: string
+  - name: group_geometry
+    description: Append a Group Create SOP to define a point/primitive/edge group.
+    source_file: scripts/group_geometry.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path, group_name]
+      properties:
+        input_path:
+          type: string
+        group_name:
+          type: string
+        group_type:
+          type: string
+          enum: [points, prims, primitives, edges, vertices]
+          default: prims
+        pattern:
+          type: string
+          description: Optional base-group selection pattern.
+        node_name:
+          type: string
+  - name: add_normals
+    description: Append a Normal SOP to compute point/vertex/primitive normals.
+    source_file: scripts/add_normals.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path]
+      properties:
+        input_path:
+          type: string
+        attribute_class:
+          type: string
+          enum: [point, vertex, primitive, detail]
+          default: point
+        node_name:
+          type: string
+  - name: triangulate_geometry
+    description: Append a Divide SOP configured to convex-triangulate polygons.
+    source_file: scripts/triangulate_geometry.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path]
+      properties:
+        input_path:
+          type: string
+        node_name:
+          type: string
+  - name: convert_geometry
+    description: Append a Convert SOP to change the primitive type (poly/mesh/nurbs/...).
+    source_file: scripts/convert_geometry.py
+    execution: sync
+    affinity: main
+    group: mesh-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path]
+      properties:
+        input_path:
+          type: string
+        to_type:
+          type: string
+          enum: [polygons, poly, mesh, nurbs, bezier, subdivision, subdiv]
+          default: polygons
+        node_name:
+          type: string

--- a/tests/test_geometry_mesh_skills.py
+++ b/tests/test_geometry_mesh_skills.py
@@ -218,9 +218,7 @@ class TestMeshOpsSkills:
         }.get(name)
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
-            result = mod.blast_geometry(
-                "/obj/geo1/box1", group="0-5", group_type="prims", delete_non_selected=True
-            )
+            result = mod.blast_geometry("/obj/geo1/box1", group="0-5", group_type="prims", delete_non_selected=True)
 
         assert result["success"] is True
         group_parm.set.assert_called_once_with("0-5")

--- a/tests/test_geometry_mesh_skills.py
+++ b/tests/test_geometry_mesh_skills.py
@@ -1,0 +1,291 @@
+"""Mock-hou unit tests for houdini-geometry and houdini-mesh-ops skills."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(skill_name: str, script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / skill_name / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"skill_{skill_name}_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = type_name
+    return node
+
+
+class TestGeometrySkills:
+    def test_create_primitive_creates_box(self) -> None:
+        mod = _load_script("houdini-geometry", "create_primitive.py")
+        new = _node("/obj/geo1/box1", "box1", "box")
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_primitive("/obj/geo1", "box")
+
+        assert result["success"] is True
+        parent.createNode.assert_called_once_with("box", node_name=None)
+        new.setDisplayFlag.assert_called_once_with(True)
+        assert result["context"]["node_path"] == "/obj/geo1/box1"
+
+    def test_create_primitive_rejects_unknown(self) -> None:
+        mod = _load_script("houdini-geometry", "create_primitive.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.create_primitive("/obj/geo1", "torus")
+        assert result["success"] is False
+
+    def test_get_geometry_info_counts_and_bounds(self) -> None:
+        mod = _load_script("houdini-geometry", "get_geometry_info.py")
+        bbox = MagicMock()
+        bbox.minvec.return_value = (0.0, 0.0, 0.0)
+        bbox.maxvec.return_value = (1.0, 2.0, 3.0)
+        bbox.sizevec.return_value = (1.0, 2.0, 3.0)
+        geo = MagicMock()
+        geo.points.return_value = [1, 2, 3, 4]
+        geo.prims.return_value = [1, 2]
+        geo.iterVertices.return_value = iter([1, 2, 3, 4, 5, 6, 7, 8])
+        geo.boundingBox.return_value = bbox
+        node = _node("/obj/geo1/box1", "box1", "box")
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_geometry_info("/obj/geo1/box1")
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert ctx["point_count"] == 4
+        assert ctx["primitive_count"] == 2
+        assert ctx["vertex_count"] == 8
+        assert ctx["bounds_max"] == [1.0, 2.0, 3.0]
+
+    def test_list_attributes_groups_by_class(self) -> None:
+        mod = _load_script("houdini-geometry", "list_attributes.py")
+        attrib = MagicMock()
+        attrib.name.return_value = "P"
+        attrib.dataType.return_value = "Float"
+        attrib.size.return_value = 3
+        geo = MagicMock()
+        geo.pointAttribs.return_value = [attrib]
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        node = _node("/obj/geo1/box1", "box1")
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_attributes("/obj/geo1/box1")
+
+        assert result["success"] is True
+        point_attrs = result["context"]["attributes"]["point"]
+        assert point_attrs[0]["name"] == "P"
+        assert point_attrs[0]["size"] == 3
+
+    def test_list_groups_reports_counts(self) -> None:
+        mod = _load_script("houdini-geometry", "list_groups.py")
+        group = MagicMock()
+        group.name.return_value = "myGroup"
+        group.prims.return_value = [1, 2, 3]
+        geo = MagicMock()
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = [group]
+        geo.edgeGroups.return_value = []
+        node = _node("/obj/geo1/box1", "box1")
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_groups("/obj/geo1/box1")
+
+        assert result["success"] is True
+        prim_groups = result["context"]["groups"]["primitive"]
+        assert prim_groups[0]["name"] == "myGroup"
+        assert prim_groups[0]["count"] == 3
+
+    def test_get_cook_status_reports_warnings(self) -> None:
+        mod = _load_script("houdini-geometry", "get_cook_status.py")
+        node = _node("/obj/geo1/box1", "box1")
+        node.errors.return_value = []
+        node.warnings.return_value = ["heads up"]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_cook_status("/obj/geo1/box1")
+
+        assert result["success"] is True
+        assert result["context"]["cooked"] is True
+        assert result["context"]["warnings"] == ["heads up"]
+        node.cook.assert_called_once_with(force=False)
+
+    def test_get_cook_status_surfaces_cook_error(self) -> None:
+        mod = _load_script("houdini-geometry", "get_cook_status.py")
+        node = _node("/obj/geo1/box1", "box1")
+        node.cook.side_effect = RuntimeError("cook failed")
+        node.errors.return_value = ["cook failed"]
+        node.warnings.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_cook_status("/obj/geo1/box1")
+
+        assert result["success"] is True
+        assert result["context"]["cooked"] is False
+        assert result["context"]["cook_error"] == "cook failed"
+
+
+class TestMeshOpsSkills:
+    def _wire_downstream(self, optype: str = "xform"):
+        new = _node(f"/obj/geo1/{optype}1", f"{optype}1", optype)
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        source = _node("/obj/geo1/box1", "box1", "box")
+        source.parent.return_value = parent
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = source
+        return mock_hou, source, parent, new
+
+    def test_transform_geometry_sets_trs(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "transform_geometry.py")
+        mock_hou, source, parent, new = self._wire_downstream("xform")
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.transform_geometry("/obj/geo1/box1", translate=[1, 0, 0], scale=[2, 2, 2])
+
+        assert result["success"] is True
+        parent.createNode.assert_called_once_with("xform", node_name=None)
+        new.setInput.assert_called_once_with(0, source)
+        assert result["context"]["applied"]["t"] == [1, 0, 0]
+        assert result["context"]["applied"]["s"] == [2, 2, 2]
+
+    def test_merge_geometry_wires_all_inputs(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "merge_geometry.py")
+        merge = _node("/obj/geo1/merge1", "merge1", "merge")
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = merge
+        a = _node("/obj/geo1/box1", "box1", "box")
+        b = _node("/obj/geo1/sphere1", "sphere1", "sphere")
+        a.parent.return_value = parent
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {"/obj/geo1/box1": a, "/obj/geo1/sphere1": b}[p]
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.merge_geometry(["/obj/geo1/box1", "/obj/geo1/sphere1"])
+
+        assert result["success"] is True
+        assert result["context"]["input_count"] == 2
+        assert merge.setInput.call_count == 2
+
+    def test_merge_geometry_requires_inputs(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "merge_geometry.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.merge_geometry([])
+        assert result["success"] is False
+
+    def test_blast_geometry_sets_group_and_negate(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "blast_geometry.py")
+        mock_hou, source, parent, new = self._wire_downstream("blast")
+        group_parm = MagicMock()
+        type_parm = MagicMock()
+        negate_parm = MagicMock()
+        new.parmTuple.return_value = None
+        new.parm.side_effect = lambda name: {
+            "group": group_parm,
+            "grouptype": type_parm,
+            "negate": negate_parm,
+        }.get(name)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.blast_geometry(
+                "/obj/geo1/box1", group="0-5", group_type="prims", delete_non_selected=True
+            )
+
+        assert result["success"] is True
+        group_parm.set.assert_called_once_with("0-5")
+        type_parm.set.assert_called_once_with(4)
+        negate_parm.set.assert_called_once_with(1)
+
+    def test_group_geometry_sets_name_and_type(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "group_geometry.py")
+        mock_hou, source, parent, new = self._wire_downstream("groupcreate")
+        name_parm = MagicMock()
+        type_parm = MagicMock()
+        new.parmTuple.return_value = None
+        new.parm.side_effect = lambda n: {"groupname": name_parm, "grouptype": type_parm}.get(n)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.group_geometry("/obj/geo1/box1", group_name="top", group_type="points")
+
+        assert result["success"] is True
+        name_parm.set.assert_called_once_with("top")
+        type_parm.set.assert_called_once_with(0)
+
+    def test_add_normals_sets_class(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "add_normals.py")
+        mock_hou, source, parent, new = self._wire_downstream("normal")
+        type_parm = MagicMock()
+        new.parmTuple.return_value = None
+        new.parm.side_effect = lambda n: type_parm if n == "type" else None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.add_normals("/obj/geo1/box1", attribute_class="vertex")
+
+        assert result["success"] is True
+        type_parm.set.assert_called_once_with(1)
+
+    def test_triangulate_sets_convex(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "triangulate_geometry.py")
+        mock_hou, source, parent, new = self._wire_downstream("divide")
+        convex_parm = MagicMock()
+        sides_parm = MagicMock()
+        new.parmTuple.return_value = None
+        new.parm.side_effect = lambda n: {"convex": convex_parm, "numsides": sides_parm}.get(n)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.triangulate_geometry("/obj/geo1/box1")
+
+        assert result["success"] is True
+        convex_parm.set.assert_called_once_with(1)
+        sides_parm.set.assert_called_once_with(3)
+
+    def test_convert_geometry_maps_token(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "convert_geometry.py")
+        mock_hou, source, parent, new = self._wire_downstream("convert")
+        totype_parm = MagicMock()
+        new.parmTuple.return_value = None
+        new.parm.side_effect = lambda n: totype_parm if n == "totype" else None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.convert_geometry("/obj/geo1/box1", to_type="polygons")
+
+        assert result["success"] is True
+        totype_parm.set.assert_called_once_with("poly")
+        assert result["context"]["to_type"] == "poly"
+
+    def test_convert_geometry_rejects_unknown(self) -> None:
+        mod = _load_script("houdini-mesh-ops", "convert_geometry.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.convert_geometry("/obj/geo1/box1", to_type="voxels")
+        assert result["success"] is False


### PR DESCRIPTION
## Summary

Closes #13. Adds two authoring-stage skill packages for SOP geometry inspection and lightweight mesh operations, so agents can query and build procedural geometry through typed contracts before falling back to `execute_python`.

### `houdini-geometry` (create + inspect)
- `create_primitive` — box / sphere / grid / tube / curve / null / output under an explicit SOP network path.
- `get_geometry_info` — cook + point/primitive/vertex counts and bounding box (read-only).
- `list_attributes` — point/primitive/vertex/detail attributes (name, data type, size).
- `list_groups` — point/primitive/edge group names + member counts.
- `get_cook_status` — `async` cook with `timeout_hint_secs` and an explicit cook-error / warnings surface.

### `houdini-mesh-ops` (procedural edits)
Each tool appends a standard SOP downstream of `input_path`, wires input 0, sets the display flag, and returns the new node path for chaining:
- `transform_geometry`, `merge_geometry`, `blast_geometry` (destructive), `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry`.

### Wiring & docs
- Registered both skills in the `authoring` stage (`_skill_loader.STAGE_SKILLS`).
- Documented create/inspect and procedural-edit chains in `skills/SKILLS_INDEX.md`.
- All tools are `affinity: main`; parameter writes are defensive (set only when the parm exists), so they degrade cleanly across Houdini versions.

## Test plan
- [x] `pytest tests/test_geometry_mesh_skills.py` — 16 new mock-hou tests (happy paths + validation errors).
- [x] `pytest tests/test_skills.py` — auto `validate_skill` + `tools.yaml` contract checks pass for both new packages.
- [x] Full suite: `155 passed, 1 skipped, 1 deselected`.
- [ ] Live Houdini smoke (create box → transform → merge → cook) — pending a licensed session.

> Note: branched off `main`; expect a trivial `_skill_loader.py` / `SKILLS_INDEX.md` rebase against #24 / #25 once those land.
