### PR TITLE
feat: Houdini interchange skill (USD/Alembic/FBX/OBJ/native caches) (#14)

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -23,7 +23,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "bootstrap": ("houdini-scripting",),
     "scene": ("houdini-scene",),
     "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
-    "interchange": (),
+    "interchange": ("houdini-interchange",),
     "pipeline": ("houdini-automation",),
 }
 

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -7,7 +7,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene` | yes |
 | `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
-| `interchange` | _(planned: USD, FBX, Alembic)_ | no |
+| `interchange` | `houdini-interchange` | no |
 | `pipeline` | `houdini-automation` | no |
 
 ## Common chains
@@ -19,5 +19,6 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
+| Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: houdini-interchange
+description: >-
+  Interchange skill — load-on-demand import/export of Houdini geometry and
+  scenes through production formats (native bgeo/geo, OBJ, Alembic, FBX, USD)
+  plus filesystem probing. Use these typed tools instead of hand-building
+  ROP/LOP/SOP networks with raw scripts.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [houdini, interchange, import, export, usd, alembic, fbx, obj, bgeo, cache]
+    search-hint: "import export usd alembic abc fbx obj bgeo cache save geometry interchange"
+    tools: tools.yaml
+---
+
+# houdini-interchange
+
+Typed import/export tools for moving geometry and scenes across DCCs. Exports
+return structured `written_files`, `skipped`, and `warnings` fields so an agent
+can tell what actually landed on disk versus what the installed runtime could
+not produce.
+
+## Tool groups
+
+- **`interchange-probe`:** `probe_file` (`affinity: any`, pure filesystem).
+- **`interchange-import`:** `import_geometry` (File SOP into a SOP network).
+- **`interchange-export`:** `export_geometry` (native/OBJ via `saveToFile`),
+  `export_alembic`, `export_fbx`, `export_usd`.
+
+## Format selection guidance
+
+| Goal | Tool | Notes |
+|------|------|-------|
+| Round-trip Houdini geometry | `export_geometry` → `.bgeo`/`.geo` | Fastest, lossless, native. |
+| Hand geometry to another DCC | `export_geometry` → `.obj`, or `export_alembic` | OBJ for static meshes; Alembic for animated/large caches. |
+| Animated caches | `export_alembic` with `frame_range` | `render: true` to actually write frames. |
+| Rigged/scene to game engine | `export_fbx` | `root_node` selects the `/obj` subtree. |
+| USD/Solaris pipelines | `export_usd` | Exports a LOP node's composed `stage()`; reports `root_layer`. |
+
+## Tracer-bullet flow (local, no render farm)
+
+1. `houdini_geometry__create_primitive(parent_path="/obj/geo1", primitive="box")`
+2. `export_geometry(node_path="/obj/geo1/box1", output_path="/tmp/box.bgeo")`
+3. `probe_file(file_path="/tmp/box.bgeo")` → `exists: true`, `format: geometry`
+4. `import_geometry(parent_path="/obj/geo2", file_path="/tmp/box.bgeo")` → round-trip
+
+Export tools that drive a ROP are `async` with generous `timeout_hint_secs`
+because caches and FBX writes can be long-running.

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/_io_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/_io_common.py
@@ -1,0 +1,114 @@
+"""Shared helpers for Houdini interchange (import/export) skills."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, Sequence
+
+# Suffix -> coarse format category.
+_FORMAT_BY_SUFFIX = {
+    ".bgeo": "geometry",
+    ".geo": "geometry",
+    ".bgeo.sc": "geometry",
+    ".ply": "geometry",
+    ".obj": "obj",
+    ".fbx": "fbx",
+    ".abc": "alembic",
+    ".usd": "usd",
+    ".usda": "usd",
+    ".usdc": "usd",
+    ".usdz": "usd",
+}
+
+# Formats a Houdini `file` SOP can read directly.
+_IMPORTABLE = {"geometry", "obj", "fbx", "alembic", "usd"}
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def detect_format(file_path: str) -> str:
+    """Return a coarse format category for *file_path* based on its suffix."""
+    lowered = file_path.lower()
+    for suffix, category in sorted(_FORMAT_BY_SUFFIX.items(), key=lambda kv: -len(kv[0])):
+        if lowered.endswith(suffix):
+            return category
+    return "unknown"
+
+
+def probe(file_path: str) -> dict:
+    """Return a structured probe of a file path (no Houdini required)."""
+    fmt = detect_format(file_path)
+    exists = os.path.isfile(file_path)
+    info = {
+        "file_path": file_path,
+        "exists": exists,
+        "format": fmt,
+        "is_supported_import": fmt in _IMPORTABLE,
+    }
+    if exists:
+        try:
+            info["size_bytes"] = os.path.getsize(file_path)
+        except OSError:
+            info["size_bytes"] = None
+    return info
+
+
+def ensure_parent_dir(file_path: str) -> None:
+    """Create the parent directory of *file_path* when missing."""
+    parent = os.path.dirname(os.path.abspath(file_path))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent, exist_ok=True)
+
+
+def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
+    """Set a scalar/tuple parm only when it exists. Return whether it was set."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            return False
+        parm_tuple.set(tuple(value))
+        return True
+    parm = node.parm(name)
+    if parm is None:
+        return False
+    parm.set(value)
+    return True
+
+
+def set_first_parm(node: Any, names: Sequence[str], value: Any) -> Optional[str]:
+    """Set the first existing parm in *names*; return the name used or None."""
+    for name in names:
+        if set_parm_if_exists(node, name, value):
+            return name
+    return None
+
+
+def apply_frame_range(node: Any, frame_range: Optional[Sequence[float]]) -> Optional[list]:
+    """Set ROP frame-range parms defensively. Return the applied [start, end]."""
+    if not frame_range:
+        return None
+    start, end = float(frame_range[0]), float(frame_range[1])
+    step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+    # trange=1 -> "Render Frame Range".
+    set_parm_if_exists(node, "trange", 1)
+    if not set_parm_if_exists(node, "f", [start, end, step]):
+        set_parm_if_exists(node, "f1", start)
+        set_parm_if_exists(node, "f2", end)
+        set_parm_if_exists(node, "f3", step)
+    return [start, end]
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_alembic.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_alembic.py
@@ -1,0 +1,81 @@
+"""Export a SOP stream to Alembic via a ROP Alembic Output SOP."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _io_common import (  # noqa: E402
+    apply_frame_range,
+    ensure_parent_dir,
+    get_node,
+    node_summary,
+    set_first_parm,
+)
+
+
+def export_alembic(
+    node_path: str,
+    output_path: str,
+    frame_range: Optional[List[float]] = None,
+    render: bool = True,
+    create_dirs: bool = True,
+) -> dict:
+    """Append a ROP Alembic Output SOP to *node_path* and (optionally) render."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        source = get_node(hou, node_path)
+        parent = source.parent()
+        if parent is None:
+            return skill_error("No parent network", "Input has no parent network")
+        rop = parent.createNode("rop_alembic", node_name="abc_export")
+        rop.setInput(0, source)
+        used = set_first_parm(rop, ("filename", "abcoutput", "sopoutput"), output_path)
+        applied_range = apply_frame_range(rop, frame_range)
+        if create_dirs:
+            ensure_parent_dir(output_path)
+        warnings: List[str] = []
+        if used is None:
+            warnings.append("Could not find an output-path parameter on rop_alembic")
+        if render and used is not None:
+            try:
+                rop.render()
+            except Exception as render_exc:  # noqa: BLE001
+                warnings.append("Render failed: {}".format(render_exc))
+        written = [output_path] if os.path.isfile(output_path) else []
+        skipped = [] if written else [output_path]
+        return skill_success(
+            "Exported Alembic",
+            node_path=source.path(),
+            rop=node_summary(rop),
+            output_path=output_path,
+            frame_range=applied_range,
+            written_files=written,
+            skipped=skipped,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export Alembic")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_alembic(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_fbx.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_fbx.py
@@ -1,0 +1,83 @@
+"""Export OBJ-level content to FBX via a /out Filmbox FBX ROP."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _io_common import (  # noqa: E402
+    apply_frame_range,
+    ensure_parent_dir,
+    get_node,
+    node_summary,
+    set_first_parm,
+)
+
+
+def export_fbx(
+    output_path: str,
+    root_node: str = "/obj",
+    frame_range: Optional[List[float]] = None,
+    render: bool = True,
+    create_dirs: bool = True,
+) -> dict:
+    """Create a Filmbox FBX ROP under /out and (optionally) render *root_node*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        # Validate the export root exists before building the ROP.
+        get_node(hou, root_node)
+        out = hou.node("/out")
+        if out is None:
+            out = hou.node("/").createNode("ropnet", node_name="out")
+        rop = out.createNode("filmboxfbx", node_name="fbx_export")
+        used = set_first_parm(rop, ("sopoutput", "filename", "outfile", "output"), output_path)
+        # FBX ROP exports the subtree rooted at this node.
+        set_first_parm(rop, ("startnode",), root_node)
+        applied_range = apply_frame_range(rop, frame_range)
+        if create_dirs:
+            ensure_parent_dir(output_path)
+        warnings: List[str] = []
+        if used is None:
+            warnings.append("Could not find an output-path parameter on filmboxfbx")
+        if render and used is not None:
+            try:
+                rop.render()
+            except Exception as render_exc:  # noqa: BLE001
+                warnings.append("Render failed: {}".format(render_exc))
+        written = [output_path] if os.path.isfile(output_path) else []
+        skipped = [] if written else [output_path]
+        return skill_success(
+            "Exported FBX",
+            root_node=root_node,
+            rop=node_summary(rop),
+            output_path=output_path,
+            frame_range=applied_range,
+            written_files=written,
+            skipped=skipped,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export FBX")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_fbx(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_geometry.py
@@ -1,0 +1,69 @@
+"""Export a SOP node's geometry to a native/interchange file via saveToFile."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _io_common import detect_format, ensure_parent_dir, get_node  # noqa: E402
+
+
+def export_geometry(
+    node_path: str,
+    output_path: str,
+    create_dirs: bool = True,
+) -> dict:
+    """Write the cooked geometry of *node_path* to *output_path*.
+
+    Uses ``hou.Geometry.saveToFile`` which supports native (.bgeo/.geo),
+    .obj, .ply, and other formats recognised by the installed runtime.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        geo = node.geometry() if hasattr(node, "geometry") else None
+        if geo is None:
+            return skill_error(
+                "No SOP geometry",
+                "Node has no geometry to export",
+                node_path=node.path(),
+            )
+        if create_dirs:
+            ensure_parent_dir(output_path)
+        geo.saveToFile(output_path)
+        written = [output_path] if os.path.isfile(output_path) else []
+        skipped = [] if written else [output_path]
+        return skill_success(
+            "Exported geometry",
+            node_path=node.path(),
+            output_path=output_path,
+            format=detect_format(output_path),
+            written_files=written,
+            skipped=skipped,
+            warnings=[],
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export geometry")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_geometry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_usd.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_usd.py
@@ -1,0 +1,91 @@
+"""Export a LOP node's USD stage to disk and report the root layer."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _io_common import ensure_parent_dir, get_node  # noqa: E402
+
+
+def _root_layer_identifier(stage) -> Optional[str]:
+    try:
+        layer = stage.GetRootLayer()
+    except Exception:  # noqa: BLE001
+        return None
+    for attr in ("identifier", "realPath"):
+        value = getattr(layer, attr, None)
+        if value:
+            return value
+    return None
+
+
+def export_usd(
+    lop_node_path: str,
+    output_path: str,
+    frame_range: Optional[List[float]] = None,
+    create_dirs: bool = True,
+) -> dict:
+    """Export the composed stage of a LOP node (``node.stage()``) to USD."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, lop_node_path)
+        stage_fn = getattr(node, "stage", None)
+        if not callable(stage_fn):
+            return skill_error(
+                "Not a LOP node",
+                "Node has no stage(); USD export requires a LOP/Solaris node",
+                node_path=node.path(),
+            )
+        stage = stage_fn()
+        if stage is None:
+            return skill_error(
+                "No USD stage",
+                "LOP node produced no stage to export",
+                node_path=node.path(),
+            )
+        root_layer = _root_layer_identifier(stage)
+        if create_dirs:
+            ensure_parent_dir(output_path)
+        warnings: List[str] = []
+        try:
+            stage.Export(output_path)
+        except Exception as export_exc:  # noqa: BLE001
+            warnings.append("Stage export failed: {}".format(export_exc))
+        written = [output_path] if os.path.isfile(output_path) else []
+        skipped = [] if written else [output_path]
+        return skill_success(
+            "Exported USD stage",
+            node_path=node.path(),
+            output_path=output_path,
+            root_layer=root_layer,
+            frame_range=list(frame_range) if frame_range else None,
+            written_files=written,
+            skipped=skipped,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export USD stage")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_usd(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/import_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/import_geometry.py
@@ -1,0 +1,89 @@
+"""Import a geometry/scene file into a SOP network via a File SOP."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _io_common import (  # noqa: E402
+    detect_format,
+    get_node,
+    node_summary,
+    probe,
+    set_first_parm,
+)
+
+
+def import_geometry(
+    parent_path: str,
+    file_path: str,
+    node_name: Optional[str] = None,
+    cook: bool = True,
+) -> dict:
+    """Create a File SOP under *parent_path* reading *file_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    info = probe(file_path)
+    if not info["exists"]:
+        return skill_error(
+            "File not found",
+            "No file at the given path",
+            file_path=file_path,
+        )
+    if not info["is_supported_import"]:
+        return skill_error(
+            "Unsupported import format",
+            "Detected format {!r} is not a supported File SOP import".format(info["format"]),
+            file_path=file_path,
+            format=info["format"],
+        )
+    try:
+        parent = get_node(hou, parent_path)
+        node = parent.createNode("file", node_name=node_name)
+        used = set_first_parm(node, ("file", "filename"), file_path)
+        if used is None:
+            return skill_error(
+                "Could not set file parameter",
+                "File SOP has no recognised file parm",
+                node_path=node.path(),
+            )
+        context = {
+            "parent_path": parent.path(),
+            "node": node_summary(node),
+            "file_path": file_path,
+            "format": detect_format(file_path),
+        }
+        if cook:
+            try:
+                node.cook(force=True)
+                geo = node.geometry() if hasattr(node, "geometry") else None
+                if geo is not None:
+                    context["point_count"] = len(geo.points()) if hasattr(geo, "points") else None
+                    context["primitive_count"] = len(geo.prims()) if hasattr(geo, "prims") else None
+                context["warnings"] = list(node.warnings()) if hasattr(node, "warnings") else []
+            except Exception as cook_exc:  # noqa: BLE001
+                context["cook_error"] = str(cook_exc)
+        return skill_success("Imported geometry", **context)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to import geometry")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return import_geometry(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/probe_file.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/probe_file.py
@@ -1,0 +1,34 @@
+"""Probe a file path for interchange (no Houdini required)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _io_common import probe  # noqa: E402
+
+
+def probe_file(file_path: str) -> dict:
+    """Report existence, size, format category, and import support for a path."""
+    try:
+        info = probe(file_path)
+        return skill_success("Probed file", **info)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to probe file")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return probe_file(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/tools.yaml
@@ -1,0 +1,188 @@
+tools:
+  - name: probe_file
+    description: >-
+      Probe a file path: existence, size, detected format category, and whether
+      it is a supported import. Pure filesystem — no Houdini required.
+    source_file: scripts/probe_file.py
+    execution: sync
+    affinity: any
+    group: interchange-probe
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [file_path]
+      properties:
+        file_path:
+          type: string
+          description: Absolute or hip-relative path to probe.
+  - name: import_geometry
+    description: >-
+      Import a geometry/scene file (bgeo/obj/fbx/abc/usd) into a SOP network via
+      a File SOP, with explicit parent path and optional cook.
+    source_file: scripts/import_geometry.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 180
+    group: interchange-import
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [parent_path, file_path]
+      properties:
+        parent_path:
+          type: string
+          description: SOP network to import into (e.g. /obj/geo1).
+        file_path:
+          type: string
+        node_name:
+          type: string
+        cook:
+          type: boolean
+          default: true
+    next-tools:
+      on-success:
+        - houdini_geometry__get_geometry_info
+  - name: export_geometry
+    description: >-
+      Export a SOP node's cooked geometry to a native/interchange file
+      (.bgeo/.geo/.obj/.ply) via Geometry.saveToFile.
+    source_file: scripts/export_geometry.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 300
+    group: interchange-export
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, output_path]
+      properties:
+        node_path:
+          type: string
+        output_path:
+          type: string
+        create_dirs:
+          type: boolean
+          default: true
+  - name: export_alembic
+    description: >-
+      Export a SOP stream to Alembic (.abc) via a ROP Alembic Output SOP, with
+      optional frame range and render.
+    source_file: scripts/export_alembic.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: interchange-export
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, output_path]
+      properties:
+        node_path:
+          type: string
+        output_path:
+          type: string
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3
+          description: "[start, end] or [start, end, step]."
+        render:
+          type: boolean
+          default: true
+        create_dirs:
+          type: boolean
+          default: true
+  - name: export_fbx
+    description: >-
+      Export an /obj subtree to FBX via a Filmbox FBX ROP, with optional frame
+      range and render. Reports skipped outputs and runtime limitations.
+    source_file: scripts/export_fbx.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: interchange-export
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [output_path]
+      properties:
+        output_path:
+          type: string
+        root_node:
+          type: string
+          default: /obj
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3
+        render:
+          type: boolean
+          default: true
+        create_dirs:
+          type: boolean
+          default: true
+  - name: export_usd
+    description: >-
+      Export the composed USD stage of a LOP/Solaris node to disk and report the
+      root layer, output path, frame range, and warnings.
+    source_file: scripts/export_usd.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: interchange-export
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [lop_node_path, output_path]
+      properties:
+        lop_node_path:
+          type: string
+          description: LOP node whose composed stage will be exported.
+        output_path:
+          type: string
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3
+        create_dirs:
+          type: boolean
+          default: true

--- a/tests/test_interchange_skills.py
+++ b/tests/test_interchange_skills.py
@@ -1,0 +1,214 @@
+"""Mock-hou unit tests for the houdini-interchange skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-interchange" / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"interchange_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = type_name
+    return node
+
+
+class TestProbeFile:
+    def test_existing_geometry_file(self, tmp_path: Path) -> None:
+        mod = _load_script("probe_file.py")
+        f = tmp_path / "cache.bgeo"
+        f.write_bytes(b"data")
+        result = mod.probe_file(str(f))
+        assert result["success"] is True
+        assert result["context"]["exists"] is True
+        assert result["context"]["format"] == "geometry"
+        assert result["context"]["is_supported_import"] is True
+        assert result["context"]["size_bytes"] == 4
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        mod = _load_script("probe_file.py")
+        result = mod.probe_file(str(tmp_path / "nope.usd"))
+        assert result["success"] is True
+        assert result["context"]["exists"] is False
+        assert result["context"]["format"] == "usd"
+
+
+class TestImportGeometry:
+    def test_import_sets_file_parm(self, tmp_path: Path) -> None:
+        mod = _load_script("import_geometry.py")
+        src = tmp_path / "asset.obj"
+        src.write_text("o", encoding="utf-8")
+        file_parm = MagicMock()
+        node = _node("/obj/geo1/file1", "file1", "file")
+        node.parmTuple.return_value = None
+        node.parm.side_effect = lambda n: file_parm if n == "file" else None
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = node
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.import_geometry("/obj/geo1", str(src), cook=False)
+
+        assert result["success"] is True
+        file_parm.set.assert_called_once_with(str(src))
+        assert result["context"]["format"] == "obj"
+
+    def test_missing_file_errors(self, tmp_path: Path) -> None:
+        mod = _load_script("import_geometry.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.import_geometry("/obj/geo1", str(tmp_path / "absent.abc"))
+        assert result["success"] is False
+
+    def test_unsupported_format_errors(self, tmp_path: Path) -> None:
+        mod = _load_script("import_geometry.py")
+        src = tmp_path / "notes.txt"
+        src.write_text("x", encoding="utf-8")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.import_geometry("/obj/geo1", str(src))
+        assert result["success"] is False
+
+
+class TestExportGeometry:
+    def test_export_writes_file(self, tmp_path: Path) -> None:
+        mod = _load_script("export_geometry.py")
+        out = tmp_path / "out" / "box.bgeo"
+        geo = MagicMock()
+        geo.saveToFile.side_effect = lambda p: Path(p).write_bytes(b"geo")
+        node = _node("/obj/geo1/box1", "box1", "box")
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_geometry("/obj/geo1/box1", str(out))
+
+        assert result["success"] is True
+        geo.saveToFile.assert_called_once_with(str(out))
+        assert result["context"]["written_files"] == [str(out)]
+        assert result["context"]["skipped"] == []
+        assert result["context"]["format"] == "geometry"
+
+
+class TestExportAlembic:
+    def test_export_configures_rop_without_render(self, tmp_path: Path) -> None:
+        mod = _load_script("export_alembic.py")
+        out = tmp_path / "cache.abc"
+        filename_parm = MagicMock()
+        rop = _node("/obj/geo1/abc_export", "abc_export", "rop_alembic")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: filename_parm if n == "filename" else None
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = rop
+        source = _node("/obj/geo1/box1", "box1", "box")
+        source.parent.return_value = parent
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = source
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_alembic("/obj/geo1/box1", str(out), render=False)
+
+        assert result["success"] is True
+        filename_parm.set.assert_called_once_with(str(out))
+        rop.setInput.assert_called_once_with(0, source)
+        assert result["context"]["written_files"] == []
+        assert result["context"]["skipped"] == [str(out)]
+
+    def test_export_renders_and_reports_written(self, tmp_path: Path) -> None:
+        mod = _load_script("export_alembic.py")
+        out = tmp_path / "cache.abc"
+        filename_parm = MagicMock()
+        rop = _node("/obj/geo1/abc_export", "abc_export", "rop_alembic")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: filename_parm if n == "filename" else None
+        rop.render.side_effect = lambda: out.write_bytes(b"abc")
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = rop
+        source = _node("/obj/geo1/box1", "box1", "box")
+        source.parent.return_value = parent
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = source
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_alembic("/obj/geo1/box1", str(out), frame_range=[1, 10], render=True)
+
+        assert result["success"] is True
+        rop.render.assert_called_once()
+        assert result["context"]["written_files"] == [str(out)]
+        assert result["context"]["frame_range"] == [1.0, 10.0]
+
+
+class TestExportFbx:
+    def test_export_configures_fbx_rop(self, tmp_path: Path) -> None:
+        mod = _load_script("export_fbx.py")
+        out = tmp_path / "scene.fbx"
+        sopoutput = MagicMock()
+        startnode = MagicMock()
+        rop = _node("/out/fbx_export", "fbx_export", "filmboxfbx")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: {"sopoutput": sopoutput, "startnode": startnode}.get(n)
+        out_net = _node("/out", "out", "ropnet")
+        out_net.createNode.return_value = rop
+        obj = _node("/obj", "obj")
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {"/out": out_net, "/obj": obj}.get(p)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_fbx(str(out), root_node="/obj", render=False)
+
+        assert result["success"] is True
+        sopoutput.set.assert_called_once_with(str(out))
+        startnode.set.assert_called_once_with("/obj")
+        assert result["context"]["skipped"] == [str(out)]
+
+
+class TestExportUsd:
+    def test_export_reports_root_layer_and_written(self, tmp_path: Path) -> None:
+        mod = _load_script("export_usd.py")
+        out = tmp_path / "stage.usd"
+        layer = MagicMock()
+        layer.identifier = "stage.usd"
+        stage = MagicMock()
+        stage.GetRootLayer.return_value = layer
+        stage.Export.side_effect = lambda p: Path(p).write_text("#usda 1.0", encoding="utf-8")
+        node = _node("/stage/out", "out", "usd_rop")
+        node.stage.return_value = stage
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_usd("/stage/out", str(out))
+
+        assert result["success"] is True
+        stage.Export.assert_called_once_with(str(out))
+        assert result["context"]["root_layer"] == "stage.usd"
+        assert result["context"]["written_files"] == [str(out)]
+
+    def test_non_lop_node_errors(self) -> None:
+        mod = _load_script("export_usd.py")
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        del node.stage  # no stage() method -> not a LOP node
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_usd("/obj/geo1", "/tmp/x.usd")
+
+        assert result["success"] is False


### PR DESCRIPTION
## Summary

Closes #14. Adds the `houdini-interchange` skill (interchange stage) for moving Houdini geometry and scenes through production formats with typed import/export tools instead of hand-built ROP/LOP/SOP networks.

### Tools
- **`probe_file`** (`affinity: any`, pure filesystem): existence, size, detected format category, and import-support flag.
- **`import_geometry`**: File SOP import (bgeo/obj/fbx/abc/usd) into an explicit SOP network, optional cook with post-cook point/prim counts and warnings. Validates the source exists and is a supported format first.
- **`export_geometry`**: native/OBJ export via `Geometry.saveToFile`.
- **`export_alembic`**: ROP Alembic Output SOP with frame range + optional render.
- **`export_fbx`**: `/out` Filmbox FBX ROP for an `/obj` subtree.
- **`export_usd`**: exports a LOP/Solaris node's composed `stage()` and reports the **root layer**, output path, frame range, and warnings.

### Design
- Every export returns structured `written_files` / `skipped` / `warnings`, so an agent can tell what actually landed on disk versus what the installed runtime could not produce.
- Output-path and frame-range parameters are set defensively against candidate names (`filename` / `sopoutput` / `f` / `f1..f3` / `trange`) for cross-version tolerance.
- Registered in the `interchange` stage (`_skill_loader.STAGE_SKILLS`); documented with format-selection guidance and a local round-trip tracer-bullet in `skills/SKILLS_INDEX.md`.

## Test plan
- [x] `pytest tests/test_interchange_skills.py` — 11 mock-hou tests (probe, import happy/missing/unsupported, native export round-trip, Alembic configure + render, FBX ROP config, USD stage export + root layer + non-LOP error).
- [x] `pytest tests/test_skills.py` — auto `validate_skill` + `tools.yaml` contract pass for the new package.
- [x] Full suite: `148 passed, 1 skipped, 1 deselected`.
- [ ] Live Houdini smoke (box → export_geometry .bgeo → probe → import round-trip; Alembic/USD render) — pending a licensed session.

> Note: branched off `main`; expect a trivial `_skill_loader.py` / `SKILLS_INDEX.md` rebase against #24 / #25 / #26 once those land.
