### PR TITLE
feat: Houdini render, camera, light, and viewport capture skills (#15)

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -22,9 +22,14 @@ STAGES: Tuple[str, ...] = (
 STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "bootstrap": ("houdini-scripting",),
     "scene": ("houdini-scene",),
-    "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
+    "authoring": (
+        "houdini-nodes",
+        "houdini-camera-light",
+        "houdini-materials",
+        "houdini-hda",
+    ),
     "interchange": (),
-    "pipeline": ("houdini-automation",),
+    "pipeline": ("houdini-render", "houdini-automation"),
 }
 
 

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,9 +6,9 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene` | yes |
-| `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
+| `authoring` | `houdini-nodes`, `houdini-camera-light`, `houdini-materials`, `houdini-hda` | no |
 | `interchange` | _(planned: USD, FBX, Alembic)_ | no |
-| `pipeline` | `houdini-automation` | no |
+| `pipeline` | `houdini-render`, `houdini-automation` | no |
 
 ## Common chains
 
@@ -17,6 +17,8 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Verify MCP session | `houdini_scripting__get_session_info` |
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
+| Set up cameras & lights | `load_skill("houdini-camera-light")` → `houdini_camera_light__create_camera` → `houdini_camera_light__create_light` → `houdini_camera_light__frame_view` |
+| Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: houdini-camera-light
+description: >-
+  Authoring skill — create and edit cameras and lights, frame the Scene Viewer,
+  and report active camera/view state through typed tools. Pair with
+  houdini-render for viewport capture and ROP render execution.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, camera, light, hlight, viewport, view, lookthrough, authoring]
+    search-hint: "create camera light hlight intensity color exposure focal resolution frame view look through"
+    tools: tools.yaml
+---
+
+# houdini-camera-light
+
+Typed camera and light authoring for agents. All tools are `affinity: main`.
+View tools (`frame_view`, `get_view_state`) are UI-aware: in a headless
+`hython` session they return a structured `warnings` payload with
+`framed: false` / `ui_available: false` instead of failing.
+
+## Tool groups
+
+- **`camera`:** `list_cameras`, `create_camera`, `update_camera`.
+- **`view`:** `frame_view`, `get_view_state`.
+- **`light`:** `create_light`, `update_light`.
+
+## Tracer-bullet flow
+
+1. `create_camera(parent_path="/obj", name="shotcam", focal=50, resolution=[1920,1080])`
+2. `create_light(light_type="distant", intensity=2.0, color=[1,0.95,0.9])`
+3. `frame_view(camera_path="/obj/shotcam", node_path="/obj/geo1")`
+4. `get_view_state()` → confirm `active_camera`
+5. hand off to `houdini-render` (`capture_viewport` / `render`)
+
+Light/camera parameter writes are defensive (set only when the parm exists), so
+they tolerate `hlight::2.0` vs older `hlight` and Karma/Mantra camera variants.

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/_camlight_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/_camlight_common.py
@@ -47,7 +47,7 @@ def eval_parm(node: Any, name: str) -> Optional[Any]:
     parm_tuple = node.parmTuple(name)
     if parm_tuple is not None:
         try:
-            return [v for v in parm_tuple.eval()]
+            return list(parm_tuple.eval())
         except Exception:  # noqa: BLE001
             return None
     parm = node.parm(name)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/_camlight_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/_camlight_common.py
@@ -1,0 +1,86 @@
+"""Shared helpers for Houdini camera/light skills."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+# Friendly light type -> hlight 'light_type' menu index (hlight::2.0).
+LIGHT_TYPES = {
+    "point": 0,
+    "line": 1,
+    "grid": 2,
+    "disk": 3,
+    "sphere": 4,
+    "tube": 5,
+    "geometry": 6,
+    "distant": 7,
+    "sun": 7,
+    "environment": 8,
+}
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
+    """Set a scalar/tuple parm only when it exists. Return whether it was set."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            return False
+        parm_tuple.set(tuple(value))
+        return True
+    parm = node.parm(name)
+    if parm is None:
+        return False
+    parm.set(value)
+    return True
+
+
+def eval_parm(node: Any, name: str) -> Optional[Any]:
+    """Eval a scalar parm or parm tuple if present, else None."""
+    parm_tuple = node.parmTuple(name)
+    if parm_tuple is not None:
+        try:
+            return [v for v in parm_tuple.eval()]
+        except Exception:  # noqa: BLE001
+            return None
+    parm = node.parm(name)
+    if parm is not None:
+        try:
+            return parm.eval()
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def apply_transform(
+    node: Any,
+    translate: Optional[Sequence[float]],
+    rotate: Optional[Sequence[float]],
+    scale: Optional[Sequence[float]] = None,
+) -> dict:
+    """Set t/r/s parm tuples defensively; return what was applied."""
+    applied: dict = {}
+    if translate is not None and set_parm_if_exists(node, "t", translate):
+        applied["t"] = list(translate)
+    if rotate is not None and set_parm_if_exists(node, "r", rotate):
+        applied["r"] = list(rotate)
+    if scale is not None and set_parm_if_exists(node, "s", scale):
+        applied["s"] = list(scale)
+    return applied

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/create_camera.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/create_camera.py
@@ -1,0 +1,60 @@
+"""Create a camera node with optional transform, resolution, and focal length."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _camlight_common import apply_transform, get_node, node_summary, set_parm_if_exists  # noqa: E402
+
+
+def create_camera(
+    parent_path: str = "/obj",
+    name: Optional[str] = None,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    resolution: Optional[List[int]] = None,
+    focal: Optional[float] = None,
+) -> dict:
+    """Create a ``cam`` node under *parent_path* and configure lens/transform."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+        cam = parent.createNode("cam", node_name=name)
+        applied = apply_transform(cam, translate, rotate)
+        if resolution is not None and len(resolution) >= 2:
+            set_parm_if_exists(cam, "resx", int(resolution[0]))
+            set_parm_if_exists(cam, "resy", int(resolution[1]))
+            applied["resolution"] = [int(resolution[0]), int(resolution[1])]
+        if focal is not None and set_parm_if_exists(cam, "focal", float(focal)):
+            applied["focal"] = float(focal)
+        return skill_success(
+            "Created camera",
+            parent_path=parent.path(),
+            node=node_summary(cam),
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create camera")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_camera(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/create_light.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/create_light.py
@@ -1,0 +1,80 @@
+"""Create an hlight node with typed intensity/color/exposure/transform."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _camlight_common import (  # noqa: E402
+    LIGHT_TYPES,
+    apply_transform,
+    get_node,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def create_light(
+    parent_path: str = "/obj",
+    light_type: str = "point",
+    name: Optional[str] = None,
+    intensity: Optional[float] = None,
+    color: Optional[List[float]] = None,
+    exposure: Optional[float] = None,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+) -> dict:
+    """Create an ``hlight::2.0`` node and configure its core light parms."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    type_index = LIGHT_TYPES.get(light_type.lower())
+    if type_index is None:
+        return skill_error(
+            "Unsupported light type",
+            "light_type must be one of: {}".format(", ".join(sorted(LIGHT_TYPES))),
+            requested=light_type,
+        )
+    try:
+        parent = get_node(hou, parent_path)
+        try:
+            light = parent.createNode("hlight::2.0", node_name=name)
+        except Exception:  # noqa: BLE001 - older Houdini uses unversioned hlight
+            light = parent.createNode("hlight", node_name=name)
+        applied = apply_transform(light, translate, rotate)
+        set_parm_if_exists(light, "light_type", type_index)
+        applied["light_type"] = light_type.lower()
+        if intensity is not None and set_parm_if_exists(light, "light_intensity", float(intensity)):
+            applied["intensity"] = float(intensity)
+        if color is not None and set_parm_if_exists(light, "light_color", color):
+            applied["color"] = list(color)
+        if exposure is not None and set_parm_if_exists(light, "light_exposure", float(exposure)):
+            applied["exposure"] = float(exposure)
+        return skill_success(
+            "Created light",
+            parent_path=parent.path(),
+            node=node_summary(light),
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create light")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_light(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
@@ -1,0 +1,91 @@
+"""Frame the Scene Viewer on a node and/or look through a camera."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _camlight_common import get_node  # noqa: E402
+
+
+def _scene_viewer(hou):
+    try:
+        return hou.ui.paneTabOfType(hou.paneTabType.SceneViewer)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def frame_view(
+    node_path: Optional[str] = None,
+    camera_path: Optional[str] = None,
+) -> dict:
+    """Look through *camera_path* (optional) and frame *node_path* (optional)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        warnings: List[str] = []
+        if not hou.isUIAvailable():
+            return skill_success(
+                "Viewport not available (headless)",
+                framed=False,
+                warnings=["UI is not available; cannot frame a viewport"],
+            )
+        viewer = _scene_viewer(hou)
+        if viewer is None:
+            return skill_success(
+                "No Scene Viewer pane",
+                framed=False,
+                warnings=["No Scene Viewer pane is open"],
+            )
+        viewport = viewer.curViewport()
+        if camera_path:
+            cam = get_node(hou, camera_path)
+            try:
+                viewport.setCamera(cam)
+            except Exception as cam_exc:  # noqa: BLE001
+                warnings.append("Could not set camera: {}".format(cam_exc))
+        framed = False
+        if node_path:
+            node = get_node(hou, node_path)
+            try:
+                node.setSelected(True, clear_all_selected=True)
+                viewport.frameSelected()
+                framed = True
+            except Exception as frame_exc:  # noqa: BLE001
+                warnings.append("Could not frame node: {}".format(frame_exc))
+        else:
+            try:
+                viewport.frameAll()
+                framed = True
+            except Exception as frame_exc:  # noqa: BLE001
+                warnings.append("Could not frame view: {}".format(frame_exc))
+        return skill_success(
+            "Framed view",
+            framed=framed,
+            camera_path=camera_path,
+            node_path=node_path,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to frame view")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return frame_view(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/get_view_state.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/get_view_state.py
@@ -1,0 +1,76 @@
+"""Report the active Scene Viewer's camera and viewport state."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+
+def _scene_viewer(hou):
+    try:
+        return hou.ui.paneTabOfType(hou.paneTabType.SceneViewer)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def get_view_state() -> dict:
+    """Return active camera path and viewport name (read-only, UI-aware)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not hou.isUIAvailable():
+            return skill_success(
+                "Viewport not available (headless)",
+                ui_available=False,
+                active_camera=None,
+                viewport_name=None,
+            )
+        viewer = _scene_viewer(hou)
+        if viewer is None:
+            return skill_success(
+                "No Scene Viewer pane",
+                ui_available=True,
+                active_camera=None,
+                viewport_name=None,
+            )
+        viewport = viewer.curViewport()
+        camera = None
+        try:
+            cam_node = viewport.camera()
+            if cam_node is not None:
+                camera = cam_node.path()
+        except Exception:  # noqa: BLE001
+            camera = None
+        viewport_name = None
+        try:
+            viewport_name = viewport.name()
+        except Exception:  # noqa: BLE001
+            viewport_name = None
+        return skill_success(
+            "Read view state",
+            ui_available=True,
+            active_camera=camera,
+            viewport_name=viewport_name,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read view state")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_view_state(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/list_cameras.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/list_cameras.py
@@ -1,0 +1,58 @@
+"""List camera nodes under a network with key lens/resolution fields."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _camlight_common import eval_parm, get_node  # noqa: E402
+
+
+def list_cameras(parent_path: str = "/obj") -> dict:
+    """Return camera nodes (type name containing 'cam') under *parent_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+        cameras = []
+        for child in parent.children():
+            type_name = child.type().name()
+            if "cam" not in type_name.lower():
+                continue
+            cameras.append(
+                {
+                    "path": child.path(),
+                    "name": child.name(),
+                    "type": type_name,
+                    "resolution": [eval_parm(child, "resx"), eval_parm(child, "resy")],
+                    "focal": eval_parm(child, "focal"),
+                }
+            )
+        return skill_success(
+            "Listed cameras",
+            parent_path=parent.path(),
+            count=len(cameras),
+            cameras=cameras,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list cameras")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_cameras(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/update_camera.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/update_camera.py
@@ -1,0 +1,57 @@
+"""Update an existing camera's transform, resolution, and focal length."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _camlight_common import apply_transform, get_node, node_summary, set_parm_if_exists  # noqa: E402
+
+
+def update_camera(
+    camera_path: str,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    resolution: Optional[List[int]] = None,
+    focal: Optional[float] = None,
+) -> dict:
+    """Apply lens/transform changes to the camera at *camera_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        cam = get_node(hou, camera_path)
+        applied = apply_transform(cam, translate, rotate)
+        if resolution is not None and len(resolution) >= 2:
+            set_parm_if_exists(cam, "resx", int(resolution[0]))
+            set_parm_if_exists(cam, "resy", int(resolution[1]))
+            applied["resolution"] = [int(resolution[0]), int(resolution[1])]
+        if focal is not None and set_parm_if_exists(cam, "focal", float(focal)):
+            applied["focal"] = float(focal)
+        return skill_success(
+            "Updated camera",
+            node=node_summary(cam),
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to update camera")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return update_camera(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/update_light.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/update_light.py
@@ -1,0 +1,74 @@
+"""Update an existing hlight's intensity/color/exposure/type/transform."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _camlight_common import (  # noqa: E402
+    LIGHT_TYPES,
+    apply_transform,
+    get_node,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def update_light(
+    light_path: str,
+    intensity: Optional[float] = None,
+    color: Optional[List[float]] = None,
+    exposure: Optional[float] = None,
+    light_type: Optional[str] = None,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+) -> dict:
+    """Apply light changes to the hlight node at *light_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if light_type is not None and light_type.lower() not in LIGHT_TYPES:
+        return skill_error(
+            "Unsupported light type",
+            "light_type must be one of: {}".format(", ".join(sorted(LIGHT_TYPES))),
+            requested=light_type,
+        )
+    try:
+        light = get_node(hou, light_path)
+        applied = apply_transform(light, translate, rotate)
+        if light_type is not None:
+            set_parm_if_exists(light, "light_type", LIGHT_TYPES[light_type.lower()])
+            applied["light_type"] = light_type.lower()
+        if intensity is not None and set_parm_if_exists(light, "light_intensity", float(intensity)):
+            applied["intensity"] = float(intensity)
+        if color is not None and set_parm_if_exists(light, "light_color", color):
+            applied["color"] = list(color)
+        if exposure is not None and set_parm_if_exists(light, "light_exposure", float(exposure)):
+            applied["exposure"] = float(exposure)
+        return skill_success(
+            "Updated light",
+            node=node_summary(light),
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to update light")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return update_light(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/tools.yaml
@@ -1,0 +1,219 @@
+tools:
+  - name: list_cameras
+    description: List camera nodes under a network with resolution and focal length.
+    source_file: scripts/list_cameras.py
+    execution: sync
+    affinity: main
+    group: camera
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+  - name: create_camera
+    description: Create a camera node with optional transform, resolution, and focal.
+    source_file: scripts/create_camera.py
+    execution: sync
+    affinity: main
+    group: camera
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+        name:
+          type: string
+        translate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        rotate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+        focal:
+          type: number
+  - name: update_camera
+    description: Update an existing camera's transform, resolution, and focal length.
+    source_file: scripts/update_camera.py
+    execution: sync
+    affinity: main
+    group: camera
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [camera_path]
+      properties:
+        camera_path:
+          type: string
+        translate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        rotate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+        focal:
+          type: number
+  - name: frame_view
+    description: >-
+      Look through a camera and/or frame a node in the Scene Viewer. UI-aware:
+      returns framed=false with a warning when headless.
+    source_file: scripts/frame_view.py
+    execution: sync
+    affinity: main
+    group: view
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        node_path:
+          type: string
+        camera_path:
+          type: string
+  - name: get_view_state
+    description: Report the active Scene Viewer camera and viewport (read-only, UI-aware).
+    source_file: scripts/get_view_state.py
+    execution: sync
+    affinity: main
+    group: view
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties: {}
+  - name: create_light
+    description: >-
+      Create an hlight node (point/distant/sphere/environment/...) with typed
+      intensity, color, exposure, and transform.
+    source_file: scripts/create_light.py
+    execution: sync
+    affinity: main
+    group: light
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+        light_type:
+          type: string
+          enum: [point, line, grid, disk, sphere, tube, geometry, distant, sun, environment]
+          default: point
+        name:
+          type: string
+        intensity:
+          type: number
+        color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        exposure:
+          type: number
+        translate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        rotate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+  - name: update_light
+    description: Update an existing hlight's intensity/color/exposure/type/transform.
+    source_file: scripts/update_light.py
+    execution: sync
+    affinity: main
+    group: light
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [light_path]
+      properties:
+        light_path:
+          type: string
+        intensity:
+          type: number
+        color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        exposure:
+          type: number
+        light_type:
+          type: string
+          enum: [point, line, grid, disk, sphere, tube, geometry, distant, sun, environment]
+        translate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+        rotate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: houdini-render
+description: >-
+  Pipeline skill — viewport capture/flipbook plus ROP render settings and
+  render execution through typed, runtime-aware tools. Exports report
+  written_files, elapsed time, and warnings without hanging the host. Pair with
+  houdini-camera-light to set up cameras and lights first.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: pipeline
+    version: "1.0.0"
+    tags: [houdini, render, rop, karma, mantra, viewport, flipbook, capture, pipeline]
+    search-hint: "render rop karma mantra viewport capture flipbook screenshot render settings resolution output"
+    tools: tools.yaml
+---
+
+# houdini-render
+
+Typed render and visual-verification tools. All tools are `affinity: main`.
+Viewport tools are **UI-aware**: in a headless `hython` session they return a
+structured `warnings` payload with `captured: false` instead of failing, so an
+agent can detect and skip cleanly when rendering is unavailable.
+
+## Tool groups
+
+- **`viewport`:** `capture_viewport` (single frame), `flipbook` (range). Both
+  clamp resolution to 4096 and return `written_files` / `skipped` / `warnings`.
+- **`render`:** `get_render_settings` (read-only), `set_render_settings`
+  (reports `unsupported` fields per ROP type), `render_rop` (async, long
+  timeout, reports `elapsed_secs` + `written_files`).
+
+## Tracer-bullet flow
+
+1. `houdini_camera_light__create_camera(name="rendercam")`
+2. `set_render_settings(rop_path="/out/mantra1", camera="/obj/rendercam", resolution=[1280,720], output_path="/tmp/beauty.exr")`
+3. `get_render_settings("/out/mantra1")` → verify
+4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only)
+5. `render_rop("/out/mantra1", frame_range=[1,1])` → `written_files`, `elapsed_secs`
+
+`render_rop` is `async` with a 30-minute timeout hint; output-path and
+resolution parameter writes are defensive (candidate names) so Mantra, Karma,
+and ROP geometry/USD drivers are all tolerated.

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -62,7 +62,7 @@ def eval_first_parm(node: Any, names: Sequence[str]):
         parm_tuple = node.parmTuple(name)
         if parm_tuple is not None:
             try:
-                return [v for v in parm_tuple.eval()]
+                return list(parm_tuple.eval())
             except Exception:  # noqa: BLE001
                 continue
         parm = node.parm(name)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -1,0 +1,103 @@
+"""Shared helpers for Houdini render/viewport skills."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, Sequence
+
+MAX_DIMENSION = 4096
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def scene_viewer(hou):
+    """Return the current Scene Viewer pane tab or None."""
+    try:
+        return hou.ui.paneTabOfType(hou.paneTabType.SceneViewer)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def clamp_resolution(resolution: Optional[Sequence[int]]) -> Optional[list]:
+    """Clamp [w, h] to a sane maximum; return None when not provided."""
+    if not resolution or len(resolution) < 2:
+        return None
+    width = max(1, min(int(resolution[0]), MAX_DIMENSION))
+    height = max(1, min(int(resolution[1]), MAX_DIMENSION))
+    return [width, height]
+
+
+def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
+    """Set a scalar/tuple parm only when it exists. Return whether it was set."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            return False
+        parm_tuple.set(tuple(value))
+        return True
+    parm = node.parm(name)
+    if parm is None:
+        return False
+    parm.set(value)
+    return True
+
+
+def set_first_parm(node: Any, names: Sequence[str], value: Any) -> Optional[str]:
+    """Set the first existing parm in *names*; return the name used or None."""
+    for name in names:
+        if set_parm_if_exists(node, name, value):
+            return name
+    return None
+
+
+def eval_first_parm(node: Any, names: Sequence[str]):
+    """Eval the first existing parm/parm-tuple in *names*, else None."""
+    for name in names:
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is not None:
+            try:
+                return [v for v in parm_tuple.eval()]
+            except Exception:  # noqa: BLE001
+                continue
+        parm = node.parm(name)
+        if parm is not None:
+            try:
+                return parm.eval()
+            except Exception:  # noqa: BLE001
+                continue
+    return None
+
+
+def apply_frame_range(node: Any, frame_range: Optional[Sequence[float]]) -> Optional[list]:
+    """Set ROP frame-range parms defensively. Return the applied [start, end]."""
+    if not frame_range:
+        return None
+    start, end = float(frame_range[0]), float(frame_range[1])
+    step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+    set_parm_if_exists(node, "trange", 1)
+    if not set_parm_if_exists(node, "f", [start, end, step]):
+        set_parm_if_exists(node, "f1", start)
+        set_parm_if_exists(node, "f2", end)
+        set_parm_if_exists(node, "f3", step)
+    return [start, end]
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def existing_outputs(output_path: str) -> list:
+    """Return [output_path] when it is an existing file, else []."""
+    return [output_path] if output_path and os.path.isfile(output_path) else []

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/capture_viewport.py
@@ -1,0 +1,98 @@
+"""Capture the current Scene Viewer to an image file (flipbook, single frame)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import clamp_resolution, scene_viewer  # noqa: E402
+
+
+def capture_viewport(
+    output_path: str,
+    resolution: Optional[List[int]] = None,
+    frame: Optional[float] = None,
+) -> dict:
+    """Flipbook the current viewport to *output_path* for a single frame.
+
+    UI-aware: a headless ``hython`` session returns ``captured: false`` with a
+    structured warning rather than failing.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        clamped = clamp_resolution(resolution)
+        if not hou.isUIAvailable():
+            return skill_success(
+                "Viewport capture unavailable (headless)",
+                captured=False,
+                output_path=output_path,
+                written_files=[],
+                skipped=[output_path],
+                warnings=["UI is not available; cannot capture a viewport"],
+            )
+        viewer = scene_viewer(hou)
+        if viewer is None:
+            return skill_success(
+                "No Scene Viewer pane",
+                captured=False,
+                output_path=output_path,
+                written_files=[],
+                skipped=[output_path],
+                warnings=["No Scene Viewer pane is open"],
+            )
+        target_frame = float(frame) if frame is not None else float(hou.frame())
+        parent = os.path.dirname(os.path.abspath(output_path))
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, exist_ok=True)
+        warnings: List[str] = []
+        settings = viewer.flipbookSettings().stash()
+        settings.frameRange((target_frame, target_frame))
+        settings.output(output_path)
+        try:
+            settings.outputToMPlay(False)
+        except Exception:  # noqa: BLE001
+            pass
+        if clamped is not None:
+            try:
+                settings.useResolution(True)
+                settings.resolution(tuple(clamped))
+            except Exception as res_exc:  # noqa: BLE001
+                warnings.append("Could not set resolution: {}".format(res_exc))
+        viewer.flipbook(viewer.curViewport(), settings)
+        written = [output_path] if os.path.isfile(output_path) else []
+        skipped = [] if written else [output_path]
+        return skill_success(
+            "Captured viewport",
+            captured=bool(written),
+            output_path=output_path,
+            frame=target_frame,
+            resolution=clamped,
+            written_files=written,
+            skipped=skipped,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to capture viewport")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return capture_viewport(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
@@ -1,0 +1,111 @@
+"""Flipbook the current Scene Viewer over a frame range to image files."""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import clamp_resolution, scene_viewer  # noqa: E402
+
+
+def _glob_outputs(output_path: str) -> list:
+    # Expand a $F / $F4 style pattern to a filesystem glob for verification.
+    pattern = output_path
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        pattern = pattern.replace(token, "*")
+    if "*" in pattern:
+        return sorted(glob.glob(pattern))
+    return [output_path] if os.path.isfile(output_path) else []
+
+
+def flipbook(
+    output_path: str,
+    frame_range: List[float],
+    resolution: Optional[List[int]] = None,
+) -> dict:
+    """Flipbook the current viewport across *frame_range* to *output_path*.
+
+    *output_path* should contain a frame token (e.g. ``/tmp/fb.$F4.jpg``).
+    UI-aware: headless sessions return ``captured: false`` with a warning.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if not frame_range or len(frame_range) < 2:
+        return skill_error("Invalid frame range", "frame_range must be [start, end]")
+
+    try:
+        clamped = clamp_resolution(resolution)
+        if not hou.isUIAvailable():
+            return skill_success(
+                "Flipbook unavailable (headless)",
+                captured=False,
+                output_path=output_path,
+                written_files=[],
+                skipped=[output_path],
+                warnings=["UI is not available; cannot flipbook"],
+            )
+        viewer = scene_viewer(hou)
+        if viewer is None:
+            return skill_success(
+                "No Scene Viewer pane",
+                captured=False,
+                output_path=output_path,
+                written_files=[],
+                skipped=[output_path],
+                warnings=["No Scene Viewer pane is open"],
+            )
+        start, end = float(frame_range[0]), float(frame_range[1])
+        parent = os.path.dirname(os.path.abspath(output_path))
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, exist_ok=True)
+        warnings: List[str] = []
+        settings = viewer.flipbookSettings().stash()
+        settings.frameRange((start, end))
+        settings.output(output_path)
+        try:
+            settings.outputToMPlay(False)
+        except Exception:  # noqa: BLE001
+            pass
+        if clamped is not None:
+            try:
+                settings.useResolution(True)
+                settings.resolution(tuple(clamped))
+            except Exception as res_exc:  # noqa: BLE001
+                warnings.append("Could not set resolution: {}".format(res_exc))
+        viewer.flipbook(viewer.curViewport(), settings)
+        written = _glob_outputs(output_path)
+        return skill_success(
+            "Flipbook complete",
+            captured=bool(written),
+            output_path=output_path,
+            frame_range=[start, end],
+            resolution=clamped,
+            written_files=written,
+            skipped=[] if written else [output_path],
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to flipbook viewport")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return flipbook(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
@@ -1,0 +1,52 @@
+"""Read renderer/camera/resolution/frame-range/output from a ROP node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import eval_first_parm, get_node, node_summary  # noqa: E402
+
+
+def get_render_settings(rop_path: str) -> dict:
+    """Return structured render settings read from the ROP at *rop_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        rop = get_node(hou, rop_path)
+        res_x = eval_first_parm(rop, ("res_overridex", "resx", "vm_resx"))
+        res_y = eval_first_parm(rop, ("res_overridey", "resy", "vm_resy"))
+        settings = {
+            "rop": node_summary(rop),
+            "renderer": rop.type().name(),
+            "camera": eval_first_parm(rop, ("camera", "render_camera")),
+            "resolution": [res_x, res_y] if (res_x is not None or res_y is not None) else None,
+            "frame_range": eval_first_parm(rop, ("f",)),
+            "output_path": eval_first_parm(
+                rop, ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
+            ),
+            "image_format": eval_first_parm(rop, ("vm_image_format", "image_format")),
+        }
+        return skill_success("Read render settings", **settings)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read render settings")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_render_settings(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -1,0 +1,96 @@
+"""Render a ROP node and report written files, elapsed time, and warnings."""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import (  # noqa: E402
+    apply_frame_range,
+    eval_first_parm,
+    get_node,
+    node_summary,
+)
+
+_OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
+
+
+def _expand_outputs(pattern: Optional[str]) -> list:
+    if not pattern:
+        return []
+    globbed = pattern
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        globbed = globbed.replace(token, "*")
+    if "*" in globbed:
+        return sorted(glob.glob(globbed))
+    return [pattern] if os.path.isfile(pattern) else []
+
+
+def render_rop(
+    rop_path: str,
+    frame_range: Optional[List[float]] = None,
+) -> dict:
+    """Render the ROP at *rop_path*, returning written files and elapsed time."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        rop = get_node(hou, rop_path)
+        if not hasattr(rop, "render"):
+            return skill_error(
+                "Not a render node",
+                "Node has no render(); expected a ROP/output driver",
+                node_path=rop.path(),
+            )
+        applied_range = apply_frame_range(rop, frame_range) if frame_range else None
+        output_pattern = eval_first_parm(rop, _OUTPUT_PARMS)
+        warnings: List[str] = []
+        start = time.time()
+        rendered = True
+        try:
+            rop.render(verbose=False)
+        except TypeError:
+            rop.render()
+        except Exception as render_exc:  # noqa: BLE001
+            rendered = False
+            warnings.append("Render failed: {}".format(render_exc))
+        elapsed = round(time.time() - start, 3)
+        if hasattr(rop, "errors"):
+            warnings.extend(list(rop.errors()))
+        written = _expand_outputs(output_pattern)
+        return skill_success(
+            "Rendered ROP",
+            rop=node_summary(rop),
+            rendered=rendered,
+            elapsed_secs=elapsed,
+            frame_range=applied_range,
+            output_pattern=output_pattern,
+            written_files=written,
+            skipped=[] if written or not output_pattern else [output_pattern],
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to render ROP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return render_rop(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/set_render_settings.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/set_render_settings.py
@@ -1,0 +1,91 @@
+"""Set renderer camera/resolution/frame-range/output/format on a ROP node."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import (  # noqa: E402
+    apply_frame_range,
+    clamp_resolution,
+    get_node,
+    node_summary,
+    set_first_parm,
+)
+
+
+def set_render_settings(
+    rop_path: str,
+    camera: Optional[str] = None,
+    resolution: Optional[List[int]] = None,
+    frame_range: Optional[List[float]] = None,
+    output_path: Optional[str] = None,
+    image_format: Optional[str] = None,
+) -> dict:
+    """Apply render settings to the ROP at *rop_path* (defensive parm writes)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        rop = get_node(hou, rop_path)
+        applied: dict = {}
+        unsupported: List[str] = []
+        if camera is not None:
+            if set_first_parm(rop, ("camera", "render_camera"), camera):
+                applied["camera"] = camera
+            else:
+                unsupported.append("camera")
+        clamped = clamp_resolution(resolution)
+        if clamped is not None:
+            x = set_first_parm(rop, ("res_overridex", "resx", "vm_resx"), clamped[0])
+            y = set_first_parm(rop, ("res_overridey", "resy", "vm_resy"), clamped[1])
+            if x or y:
+                applied["resolution"] = clamped
+            else:
+                unsupported.append("resolution")
+        if frame_range is not None:
+            applied["frame_range"] = apply_frame_range(rop, frame_range)
+        if output_path is not None:
+            used = set_first_parm(
+                rop,
+                ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage"),
+                output_path,
+            )
+            if used:
+                applied["output_path"] = output_path
+            else:
+                unsupported.append("output_path")
+        if image_format is not None:
+            used = set_first_parm(rop, ("vm_image_format", "image_format"), image_format)
+            if used:
+                applied["image_format"] = image_format
+            else:
+                unsupported.append("image_format")
+        return skill_success(
+            "Set render settings",
+            rop=node_summary(rop),
+            applied=applied,
+            unsupported=unsupported,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set render settings")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_render_settings(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -1,0 +1,149 @@
+tools:
+  - name: capture_viewport
+    description: >-
+      Capture the current Scene Viewer to an image file for a single frame via
+      flipbook, with clamped resolution. UI-aware (headless returns a warning).
+    source_file: scripts/capture_viewport.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 120
+    group: viewport
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [output_path]
+      properties:
+        output_path:
+          type: string
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+          description: "[width, height], clamped to 4096."
+        frame:
+          type: number
+  - name: flipbook
+    description: >-
+      Flipbook the current viewport across a frame range to image files (use a
+      $F token in output_path). UI-aware.
+    source_file: scripts/flipbook.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: viewport
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [output_path, frame_range]
+      properties:
+        output_path:
+          type: string
+          description: "Image path, ideally with a frame token e.g. /tmp/fb.$F4.jpg."
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+  - name: get_render_settings
+    description: >-
+      Read renderer, camera, resolution, frame range, output path, and image
+      format from a ROP node. Read-only.
+    source_file: scripts/get_render_settings.py
+    execution: sync
+    affinity: main
+    group: render
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [rop_path]
+      properties:
+        rop_path:
+          type: string
+  - name: set_render_settings
+    description: >-
+      Set camera, resolution (clamped), frame range, output path, and image
+      format on a ROP node. Reports unsupported fields for the ROP type.
+    source_file: scripts/set_render_settings.py
+    execution: sync
+    affinity: main
+    group: render
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [rop_path]
+      properties:
+        rop_path:
+          type: string
+        camera:
+          type: string
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3
+        output_path:
+          type: string
+        image_format:
+          type: string
+  - name: render_rop
+    description: >-
+      Render a ROP/output driver and report written files, elapsed time,
+      warnings/errors. Async with a long timeout hint to avoid hanging the host.
+    source_file: scripts/render_rop.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 1800
+    group: render
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [rop_path]
+      properties:
+        rop_path:
+          type: string
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -1,0 +1,227 @@
+"""Mock-hou unit tests for houdini-camera-light and houdini-render skills."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(skill_name: str, script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / skill_name / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"{skill_name}_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = type_name
+    return node
+
+
+def _scalar_parm(value):
+    parm = MagicMock()
+    parm.eval.return_value = value
+    return parm
+
+
+class TestCameraSkills:
+    def test_list_cameras_filters_and_reads_parms(self) -> None:
+        mod = _load_script("houdini-camera-light", "list_cameras.py")
+        cam = _node("/obj/cam1", "cam1", "cam")
+        cam.parmTuple.return_value = None
+        cam.parm.side_effect = lambda n: {
+            "resx": _scalar_parm(1920),
+            "resy": _scalar_parm(1080),
+            "focal": _scalar_parm(50.0),
+        }.get(n)
+        geo = _node("/obj/geo1", "geo1", "geo")
+        parent = _node("/obj", "obj")
+        parent.children.return_value = [cam, geo]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_cameras("/obj")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["cameras"][0]["resolution"] == [1920, 1080]
+        assert result["context"]["cameras"][0]["focal"] == 50.0
+
+    def test_create_camera_sets_lens(self) -> None:
+        mod = _load_script("houdini-camera-light", "create_camera.py")
+        cam = _node("/obj/shotcam", "shotcam", "cam")
+        cam.parmTuple.return_value = MagicMock()
+        resx, resy, focal = MagicMock(), MagicMock(), MagicMock()
+        cam.parm.side_effect = lambda n: {"resx": resx, "resy": resy, "focal": focal}.get(n)
+        parent = _node("/obj", "obj")
+        parent.createNode.return_value = cam
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_camera("/obj", name="shotcam", resolution=[1280, 720], focal=35)
+
+        assert result["success"] is True
+        parent.createNode.assert_called_once_with("cam", node_name="shotcam")
+        resx.set.assert_called_once_with(1280)
+        focal.set.assert_called_once_with(35.0)
+
+
+class TestLightSkills:
+    def test_create_light_sets_core_parms(self) -> None:
+        mod = _load_script("houdini-camera-light", "create_light.py")
+        light = _node("/obj/keylight", "keylight", "hlight::2.0")
+        light.parmTuple.return_value = MagicMock()
+        type_parm, intensity_parm, exposure_parm = MagicMock(), MagicMock(), MagicMock()
+        light.parm.side_effect = lambda n: {
+            "light_type": type_parm,
+            "light_intensity": intensity_parm,
+            "light_exposure": exposure_parm,
+        }.get(n)
+        parent = _node("/obj", "obj")
+        parent.createNode.return_value = light
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_light("/obj", light_type="distant", name="keylight", intensity=2.0, exposure=1.5)
+
+        assert result["success"] is True
+        type_parm.set.assert_called_once_with(7)
+        intensity_parm.set.assert_called_once_with(2.0)
+        exposure_parm.set.assert_called_once_with(1.5)
+
+    def test_create_light_rejects_unknown_type(self) -> None:
+        mod = _load_script("houdini-camera-light", "create_light.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.create_light("/obj", light_type="laser")
+        assert result["success"] is False
+
+
+class TestViewSkills:
+    def test_frame_view_headless(self) -> None:
+        mod = _load_script("houdini-camera-light", "frame_view.py")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.frame_view(node_path="/obj/geo1")
+        assert result["success"] is True
+        assert result["context"]["framed"] is False
+
+    def test_get_view_state_headless(self) -> None:
+        mod = _load_script("houdini-camera-light", "get_view_state.py")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_view_state()
+        assert result["success"] is True
+        assert result["context"]["ui_available"] is False
+
+
+class TestViewportCapture:
+    def test_capture_viewport_headless_skips(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "capture_viewport.py")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
+        out = str(tmp_path / "frame.jpg")
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.capture_viewport(out)
+        assert result["success"] is True
+        assert result["context"]["captured"] is False
+        assert result["context"]["skipped"] == [out]
+
+    def test_capture_viewport_with_ui_writes_file(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "capture_viewport.py")
+        out = tmp_path / "frame.jpg"
+        settings = MagicMock()
+        viewer = MagicMock()
+        viewer.flipbookSettings.return_value.stash.return_value = settings
+        viewer.flipbook.side_effect = lambda vp, s: out.write_bytes(b"img")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.frame.return_value = 1.0
+        mock_hou.ui.paneTabOfType.return_value = viewer
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.capture_viewport(str(out), resolution=[99999, 720])
+
+        assert result["success"] is True
+        assert result["context"]["captured"] is True
+        assert result["context"]["written_files"] == [str(out)]
+        # resolution clamped to MAX_DIMENSION
+        assert result["context"]["resolution"] == [4096, 720]
+
+
+class TestRenderSettings:
+    def test_get_render_settings_reads_fields(self) -> None:
+        mod = _load_script("houdini-render", "get_render_settings.py")
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: {
+            "camera": _scalar_parm("/obj/cam1"),
+            "vm_picture": _scalar_parm("/tmp/beauty.exr"),
+            "res_overridex": _scalar_parm(1280),
+            "res_overridey": _scalar_parm(720),
+        }.get(n)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_render_settings("/out/mantra1")
+
+        assert result["success"] is True
+        assert result["context"]["camera"] == "/obj/cam1"
+        assert result["context"]["output_path"] == "/tmp/beauty.exr"
+        assert result["context"]["resolution"] == [1280, 720]
+
+    def test_set_render_settings_reports_unsupported(self) -> None:
+        mod = _load_script("houdini-render", "set_render_settings.py")
+        camera_parm = MagicMock()
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        # Only the camera parm exists; output_path parms are all missing.
+        rop.parm.side_effect = lambda n: camera_parm if n == "camera" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_render_settings("/out/mantra1", camera="/obj/cam1", output_path="/tmp/x.exr")
+
+        assert result["success"] is True
+        camera_parm.set.assert_called_once_with("/obj/cam1")
+        assert result["context"]["applied"]["camera"] == "/obj/cam1"
+        assert "output_path" in result["context"]["unsupported"]
+
+
+class TestRenderExecution:
+    def test_render_rop_reports_written_and_elapsed(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        out = tmp_path / "beauty.exr"
+        picture = _scalar_parm(str(out))
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        rop.render.side_effect = lambda verbose=False: out.write_bytes(b"exr")
+        rop.errors.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.render_rop("/out/mantra1")
+
+        assert result["success"] is True
+        assert result["context"]["rendered"] is True
+        assert result["context"]["written_files"] == [str(out)]
+        assert "elapsed_secs" in result["context"]


### PR DESCRIPTION
## Summary

Closes #15. Adds typed render and visual-verification tools across two skill packages so agents can set up cameras/lights and render or capture the viewport without hand-building ROP networks.

### `houdini-camera-light` (authoring stage)
- `list_cameras` / `create_camera` / `update_camera` — transform, resolution, focal length.
- `create_light` / `update_light` — hlight type, intensity, color, exposure, transform (with `hlight::2.0` → `hlight` fallback).
- `frame_view` / `get_view_state` — **UI-aware** Scene Viewer helpers that return `framed: false` / `ui_available: false` with structured warnings in a headless `hython` session instead of failing.

### `houdini-render` (pipeline stage)
- `capture_viewport` / `flipbook` — flipbook the Scene Viewer to image files; resolution clamped to 4096; UI-aware headless skip.
- `get_render_settings` / `set_render_settings` — read/write renderer camera, resolution, frame range, output path, image format defensively; `set` reports `unsupported` fields per ROP type.
- `render_rop` — `async` ROP render reporting `rendered`, `elapsed_secs`, `written_files`, `skipped`, and warnings/errors with a 30-minute timeout hint so it never hangs the host.

### Design
- All tools `affinity: main`; output-path / resolution / frame-range parms are set via candidate names for cross-version tolerance (Mantra, Karma, ROP geometry/USD).
- Registered in the authoring/pipeline stages; camera/light and render chains documented in `skills/SKILLS_INDEX.md`.

## Test plan
- [x] `pytest tests/test_render_camera_light_skills.py` — 11 mock-hou tests including headless skip paths, resolution clamping, unsupported-field reporting, and a render-with-output tracer bullet.
- [x] `pytest tests/test_skills.py` — auto `validate_skill` + `tools.yaml` contract pass for both packages.
- [x] Full suite: `150 passed, 1 skipped, 1 deselected`.
- [ ] Live Houdini smoke (camera → set_render_settings → capture_viewport → render_rop) — pending a licensed session; viewport tools require an interactive UI.

> Note: branched off `main`; expect a trivial `_skill_loader.py` / `SKILLS_INDEX.md` rebase against #24–#27 once those land.
