### PR TITLE
feat: Houdini animation, channel, and timeline skills (#16)

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -24,7 +24,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "scene": ("houdini-scene",),
     "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
     "interchange": (),
-    "pipeline": ("houdini-automation",),
+    "pipeline": ("houdini-animation", "houdini-automation"),
 }
 
 

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -8,7 +8,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `scene` | `houdini-scene` | yes |
 | `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
 | `interchange` | _(planned: USD, FBX, Alembic)_ | no |
-| `pipeline` | `houdini-automation` | no |
+| `pipeline` | `houdini-animation`, `houdini-automation` | no |
 
 ## Common chains
 
@@ -18,6 +18,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
+| Animate & bake | `load_skill("houdini-animation")` → `houdini_animation__set_timeline` → `houdini_animation__set_keyframe` → `houdini_animation__get_keyframes` → `houdini_animation__bake_channels` / `houdini_animation__cache_simulation` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: houdini-animation
+description: >-
+  Pipeline skill — typed timeline, keyframe, channel, and cache-baking tools.
+  Query/set time, FPS and ranges; set/get/delete/list keyframes; inspect
+  channels and expressions; export/import channel JSON; bake channels and
+  trigger bounded simulation/cache renders. The canonical timeline API.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: pipeline
+    version: "1.0.0"
+    tags: [houdini, animation, keyframe, channel, timeline, fps, bake, simulation, cache, pipeline]
+    search-hint: "keyframe channel timeline frame range fps set time animation bake simulation cache expression"
+    tools: tools.yaml
+---
+
+# houdini-animation
+
+Typed animation tools for agents. All tools are `affinity: main`.
+
+## Tool groups
+
+- **`timeline`:** `get_timeline`, `set_timeline` — the **canonical** timeline
+  query/setter. For interactive timeline edits prefer `set_timeline` over
+  `houdini_automation__set_frame_range` (which remains for file-based batch
+  flows).
+- **`keyframes`:** `set_keyframe`, `get_keyframes`, `delete_keyframes`
+  (destructive).
+- **`channels`:** `list_animated_parms`, `get_channel_info`, `export_channels`,
+  `import_channels` (JSON round-trip).
+- **`bake`** (async): `bake_channels` (per-frame sample → constant keys, hard
+  frame cap), `cache_simulation` (render a filecache/DOP/geometry ROP, report
+  `written_files` + `elapsed_secs`).
+
+## Tracer-bullet flow
+
+1. `set_timeline(frame_range=[1,48], fps=24)`
+2. `set_keyframe(node_path="/obj/geo1", parm_name="tx", frame=1, value=0)`
+3. `set_keyframe(node_path="/obj/geo1", parm_name="tx", frame=48, value=10)`
+4. `get_keyframes("/obj/geo1", "tx")` → verify two keys
+5. `export_channels("/obj/geo1", ["tx"], "/tmp/tx.json")` → `import_channels` to retarget
+6. `bake_channels("/obj/geo1", ["tx"], frame_range=[1,48])` to flatten expressions
+
+`cache_simulation` is `async` with a 1-hour timeout hint; output-path parm
+names are probed defensively so File Cache, DOP I/O, and Geometry ROPs are all
+tolerated.

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/_anim_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/_anim_common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 def get_node(hou: Any, node_path: str) -> Any:

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/_anim_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/_anim_common.py
@@ -1,0 +1,68 @@
+"""Shared helpers for Houdini animation/channel/timeline skills."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def get_parm(node: Any, parm_name: str) -> Any:
+    """Return a parameter on *node* or raise a useful error."""
+    parm = node.parm(parm_name)
+    if parm is None:
+        raise ValueError("No parameter named {!r} on {}".format(parm_name, node.path()))
+    return parm
+
+
+def keyframe_dict(kf: Any) -> dict:
+    """Serialise a hou.Keyframe to a JSON-safe dict (defensive)."""
+    entry: dict = {}
+    for attr in ("frame", "value"):
+        fn = getattr(kf, attr, None)
+        if callable(fn):
+            try:
+                entry[attr] = fn()
+            except Exception:  # noqa: BLE001
+                entry[attr] = None
+    expression = None
+    expr_fn = getattr(kf, "expression", None)
+    if callable(expr_fn):
+        try:
+            expression = expr_fn()
+        except Exception:  # noqa: BLE001 - raised when no expression is set
+            expression = None
+    entry["expression"] = expression or None
+    slope_fn = getattr(kf, "slope", None)
+    if callable(slope_fn):
+        try:
+            slope = slope_fn()
+            if isinstance(slope, (int, float)):
+                entry["slope"] = slope
+        except Exception:  # noqa: BLE001
+            pass
+    return entry
+
+
+def parm_is_animated(parm: Any) -> bool:
+    """True when a parm has keyframes or is otherwise time-dependent."""
+    keyframes = getattr(parm, "keyframes", None)
+    if callable(keyframes):
+        try:
+            if len(keyframes()):
+                return True
+        except Exception:  # noqa: BLE001
+            pass
+    is_td = getattr(parm, "isTimeDependent", None)
+    if callable(is_td):
+        try:
+            return bool(is_td())
+        except Exception:  # noqa: BLE001
+            return False
+    return False

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/bake_channels.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/bake_channels.py
@@ -1,0 +1,101 @@
+"""Bake evaluated parameter values into per-frame keyframes over a range."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node  # noqa: E402
+
+_MAX_FRAMES = 100000
+
+
+def bake_channels(
+    node_path: str,
+    parm_names: List[str],
+    frame_range: List[float],
+    step: float = 1.0,
+) -> dict:
+    """Sample *parm_names* each frame in range and write constant keyframes.
+
+    Samples are collected first, then applied, so setting a key never perturbs
+    later samples. Bounded by a hard frame cap to avoid runaway bakes.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if not frame_range or len(frame_range) < 2:
+        return skill_error("Invalid frame range", "frame_range must be [start, end]")
+    start, end = float(frame_range[0]), float(frame_range[1])
+    step = float(step) if step else 1.0
+    if step <= 0:
+        return skill_error("Invalid step", "step must be > 0")
+    if (end - start) / step > _MAX_FRAMES:
+        return skill_error(
+            "Frame range too large",
+            "Refusing to bake more than {} frames".format(_MAX_FRAMES),
+            frame_range=[start, end],
+            step=step,
+        )
+
+    try:
+        node = get_node(hou, node_path)
+        parms = {}
+        missing = []
+        for name in parm_names:
+            parm = node.parm(name)
+            if parm is None:
+                missing.append(name)
+            else:
+                parms[name] = parm
+        if not parms:
+            return skill_error("No valid parameters", "None of parm_names exist", missing=missing)
+
+        original_frame = hou.frame() if hasattr(hou, "frame") else start
+        samples = {name: [] for name in parms}
+        frame = start
+        while frame <= end + 1e-6:
+            hou.setFrame(frame)
+            for name, parm in parms.items():
+                samples[name].append((frame, parm.eval()))
+            frame += step
+        hou.setFrame(original_frame)
+
+        baked = {}
+        for name, parm in parms.items():
+            for sample_frame, value in samples[name]:
+                kf = hou.Keyframe()
+                kf.setFrame(sample_frame)
+                kf.setValue(float(value))
+                parm.setKeyframe(kf)
+            baked[name] = len(samples[name])
+        return skill_success(
+            "Baked channels",
+            node_path=node.path(),
+            frame_range=[start, end],
+            step=step,
+            baked=baked,
+            missing=missing,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake channels")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return bake_channels(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/cache_simulation.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/cache_simulation.py
@@ -1,0 +1,110 @@
+"""Bake a simulation/cache by rendering a ROP and reporting output paths."""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node  # noqa: E402
+
+_OUTPUT_PARMS = ("file", "sopoutput", "filename", "dopoutput", "picture", "outputimage")
+
+
+def _set_frame_range(node, frame_range):
+    if not frame_range or len(frame_range) < 2:
+        return None
+    start, end = float(frame_range[0]), float(frame_range[1])
+    if node.parm("trange") is not None:
+        node.parm("trange").set(1)
+    tuple_parm = node.parmTuple("f")
+    if tuple_parm is not None:
+        step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+        tuple_parm.set((start, end, step))
+    return [start, end]
+
+
+def _eval_output(node) -> Optional[str]:
+    for name in _OUTPUT_PARMS:
+        parm = node.parm(name)
+        if parm is not None:
+            try:
+                return parm.eval()
+            except Exception:  # noqa: BLE001
+                continue
+    return None
+
+
+def _expand(pattern: Optional[str]) -> list:
+    if not pattern:
+        return []
+    globbed = pattern
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        globbed = globbed.replace(token, "*")
+    if "*" in globbed:
+        return sorted(glob.glob(globbed))
+    return [pattern] if os.path.isfile(pattern) else []
+
+
+def cache_simulation(rop_path: str, frame_range: Optional[List[float]] = None) -> dict:
+    """Render a cache/sim ROP (filecache/dop/geometry) and report outputs."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        rop = get_node(hou, rop_path)
+        if not hasattr(rop, "render"):
+            return skill_error(
+                "Not a cache/render node",
+                "Node has no render(); expected a ROP/file cache node",
+                node_path=rop.path(),
+            )
+        applied_range = _set_frame_range(rop, frame_range)
+        output_pattern = _eval_output(rop)
+        warnings: List[str] = []
+        start = time.time()
+        cached = True
+        try:
+            rop.render(verbose=False)
+        except TypeError:
+            rop.render()
+        except Exception as render_exc:  # noqa: BLE001
+            cached = False
+            warnings.append("Cache render failed: {}".format(render_exc))
+        elapsed = round(time.time() - start, 3)
+        written = _expand(output_pattern)
+        return skill_success(
+            "Cached simulation",
+            node_path=rop.path(),
+            cached=cached,
+            elapsed_secs=elapsed,
+            frame_range=applied_range,
+            output_pattern=output_pattern,
+            written_files=written,
+            skipped=[] if written or not output_pattern else [output_pattern],
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cache simulation")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return cache_simulation(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/delete_keyframes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/delete_keyframes.py
@@ -1,0 +1,71 @@
+"""Delete keyframes on a node parameter (all, or within a frame range)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node, get_parm  # noqa: E402
+
+
+def delete_keyframes(
+    node_path: str,
+    parm_name: str,
+    frame_range: Optional[List[float]] = None,
+) -> dict:
+    """Delete keyframes on ``node_path/parm_name``.
+
+    With no ``frame_range`` all keyframes are removed; otherwise only those
+    whose frame falls within ``[start, end]`` inclusive.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        parm = get_parm(node, parm_name)
+        if frame_range is None:
+            before = len(parm.keyframes())
+            parm.deleteAllKeyframes()
+            return skill_success(
+                "Deleted all keyframes",
+                node_path=node.path(),
+                parm=parm_name,
+                deleted=before,
+            )
+        start, end = float(frame_range[0]), float(frame_range[1])
+        removed = 0
+        for kf in list(parm.keyframes()):
+            frame = kf.frame()
+            if start <= frame <= end:
+                parm.deleteKeyframeAtFrame(frame)
+                removed += 1
+        return skill_success(
+            "Deleted keyframes in range",
+            node_path=node.path(),
+            parm=parm_name,
+            frame_range=[start, end],
+            deleted=removed,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete keyframes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return delete_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/export_channels.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/export_channels.py
@@ -1,0 +1,63 @@
+"""Export keyframe channel data for parameters to a JSON file."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node, keyframe_dict  # noqa: E402
+
+
+def export_channels(node_path: str, parm_names: List[str], output_path: str) -> dict:
+    """Write a JSON channel dump for *parm_names* on *node_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        channels = {}
+        warnings: List[str] = []
+        for name in parm_names:
+            parm = node.parm(name)
+            if parm is None:
+                warnings.append("No parameter named {!r}".format(name))
+                continue
+            channels[name] = [keyframe_dict(kf) for kf in parm.keyframes()]
+        payload = {"node_path": node.path(), "channels": channels}
+        parent = os.path.dirname(os.path.abspath(output_path))
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        return skill_success(
+            "Exported channels",
+            node_path=node.path(),
+            output_path=output_path,
+            channel_count=len(channels),
+            written_files=[output_path] if os.path.isfile(output_path) else [],
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export channels")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_channels(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_channel_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_channel_info.py
@@ -1,0 +1,69 @@
+"""Inspect a channel: expression, keyframe count, time dependence, value."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node, get_parm  # noqa: E402
+
+
+def get_channel_info(node_path: str, parm_name: str) -> dict:
+    """Return expression/keyframe/time-dependence info for a parameter."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        parm = get_parm(node, parm_name)
+        expression = None
+        language = None
+        try:
+            expression = parm.expression()
+            lang = parm.expressionLanguage()
+            language = lang.name() if hasattr(lang, "name") else str(lang)
+        except Exception:  # noqa: BLE001 - no expression set
+            expression = None
+        try:
+            keyframe_count = len(parm.keyframes())
+        except Exception:  # noqa: BLE001
+            keyframe_count = None
+        try:
+            is_time_dependent = bool(parm.isTimeDependent())
+        except Exception:  # noqa: BLE001
+            is_time_dependent = None
+        try:
+            value = parm.eval()
+        except Exception:  # noqa: BLE001
+            value = None
+        return skill_success(
+            "Read channel info",
+            node_path=node.path(),
+            parm=parm_name,
+            expression=expression,
+            language=language,
+            keyframe_count=keyframe_count,
+            is_time_dependent=is_time_dependent,
+            value=value,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read channel info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_channel_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_keyframes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_keyframes.py
@@ -1,0 +1,47 @@
+"""List keyframes on a node parameter."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node, get_parm, keyframe_dict  # noqa: E402
+
+
+def get_keyframes(node_path: str, parm_name: str) -> dict:
+    """Return the keyframes on ``node_path/parm_name``."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        parm = get_parm(node, parm_name)
+        keyframes = [keyframe_dict(kf) for kf in parm.keyframes()]
+        return skill_success(
+            "Listed keyframes",
+            node_path=node.path(),
+            parm=parm_name,
+            count=len(keyframes),
+            keyframes=keyframes,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list keyframes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_timeline.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_timeline.py
@@ -1,0 +1,49 @@
+"""Query current frame, frame/playback range, FPS, and time units."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+
+def get_timeline() -> dict:
+    """Return the canonical timeline state for the current hip."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        playbar = hou.playbar
+        frame_range = list(playbar.frameRange()) if hasattr(playbar, "frameRange") else None
+        playback_range = list(playbar.playbackRange()) if hasattr(playbar, "playbackRange") else None
+        fps = hou.fps() if hasattr(hou, "fps") else None
+        return skill_success(
+            "Read timeline",
+            current_frame=hou.frame() if hasattr(hou, "frame") else None,
+            current_time=hou.time() if hasattr(hou, "time") else None,
+            frame_range=[float(frame_range[0]), float(frame_range[1])] if frame_range else None,
+            playback_range=[float(playback_range[0]), float(playback_range[1])]
+            if playback_range
+            else None,
+            fps=fps,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read timeline")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_timeline(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_timeline.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/get_timeline.py
@@ -29,9 +29,7 @@ def get_timeline() -> dict:
             current_frame=hou.frame() if hasattr(hou, "frame") else None,
             current_time=hou.time() if hasattr(hou, "time") else None,
             frame_range=[float(frame_range[0]), float(frame_range[1])] if frame_range else None,
-            playback_range=[float(playback_range[0]), float(playback_range[1])]
-            if playback_range
-            else None,
+            playback_range=[float(playback_range[0]), float(playback_range[1])] if playback_range else None,
             fps=fps,
         )
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/import_channels.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/import_channels.py
@@ -1,0 +1,82 @@
+"""Import keyframe channel data from a JSON file onto node parameters."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node  # noqa: E402
+
+
+def import_channels(input_path: str, node_path: Optional[str] = None) -> dict:
+    """Apply a JSON channel dump (from export_channels) onto a node.
+
+    The target defaults to the dump's recorded ``node_path``; pass *node_path*
+    to retarget the channels onto a different node.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if not os.path.isfile(input_path):
+        return skill_error("File not found", "No channel file at the given path", input_path=input_path)
+
+    try:
+        with open(input_path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+        channels = payload.get("channels", {})
+        target_path = node_path or payload.get("node_path")
+        if not target_path:
+            return skill_error("No target node", "No node_path in payload or argument")
+        node = get_node(hou, target_path)
+        applied = {}
+        warnings = []
+        for name, keyframes in channels.items():
+            parm = node.parm(name)
+            if parm is None:
+                warnings.append("No parameter named {!r}".format(name))
+                continue
+            count = 0
+            for entry in keyframes:
+                kf = hou.Keyframe()
+                kf.setFrame(float(entry.get("frame", 0.0)))
+                expression = entry.get("expression")
+                if expression:
+                    kf.setExpression(expression, hou.exprLanguage.Hscript)
+                elif entry.get("value") is not None:
+                    kf.setValue(float(entry["value"]))
+                else:
+                    continue
+                parm.setKeyframe(kf)
+                count += 1
+            applied[name] = count
+        return skill_success(
+            "Imported channels",
+            node_path=node.path(),
+            input_path=input_path,
+            applied=applied,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to import channels")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return import_channels(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/list_animated_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/list_animated_parms.py
@@ -1,0 +1,53 @@
+"""List parameters on a node that are keyframed or time-dependent."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node, parm_is_animated  # noqa: E402
+
+
+def list_animated_parms(node_path: str) -> dict:
+    """Return parameters on *node_path* that have keyframes or are time-dependent."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        animated = []
+        for parm in node.parms():
+            if not parm_is_animated(parm):
+                continue
+            try:
+                keyframe_count = len(parm.keyframes())
+            except Exception:  # noqa: BLE001
+                keyframe_count = None
+            animated.append({"name": parm.name(), "keyframe_count": keyframe_count})
+        return skill_success(
+            "Listed animated parameters",
+            node_path=node.path(),
+            count=len(animated),
+            parameters=animated,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list animated parameters")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_animated_parms(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_keyframe.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_keyframe.py
@@ -1,0 +1,74 @@
+"""Set a keyframe (value or expression) on a node parameter at a frame."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _anim_common import get_node, get_parm  # noqa: E402
+
+
+def set_keyframe(
+    node_path: str,
+    parm_name: str,
+    frame: float,
+    value: Optional[float] = None,
+    expression: Optional[str] = None,
+    language: str = "hscript",
+) -> dict:
+    """Set a keyframe on ``node_path/parm_name`` at *frame*.
+
+    Provide ``value`` for a constant key or ``expression`` for an expression
+    key (``language`` is "hscript" or "python").
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if value is None and expression is None:
+        return skill_error("Nothing to set", "Provide value or expression")
+
+    try:
+        node = get_node(hou, node_path)
+        parm = get_parm(node, parm_name)
+        kf = hou.Keyframe()
+        kf.setFrame(float(frame))
+        if expression is not None:
+            lang = (
+                hou.exprLanguage.Python
+                if language.lower() == "python"
+                else hou.exprLanguage.Hscript
+            )
+            kf.setExpression(expression, lang)
+        else:
+            kf.setValue(float(value))
+        parm.setKeyframe(kf)
+        return skill_success(
+            "Set keyframe",
+            node_path=node.path(),
+            parm=parm_name,
+            frame=float(frame),
+            value=value,
+            expression=expression,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set keyframe")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_keyframe(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_keyframe.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_keyframe.py
@@ -42,11 +42,7 @@ def set_keyframe(
         kf = hou.Keyframe()
         kf.setFrame(float(frame))
         if expression is not None:
-            lang = (
-                hou.exprLanguage.Python
-                if language.lower() == "python"
-                else hou.exprLanguage.Hscript
-            )
+            lang = hou.exprLanguage.Python if language.lower() == "python" else hou.exprLanguage.Hscript
             kf.setExpression(expression, lang)
         else:
             kf.setValue(float(value))

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_timeline.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_timeline.py
@@ -1,0 +1,61 @@
+"""Set current frame, frame range, playback range, and FPS."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+
+def set_timeline(
+    current_frame: Optional[float] = None,
+    frame_range: Optional[List[float]] = None,
+    playback_range: Optional[List[float]] = None,
+    fps: Optional[float] = None,
+) -> dict:
+    """Apply timeline changes. This is the canonical timeline setter.
+
+    Prefer this over ``houdini_automation__set_frame_range`` for interactive
+    timeline edits; the automation tool remains for file-based batch flows.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        applied: dict = {}
+        if fps is not None and hasattr(hou, "setFps"):
+            hou.setFps(float(fps))
+            applied["fps"] = float(fps)
+        if frame_range is not None and len(frame_range) >= 2:
+            hou.playbar.setFrameRange(float(frame_range[0]), float(frame_range[1]))
+            applied["frame_range"] = [float(frame_range[0]), float(frame_range[1])]
+        # Default playback range to the frame range when only the latter is given.
+        pb = playback_range if playback_range is not None else frame_range
+        if pb is not None and len(pb) >= 2 and hasattr(hou.playbar, "setPlaybackRange"):
+            hou.playbar.setPlaybackRange(float(pb[0]), float(pb[1]))
+            applied["playback_range"] = [float(pb[0]), float(pb[1])]
+        if current_frame is not None and hasattr(hou, "setFrame"):
+            hou.setFrame(float(current_frame))
+            applied["current_frame"] = float(current_frame)
+        return skill_success("Set timeline", applied=applied)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set timeline")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_timeline(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
@@ -1,0 +1,277 @@
+tools:
+  - name: get_timeline
+    description: Read current frame, frame/playback range, and FPS (canonical timeline query).
+    source_file: scripts/get_timeline.py
+    execution: sync
+    affinity: main
+    group: timeline
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties: {}
+  - name: set_timeline
+    description: >-
+      Set current frame, frame range, playback range, and FPS. Canonical
+      timeline setter (prefer over automation set_frame_range for live edits).
+    source_file: scripts/set_timeline.py
+    execution: sync
+    affinity: main
+    group: timeline
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        current_frame:
+          type: number
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+        playback_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+        fps:
+          type: number
+  - name: set_keyframe
+    description: Set a value or expression keyframe on a node parameter at a frame.
+    source_file: scripts/set_keyframe.py
+    execution: sync
+    affinity: main
+    group: keyframes
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, parm_name, frame]
+      properties:
+        node_path:
+          type: string
+        parm_name:
+          type: string
+        frame:
+          type: number
+        value:
+          type: number
+        expression:
+          type: string
+        language:
+          type: string
+          enum: [hscript, python]
+          default: hscript
+  - name: get_keyframes
+    description: List keyframes on a node parameter (frame, value, expression).
+    source_file: scripts/get_keyframes.py
+    execution: sync
+    affinity: main
+    group: keyframes
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, parm_name]
+      properties:
+        node_path:
+          type: string
+        parm_name:
+          type: string
+  - name: delete_keyframes
+    description: Delete all keyframes on a parameter, or only those in a frame range.
+    source_file: scripts/delete_keyframes.py
+    execution: sync
+    affinity: main
+    group: keyframes
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, parm_name]
+      properties:
+        node_path:
+          type: string
+        parm_name:
+          type: string
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+  - name: list_animated_parms
+    description: List parameters on a node that are keyframed or time-dependent.
+    source_file: scripts/list_animated_parms.py
+    execution: sync
+    affinity: main
+    group: channels
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+  - name: get_channel_info
+    description: >-
+      Inspect a parameter channel: expression, language, keyframe count, time
+      dependence, current value.
+    source_file: scripts/get_channel_info.py
+    execution: sync
+    affinity: main
+    group: channels
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, parm_name]
+      properties:
+        node_path:
+          type: string
+        parm_name:
+          type: string
+  - name: export_channels
+    description: Export keyframe data for parameters to a JSON file.
+    source_file: scripts/export_channels.py
+    execution: sync
+    affinity: main
+    group: channels
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, parm_names, output_path]
+      properties:
+        node_path:
+          type: string
+        parm_names:
+          type: array
+          items: {type: string}
+          minItems: 1
+        output_path:
+          type: string
+  - name: import_channels
+    description: Apply a JSON channel dump (from export_channels) onto a node.
+    source_file: scripts/import_channels.py
+    execution: sync
+    affinity: main
+    group: channels
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [input_path]
+      properties:
+        input_path:
+          type: string
+        node_path:
+          type: string
+          description: Optional retarget node; defaults to the dump's node_path.
+  - name: bake_channels
+    description: >-
+      Sample evaluated parameter values per frame and write constant keyframes
+      (bounded by a hard frame cap). Async.
+    source_file: scripts/bake_channels.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: bake
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [node_path, parm_names, frame_range]
+      properties:
+        node_path:
+          type: string
+        parm_names:
+          type: array
+          items: {type: string}
+          minItems: 1
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+        step:
+          type: number
+          default: 1.0
+  - name: cache_simulation
+    description: >-
+      Bake a simulation/cache by rendering a ROP (filecache/dop/geometry) over a
+      frame range; reports written files, elapsed time, and warnings. Async.
+    source_file: scripts/cache_simulation.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 3600
+    group: bake
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [rop_path]
+      properties:
+        rop_path:
+          type: string
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3

--- a/tests/test_animation_skills.py
+++ b/tests/test_animation_skills.py
@@ -1,0 +1,270 @@
+"""Mock-hou unit tests for the houdini-animation skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-animation" / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"anim_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _keyframe(frame, value, expression=None):
+    kf = MagicMock()
+    kf.frame.return_value = frame
+    kf.value.return_value = value
+    if expression is None:
+        kf.expression.side_effect = Exception("no expression")
+    else:
+        kf.expression.return_value = expression
+    return kf
+
+
+def _hou_with_keyframe_class():
+    """Return a mock hou whose Keyframe() records frame/value/expression."""
+    mock_hou = MagicMock()
+
+    class _KF:
+        def __init__(self):
+            self.frame = None
+            self.value = None
+            self.expression = None
+
+        def setFrame(self, f):
+            self.frame = f
+
+        def setValue(self, v):
+            self.value = v
+
+        def setExpression(self, e, lang):
+            self.expression = e
+
+    mock_hou.Keyframe.side_effect = _KF
+    mock_hou.exprLanguage.Hscript = "hscript"
+    mock_hou.exprLanguage.Python = "python"
+    return mock_hou
+
+
+class TestTimeline:
+    def test_get_timeline(self) -> None:
+        mod = _load_script("get_timeline.py")
+        mock_hou = MagicMock()
+        mock_hou.frame.return_value = 12.0
+        mock_hou.time.return_value = 0.5
+        mock_hou.fps.return_value = 24.0
+        mock_hou.playbar.frameRange.return_value = (1, 100)
+        mock_hou.playbar.playbackRange.return_value = (1, 100)
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_timeline()
+        assert result["success"] is True
+        assert result["context"]["current_frame"] == 12.0
+        assert result["context"]["frame_range"] == [1.0, 100.0]
+        assert result["context"]["fps"] == 24.0
+
+    def test_set_timeline_applies_and_defaults_playback(self) -> None:
+        mod = _load_script("set_timeline.py")
+        mock_hou = MagicMock()
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_timeline(frame_range=[1, 48], fps=24, current_frame=1)
+        assert result["success"] is True
+        mock_hou.setFps.assert_called_once_with(24.0)
+        mock_hou.playbar.setFrameRange.assert_called_once_with(1.0, 48.0)
+        mock_hou.playbar.setPlaybackRange.assert_called_once_with(1.0, 48.0)
+        mock_hou.setFrame.assert_called_once_with(1.0)
+
+
+class TestKeyframes:
+    def test_set_keyframe_value(self) -> None:
+        mod = _load_script("set_keyframe.py")
+        parm = MagicMock()
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = _hou_with_keyframe_class()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_keyframe("/obj/geo1", "tx", frame=10, value=5.0)
+        assert result["success"] is True
+        parm.setKeyframe.assert_called_once()
+        applied_kf = parm.setKeyframe.call_args[0][0]
+        assert applied_kf.frame == 10.0
+        assert applied_kf.value == 5.0
+
+    def test_set_keyframe_requires_value_or_expression(self) -> None:
+        mod = _load_script("set_keyframe.py")
+        mock_hou = _hou_with_keyframe_class()
+        mock_hou.node.return_value = MagicMock()
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_keyframe("/obj/geo1", "tx", frame=10)
+        assert result["success"] is False
+
+    def test_get_keyframes(self) -> None:
+        mod = _load_script("get_keyframes.py")
+        parm = MagicMock()
+        parm.keyframes.return_value = [_keyframe(1, 0.0), _keyframe(48, 10.0)]
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_keyframes("/obj/geo1", "tx")
+        assert result["success"] is True
+        assert result["context"]["count"] == 2
+        assert result["context"]["keyframes"][1]["value"] == 10.0
+
+    def test_delete_keyframes_all(self) -> None:
+        mod = _load_script("delete_keyframes.py")
+        parm = MagicMock()
+        parm.keyframes.return_value = [_keyframe(1, 0.0), _keyframe(48, 10.0)]
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.delete_keyframes("/obj/geo1", "tx")
+        assert result["success"] is True
+        parm.deleteAllKeyframes.assert_called_once()
+        assert result["context"]["deleted"] == 2
+
+    def test_delete_keyframes_in_range(self) -> None:
+        mod = _load_script("delete_keyframes.py")
+        parm = MagicMock()
+        parm.keyframes.return_value = [_keyframe(1, 0.0), _keyframe(48, 10.0)]
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.delete_keyframes("/obj/geo1", "tx", frame_range=[40, 50])
+        assert result["success"] is True
+        parm.deleteKeyframeAtFrame.assert_called_once_with(48)
+        assert result["context"]["deleted"] == 1
+
+
+class TestChannels:
+    def test_list_animated_parms(self) -> None:
+        mod = _load_script("list_animated_parms.py")
+        animated = MagicMock()
+        animated.name.return_value = "tx"
+        animated.keyframes.return_value = [_keyframe(1, 0.0)]
+        animated.isTimeDependent.return_value = True
+        static = MagicMock()
+        static.name.return_value = "ty"
+        static.keyframes.return_value = []
+        static.isTimeDependent.return_value = False
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parms.return_value = [animated, static]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_animated_parms("/obj/geo1")
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["parameters"][0]["name"] == "tx"
+
+    def test_get_channel_info_with_expression(self) -> None:
+        mod = _load_script("get_channel_info.py")
+        parm = MagicMock()
+        parm.expression.return_value = "$F"
+        parm.expressionLanguage.return_value.name.return_value = "Hscript"
+        parm.keyframes.return_value = [_keyframe(1, 0.0)]
+        parm.isTimeDependent.return_value = True
+        parm.eval.return_value = 3.0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_channel_info("/obj/geo1", "tx")
+        assert result["success"] is True
+        assert result["context"]["expression"] == "$F"
+        assert result["context"]["is_time_dependent"] is True
+
+    def test_export_then_import_channels_roundtrip(self, tmp_path: Path) -> None:
+        export_mod = _load_script("export_channels.py")
+        out = tmp_path / "tx.json"
+        parm = MagicMock()
+        parm.keyframes.return_value = [_keyframe(1, 0.0), _keyframe(48, 10.0)]
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            export_result = export_mod.export_channels("/obj/geo1", ["tx"], str(out))
+        assert export_result["success"] is True
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["channels"]["tx"][1]["value"] == 10.0
+
+        import_mod = _load_script("import_channels.py")
+        target_parm = MagicMock()
+        target = MagicMock()
+        target.path.return_value = "/obj/geo2"
+        target.parm.return_value = target_parm
+        imp_hou = _hou_with_keyframe_class()
+        imp_hou.node.return_value = target
+        with patch.dict(sys.modules, {"hou": imp_hou}):
+            import_result = import_mod.import_channels(str(out), node_path="/obj/geo2")
+        assert import_result["success"] is True
+        assert import_result["context"]["applied"]["tx"] == 2
+        assert target_parm.setKeyframe.call_count == 2
+
+
+class TestBake:
+    def test_bake_channels_samples_each_frame(self) -> None:
+        mod = _load_script("bake_channels.py")
+        parm = MagicMock()
+        parm.eval.return_value = 2.0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1"
+        node.parm.return_value = parm
+        mock_hou = _hou_with_keyframe_class()
+        mock_hou.node.return_value = node
+        mock_hou.frame.return_value = 1.0
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.bake_channels("/obj/geo1", ["tx"], frame_range=[1, 5])
+        assert result["success"] is True
+        assert result["context"]["baked"]["tx"] == 5
+        assert parm.setKeyframe.call_count == 5
+
+    def test_bake_channels_rejects_huge_range(self) -> None:
+        mod = _load_script("bake_channels.py")
+        with patch.dict(sys.modules, {"hou": _hou_with_keyframe_class()}):
+            result = mod.bake_channels("/obj/geo1", ["tx"], frame_range=[1, 10_000_000])
+        assert result["success"] is False
+
+    def test_cache_simulation_reports_written(self, tmp_path: Path) -> None:
+        mod = _load_script("cache_simulation.py")
+        out = tmp_path / "cache.bgeo"
+        file_parm = MagicMock()
+        file_parm.eval.return_value = str(out)
+        rop = MagicMock()
+        rop.path.return_value = "/out/filecache1"
+        rop.parm.side_effect = lambda n: file_parm if n == "file" else None
+        rop.parmTuple.return_value = None
+        rop.render.side_effect = lambda verbose=False: out.write_bytes(b"c")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cache_simulation("/out/filecache1")
+        assert result["success"] is True
+        assert result["context"]["cached"] is True
+        assert result["context"]["written_files"] == [str(out)]


### PR DESCRIPTION
## Summary

Closes #16. Adds the `houdini-animation` pipeline skill: typed timeline, keyframe, channel, and cache-baking tools so animation edits/queries are composable instead of routed through raw Python.

### Tool groups
- **`timeline` (canonical):** `get_timeline` / `set_timeline` for current frame, frame range, playback range, and FPS. `set_timeline` is the canonical interactive timeline setter; `houdini_automation__set_frame_range` remains for file-based batch flows (no duplicate confusing names).
- **`keyframes`:** `set_keyframe` (value or expression, hscript/python), `get_keyframes`, `delete_keyframes` (all or within a frame range, flagged destructive).
- **`channels`:** `list_animated_parms`, `get_channel_info` (expression, language, keyframe count, time dependence, value), `export_channels` / `import_channels` (JSON round-trip with optional retargeting; unsupported parms reported cleanly).
- **`bake` (async):** `bake_channels` (samples evaluated values per frame into constant keys, hard frame cap to avoid runaway bakes), `cache_simulation` (renders a File Cache / DOP I/O / Geometry ROP over a frame range and reports `written_files` + `elapsed_secs` under a 1-hour timeout hint).

### Design
- All tools `affinity: main`; ROP output-path parms probed defensively for cross-version tolerance.
- Registered in the `pipeline` stage; timeline/keyframe/bake chain documented in `skills/SKILLS_INDEX.md`.

## Test plan
- [x] `pytest tests/test_animation_skills.py` — 13 mock-hou tests: timeline get/set, keyframe CRUD, animated-parm listing, channel info, export→import round-trip, bake sampling, huge-range guard, cache reporting.
- [x] `pytest tests/test_skills.py` — auto `validate_skill` + `tools.yaml` contract pass.
- [x] Full suite: `150 passed, 1 skipped, 1 deselected`.
- [ ] Live Houdini smoke (set_timeline → set_keyframe → bake_channels → cache_simulation) — pending a licensed session.

> Note: branched off `main`; expect a trivial `_skill_loader.py` / `SKILLS_INDEX.md` rebase against #24–#28 once those land.
