### PR TITLE
feat: Houdini lookdev and shader-network skill (#17)

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -22,7 +22,12 @@ STAGES: Tuple[str, ...] = (
 STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "bootstrap": ("houdini-scripting",),
     "scene": ("houdini-scene",),
-    "authoring": ("houdini-nodes", "houdini-materials", "houdini-hda"),
+    "authoring": (
+        "houdini-nodes",
+        "houdini-materials",
+        "houdini-lookdev",
+        "houdini-hda",
+    ),
     "interchange": (),
     "pipeline": ("houdini-automation",),
 }

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,7 +6,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene` | yes |
-| `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-hda` | no |
+| `authoring` | `houdini-nodes`, `houdini-materials`, `houdini-lookdev`, `houdini-hda` | no |
 | `interchange` | _(planned: USD, FBX, Alembic)_ | no |
 | `pipeline` | `houdini-automation` | no |
 
@@ -18,6 +18,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
+| Lookdev & shader networks | `load_skill("houdini-lookdev")` → `houdini_lookdev__list_materials` → `houdini_lookdev__get_material_parms` → `houdini_lookdev__set_material_parms` → `houdini_lookdev__save_preset` / `houdini_lookdev__load_preset` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: houdini-lookdev
+description: >-
+  Authoring skill — lookdev and shader-network operations: inspect materials,
+  libraries, shader nodes and assignments; get/set shader parameters with
+  type-aware validation; inspect and rewire shader connections; reset
+  assignments; and manage adapter-owned material presets. Pair with
+  houdini-materials for material creation/assignment.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, lookdev, material, shader, vop, matnet, karma, materialx, preset, authoring]
+    search-hint: "material shader lookdev parameter connect disconnect assignment preset save load karma materialx vop"
+    tools: tools.yaml
+---
+
+# houdini-lookdev
+
+Typed lookdev tools that complement `houdini-materials` (which creates and
+assigns materials). Most tools are `affinity: main`; the filesystem-only preset
+tools `list_presets` / `delete_preset` are `affinity: any`.
+
+## Tool groups
+
+- **`lookdev-query`** (read-only): `list_materials`, `list_assignments`,
+  `get_material_parms`, `get_shader_connections`.
+- **`lookdev-edit`:** `set_material_parms`, `connect_shader`,
+  `disconnect_shader` (destructive), `reset_material` (destructive).
+- **`presets`:** `save_preset`, `list_presets`, `load_preset`, `delete_preset`
+  — JSON files under `~/.dcc-mcp/houdini/material_presets/` (override with
+  `DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR`).
+
+## Context limitations
+
+- **Karma / MaterialX:** MaterialX subnets live under a `matnet`/`mat` library;
+  pass the exact `material_path` (the surface output node). Parameter names
+  differ from `principledshader`, so prefer `get_material_parms` to discover
+  names before `set_material_parms`.
+- **VOP networks:** `connect_shader` / `disconnect_shader` operate on node
+  input slots; use `get_shader_connections` to read `inputNames()` first.
+- Presets store **evaluated parameter values** only (not node graphs); loading
+  onto a different `material_type` is allowed but reported as a warning.
+
+## Tracer-bullet flow
+
+1. `houdini_materials__create_material(material_name="clay")`
+2. `get_material_parms("/mat/clay")` → discover parm names
+3. `set_material_parms("/mat/clay", {"basecolor": [0.8,0.4,0.2], "rough": 0.6})`
+4. `houdini_materials__assign_material("/obj/geo1", "/mat/clay")`
+5. `save_preset("/mat/clay", "warm_clay")` → `load_preset` onto another material

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/_lookdev_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/_lookdev_common.py
@@ -1,0 +1,86 @@
+"""Shared helpers for Houdini lookdev / shader-network skills."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+ENV_PRESET_DIR = "DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR"
+
+# Parameter assignment for an object's material, in priority order.
+MATERIAL_ASSIGN_PARMS = ("shop_materialpath", "shop_materialpath1")
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def preset_dir() -> Path:
+    """Return the adapter-owned material-preset directory (created on demand)."""
+    override = os.environ.get(ENV_PRESET_DIR)
+    base = Path(override) if override else Path.home() / ".dcc-mcp" / "houdini" / "material_presets"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def coerce_scalar(value: Any, current: Any) -> Any:
+    """Best-effort coerce *value* to the type of *current* (the parm's value)."""
+    if current is None:
+        return value
+    try:
+        if isinstance(current, bool):
+            return bool(value)
+        if isinstance(current, int) and not isinstance(current, bool):
+            return int(value)
+        if isinstance(current, float):
+            return float(value)
+        if isinstance(current, str):
+            return str(value)
+    except (TypeError, ValueError):
+        return value
+    return value
+
+
+def set_parameters(node: Any, parameters: dict) -> tuple:
+    """Set parameters on *node*; return (applied, errors) dicts."""
+    applied: dict = {}
+    errors: dict = {}
+    for name, value in parameters.items():
+        try:
+            if isinstance(value, (list, tuple)):
+                parm_tuple = node.parmTuple(name)
+                if parm_tuple is None:
+                    errors[name] = "No parameter tuple named {!r}".format(name)
+                    continue
+                parm_tuple.set(tuple(value))
+                applied[name] = list(value)
+            else:
+                parm = node.parm(name)
+                if parm is None:
+                    errors[name] = "No parameter named {!r}".format(name)
+                    continue
+                try:
+                    current = parm.eval()
+                except Exception:  # noqa: BLE001
+                    current = None
+                coerced = coerce_scalar(value, current)
+                parm.set(coerced)
+                applied[name] = coerced
+        except Exception as exc:  # noqa: BLE001
+            errors[name] = str(exc)
+    return applied, errors
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/_lookdev_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/_lookdev_common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 ENV_PRESET_DIR = "DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR"
 

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/connect_shader.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/connect_shader.py
@@ -22,8 +22,8 @@ def _resolve_index(node, input_index: Optional[int], input_name: Optional[str]) 
         try:
             names = list(node.inputNames())
             return names.index(input_name)
-        except (ValueError, Exception):  # noqa: BLE001
-            raise ValueError("No input named {!r}".format(input_name))
+        except Exception:  # noqa: BLE001
+            raise ValueError("No input named {!r}".format(input_name)) from None
     raise ValueError("Provide input_index or input_name")
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/connect_shader.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/connect_shader.py
@@ -1,0 +1,67 @@
+"""Connect a shader output into a shader/VOP node input."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, node_summary  # noqa: E402
+
+
+def _resolve_index(node, input_index: Optional[int], input_name: Optional[str]) -> int:
+    if input_index is not None:
+        return int(input_index)
+    if input_name is not None:
+        try:
+            names = list(node.inputNames())
+            return names.index(input_name)
+        except (ValueError, Exception):  # noqa: BLE001
+            raise ValueError("No input named {!r}".format(input_name))
+    raise ValueError("Provide input_index or input_name")
+
+
+def connect_shader(
+    node_path: str,
+    source_path: str,
+    input_index: Optional[int] = None,
+    input_name: Optional[str] = None,
+    source_output: int = 0,
+) -> dict:
+    """Wire ``source_path`` (output) into ``node_path`` at an input slot."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        source = get_node(hou, source_path)
+        index = _resolve_index(node, input_index, input_name)
+        node.setInput(index, source, source_output)
+        return skill_success(
+            "Connected shader input",
+            node=node_summary(node),
+            input_index=index,
+            source_path=source.path(),
+            source_output=source_output,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to connect shader input")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return connect_shader(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/delete_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/delete_preset.py
@@ -1,0 +1,45 @@
+"""Delete a saved material preset (adapter-owned JSON store)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import preset_dir  # noqa: E402
+
+
+def delete_preset(preset_name: str) -> dict:
+    """Delete the preset named *preset_name* if it exists."""
+    try:
+        target = preset_dir() / "{}.json".format(preset_name)
+        if not target.is_file():
+            return skill_error(
+                "Preset not found",
+                "No preset named {!r}".format(preset_name),
+                preset_dir=str(preset_dir()),
+            )
+        target.unlink()
+        return skill_success(
+            "Deleted material preset",
+            preset_name=preset_name,
+            preset_path=str(target),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete material preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return delete_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/disconnect_shader.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/disconnect_shader.py
@@ -1,0 +1,52 @@
+"""Disconnect a shader/VOP node input."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, node_summary  # noqa: E402
+
+
+def disconnect_shader(node_path: str, input_index: int) -> dict:
+    """Clear the input at *input_index* on the shader node at *node_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        previous = None
+        try:
+            inputs = node.inputs()
+            if int(input_index) < len(inputs) and inputs[int(input_index)] is not None:
+                previous = inputs[int(input_index)].path()
+        except Exception:  # noqa: BLE001
+            previous = None
+        node.setInput(int(input_index), None)
+        return skill_success(
+            "Disconnected shader input",
+            node=node_summary(node),
+            input_index=int(input_index),
+            previous_source=previous,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to disconnect shader input")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return disconnect_shader(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/get_material_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/get_material_parms.py
@@ -1,0 +1,55 @@
+"""Read parameter names and values for a material/shader node (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, node_summary  # noqa: E402
+
+
+def get_material_parms(material_path: str, name_filter: Optional[str] = None) -> dict:
+    """Return evaluated parameter values for the material at *material_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, material_path)
+        parms = []
+        for parm in node.parms():
+            name = parm.name()
+            if name_filter and name_filter.lower() not in name.lower():
+                continue
+            try:
+                value = parm.eval()
+            except Exception:  # noqa: BLE001
+                value = None
+            parms.append({"name": name, "value": value})
+        return skill_success(
+            "Read material parameters",
+            material=node_summary(node),
+            count=len(parms),
+            parameters=parms,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read material parameters")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_material_parms(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/get_shader_connections.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/get_shader_connections.py
@@ -1,0 +1,59 @@
+"""Inspect a shader/VOP node's input and output connections (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, node_summary  # noqa: E402
+
+
+def get_shader_connections(node_path: str) -> dict:
+    """Return input/output connections for the shader node at *node_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        try:
+            input_names = list(node.inputNames())
+        except Exception:  # noqa: BLE001
+            input_names = []
+        inputs = []
+        for index, source in enumerate(node.inputs()):
+            name = input_names[index] if index < len(input_names) else None
+            inputs.append(
+                {
+                    "index": index,
+                    "name": name,
+                    "source": source.path() if source is not None else None,
+                }
+            )
+        outputs = [n.path() for n in node.outputs()] if hasattr(node, "outputs") else []
+        return skill_success(
+            "Read shader connections",
+            node=node_summary(node),
+            inputs=inputs,
+            outputs=outputs,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read shader connections")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_shader_connections(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_assignments.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_assignments.py
@@ -1,0 +1,59 @@
+"""List object → material assignments under a network (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import MATERIAL_ASSIGN_PARMS, get_node  # noqa: E402
+
+
+def list_assignments(parent_path: str = "/obj") -> dict:
+    """Return material assignments for objects under *parent_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+        assignments = []
+        for child in parent.children():
+            material = None
+            for parm_name in MATERIAL_ASSIGN_PARMS:
+                parm = child.parm(parm_name)
+                if parm is not None:
+                    try:
+                        value = parm.eval()
+                    except Exception:  # noqa: BLE001
+                        value = None
+                    if value:
+                        material = value
+                        break
+            if material:
+                assignments.append({"object": child.path(), "material": material})
+        return skill_success(
+            "Listed assignments",
+            parent_path=parent.path(),
+            count=len(assignments),
+            assignments=assignments,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list assignments")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_assignments(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_materials.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_materials.py
@@ -1,0 +1,56 @@
+"""List material/shader nodes under a material network (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node  # noqa: E402
+
+
+def list_materials(parent_path: str = "/mat") -> dict:
+    """Return shader/material nodes under *parent_path* (e.g. /mat or a matnet)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+        materials = []
+        for child in parent.children():
+            type_obj = child.type()
+            category = type_obj.category().name() if hasattr(type_obj, "category") else None
+            materials.append(
+                {
+                    "path": child.path(),
+                    "name": child.name(),
+                    "type": type_obj.name(),
+                    "category": category,
+                }
+            )
+        return skill_success(
+            "Listed materials",
+            parent_path=parent.path(),
+            count=len(materials),
+            materials=materials,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list materials")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_materials(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_presets.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_presets.py
@@ -1,0 +1,51 @@
+"""List saved material presets (adapter-owned JSON store, read-only)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import preset_dir  # noqa: E402
+
+
+def list_presets() -> dict:
+    """Return saved material presets with their material type and parm counts."""
+    try:
+        base = preset_dir()
+        presets = []
+        for path in sorted(base.glob("*.json")):
+            entry = {"name": path.stem, "preset_path": str(path)}
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    data = json.load(handle)
+                entry["material_type"] = data.get("material_type")
+                entry["parameter_count"] = len(data.get("parameters", {}))
+            except Exception:  # noqa: BLE001
+                entry["error"] = "unreadable preset"
+            presets.append(entry)
+        return skill_success(
+            "Listed material presets",
+            preset_dir=str(base),
+            count=len(presets),
+            presets=presets,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list material presets")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_presets(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/load_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/load_preset.py
@@ -41,9 +41,7 @@ def load_preset(preset_name: str, material_path: str) -> dict:
         material_type = data.get("material_type")
         warnings = []
         if material_type and node.type().name() != material_type:
-            warnings.append(
-                "Preset is for {!r}; target is {!r}".format(material_type, node.type().name())
-            )
+            warnings.append("Preset is for {!r}; target is {!r}".format(material_type, node.type().name()))
         applied, errors = set_parameters(node, data.get("parameters", {}))
         return skill_success(
             "Loaded material preset",

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/load_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/load_preset.py
@@ -1,0 +1,68 @@
+"""Apply a saved material preset onto a material/shader node."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, node_summary, preset_dir, set_parameters  # noqa: E402
+
+
+def load_preset(preset_name: str, material_path: str) -> dict:
+    """Apply the parameters from *preset_name* onto *material_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    target = preset_dir() / "{}.json".format(preset_name)
+    if not target.is_file():
+        # Allow passing the sanitized stem directly.
+        candidates = list(preset_dir().glob("{}.json".format(preset_name)))
+        if not candidates:
+            return skill_error(
+                "Preset not found",
+                "No preset named {!r}".format(preset_name),
+                preset_dir=str(preset_dir()),
+            )
+        target = candidates[0]
+
+    try:
+        with open(target, encoding="utf-8") as handle:
+            data = json.load(handle)
+        node = get_node(hou, material_path)
+        material_type = data.get("material_type")
+        warnings = []
+        if material_type and node.type().name() != material_type:
+            warnings.append(
+                "Preset is for {!r}; target is {!r}".format(material_type, node.type().name())
+            )
+        applied, errors = set_parameters(node, data.get("parameters", {}))
+        return skill_success(
+            "Loaded material preset",
+            preset_name=preset_name,
+            material=node_summary(node),
+            applied_count=len(applied),
+            errors=errors,
+            warnings=warnings,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to load material preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return load_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/reset_material.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/reset_material.py
@@ -1,0 +1,59 @@
+"""Reset object material assignments to a default (or clear them)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import MATERIAL_ASSIGN_PARMS, get_node  # noqa: E402
+
+
+def reset_material(object_paths: List[str], default_material: str = "") -> dict:
+    """Set each object's material assignment to *default_material* (default empty)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if not object_paths:
+        return skill_error("No objects", "Provide at least one object path")
+
+    try:
+        affected = []
+        skipped = []
+        for path in object_paths:
+            node = get_node(hou, path)
+            applied = False
+            for parm_name in MATERIAL_ASSIGN_PARMS:
+                parm = node.parm(parm_name)
+                if parm is not None:
+                    parm.set(default_material)
+                    applied = True
+                    break
+            (affected if applied else skipped).append(node.path())
+        return skill_success(
+            "Reset material assignments",
+            default_material=default_material,
+            affected=affected,
+            skipped=skipped,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to reset material assignments")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return reset_material(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/save_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/save_preset.py
@@ -1,0 +1,78 @@
+"""Save a material's parameter values as an adapter-owned JSON preset."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, preset_dir  # noqa: E402
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _safe_name(name: str) -> str:
+    cleaned = _SAFE_NAME.sub("_", name).strip("_")
+    return cleaned or "preset"
+
+
+def save_preset(
+    material_path: str,
+    preset_name: str,
+    parm_names: Optional[List[str]] = None,
+) -> dict:
+    """Write a JSON preset of *material_path*'s parameter values."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, material_path)
+        parameters = {}
+        source_parms = node.parms()
+        wanted = set(parm_names) if parm_names else None
+        for parm in source_parms:
+            name = parm.name()
+            if wanted is not None and name not in wanted:
+                continue
+            try:
+                parameters[name] = parm.eval()
+            except Exception:  # noqa: BLE001
+                continue
+        payload = {
+            "preset_name": preset_name,
+            "material_type": node.type().name(),
+            "parameters": parameters,
+        }
+        target = preset_dir() / "{}.json".format(_safe_name(preset_name))
+        with open(target, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        return skill_success(
+            "Saved material preset",
+            preset_name=preset_name,
+            material_type=payload["material_type"],
+            parameter_count=len(parameters),
+            preset_path=str(target),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to save material preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return save_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/set_material_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/set_material_parms.py
@@ -1,0 +1,53 @@
+"""Set material/shader parameter values with type-aware coercion."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _lookdev_common import get_node, node_summary, set_parameters  # noqa: E402
+
+
+def set_material_parms(material_path: str, parameters: Dict[str, Any]) -> dict:
+    """Set the given parameters on the material at *material_path*."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, material_path)
+        applied, errors = set_parameters(node, parameters)
+        if not applied and errors:
+            return skill_error(
+                "No parameters set",
+                "All parameters failed validation",
+                material=node_summary(node),
+                errors=errors,
+            )
+        return skill_success(
+            "Set material parameters",
+            material=node_summary(node),
+            applied=applied,
+            errors=errors,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set material parameters")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_material_parms(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/tools.yaml
@@ -1,0 +1,256 @@
+tools:
+  - name: list_materials
+    description: List shader/material nodes under a material network (read-only).
+    source_file: scripts/list_materials.py
+    execution: sync
+    affinity: main
+    group: lookdev-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /mat
+  - name: list_assignments
+    description: List object → material assignments under a network (read-only).
+    source_file: scripts/list_assignments.py
+    execution: sync
+    affinity: main
+    group: lookdev-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+  - name: get_material_parms
+    description: Read parameter names and values for a material/shader node (read-only).
+    source_file: scripts/get_material_parms.py
+    execution: sync
+    affinity: main
+    group: lookdev-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path]
+      properties:
+        material_path:
+          type: string
+        name_filter:
+          type: string
+  - name: set_material_parms
+    description: Set material/shader parameter values with type-aware coercion.
+    source_file: scripts/set_material_parms.py
+    execution: sync
+    affinity: main
+    group: lookdev-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path, parameters]
+      properties:
+        material_path:
+          type: string
+        parameters:
+          type: object
+          description: name -> value (lists target parm tuples).
+  - name: get_shader_connections
+    description: Inspect a shader/VOP node's input and output connections (read-only).
+    source_file: scripts/get_shader_connections.py
+    execution: sync
+    affinity: main
+    group: lookdev-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+  - name: connect_shader
+    description: Wire a shader output into a shader/VOP node input (by index or name).
+    source_file: scripts/connect_shader.py
+    execution: sync
+    affinity: main
+    group: lookdev-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [node_path, source_path]
+      properties:
+        node_path:
+          type: string
+        source_path:
+          type: string
+        input_index:
+          type: integer
+        input_name:
+          type: string
+        source_output:
+          type: integer
+          default: 0
+  - name: disconnect_shader
+    description: Clear a shader/VOP node input slot.
+    source_file: scripts/disconnect_shader.py
+    execution: sync
+    affinity: main
+    group: lookdev-edit
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path, input_index]
+      properties:
+        node_path:
+          type: string
+        input_index:
+          type: integer
+  - name: reset_material
+    description: >-
+      Reset object material assignments to a default value (default empty) and
+      report affected/skipped objects.
+    source_file: scripts/reset_material.py
+    execution: sync
+    affinity: main
+    group: lookdev-edit
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [object_paths]
+      properties:
+        object_paths:
+          type: array
+          items: {type: string}
+          minItems: 1
+        default_material:
+          type: string
+          default: ""
+  - name: save_preset
+    description: Save a material's parameter values as an adapter-owned JSON preset.
+    source_file: scripts/save_preset.py
+    execution: sync
+    affinity: main
+    group: presets
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path, preset_name]
+      properties:
+        material_path:
+          type: string
+        preset_name:
+          type: string
+        parm_names:
+          type: array
+          items: {type: string}
+  - name: list_presets
+    description: List saved material presets (read-only, no Houdini required).
+    source_file: scripts/list_presets.py
+    execution: sync
+    affinity: any
+    group: presets
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties: {}
+  - name: load_preset
+    description: Apply a saved material preset onto a material/shader node.
+    source_file: scripts/load_preset.py
+    execution: sync
+    affinity: main
+    group: presets
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [preset_name, material_path]
+      properties:
+        preset_name:
+          type: string
+        material_path:
+          type: string
+  - name: delete_preset
+    description: Delete a saved material preset (no Houdini required).
+    source_file: scripts/delete_preset.py
+    execution: sync
+    affinity: any
+    group: presets
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [preset_name]
+      properties:
+        preset_name:
+          type: string

--- a/tests/test_lookdev_skills.py
+++ b/tests/test_lookdev_skills.py
@@ -1,0 +1,201 @@
+"""Mock-hou unit tests for the houdini-lookdev skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-lookdev" / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"lookdev_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = type_name
+    return node
+
+
+def _parm(name, value):
+    parm = MagicMock()
+    parm.name.return_value = name
+    parm.eval.return_value = value
+    return parm
+
+
+class TestLookdevQuery:
+    def test_list_materials(self) -> None:
+        mod = _load_script("list_materials.py")
+        clay = _node("/mat/clay", "clay", "principledshader::2.0")
+        clay.type.return_value.category.return_value.name.return_value = "Vop"
+        parent = _node("/mat", "mat", "matnet")
+        parent.children.return_value = [clay]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_materials("/mat")
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["materials"][0]["name"] == "clay"
+
+    def test_list_assignments(self) -> None:
+        mod = _load_script("list_assignments.py")
+        geo = _node("/obj/geo1", "geo1", "geo")
+        geo.parm.side_effect = lambda n: _parm(n, "/mat/clay") if n == "shop_materialpath" else None
+        empty = _node("/obj/geo2", "geo2", "geo")
+        empty.parm.side_effect = lambda n: _parm(n, "") if n == "shop_materialpath" else None
+        parent = _node("/obj", "obj")
+        parent.children.return_value = [geo, empty]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_assignments("/obj")
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["assignments"][0]["material"] == "/mat/clay"
+
+    def test_get_material_parms_filter(self) -> None:
+        mod = _load_script("get_material_parms.py")
+        node = _node("/mat/clay", "clay", "principledshader::2.0")
+        node.parms.return_value = [_parm("basecolorr", 0.8), _parm("rough", 0.5)]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_material_parms("/mat/clay", name_filter="rough")
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["parameters"][0]["name"] == "rough"
+
+    def test_get_shader_connections(self) -> None:
+        mod = _load_script("get_shader_connections.py")
+        src = _node("/mat/clay/tex", "tex", "texture")
+        node = _node("/mat/clay/surface", "surface", "principledshader")
+        node.inputNames.return_value = ["basecolor", "rough"]
+        node.inputs.return_value = [src, None]
+        node.outputs.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_shader_connections("/mat/clay/surface")
+        assert result["success"] is True
+        assert result["context"]["inputs"][0]["name"] == "basecolor"
+        assert result["context"]["inputs"][0]["source"] == "/mat/clay/tex"
+        assert result["context"]["inputs"][1]["source"] is None
+
+
+class TestLookdevEdit:
+    def test_set_material_parms_coerces(self) -> None:
+        mod = _load_script("set_material_parms.py")
+        tuple_parm = MagicMock()
+        scalar_parm = MagicMock()
+        scalar_parm.eval.return_value = 0.0
+        node = _node("/mat/clay", "clay", "principledshader::2.0")
+        node.parmTuple.side_effect = lambda n: tuple_parm if n == "basecolor" else None
+        node.parm.side_effect = lambda n: scalar_parm if n == "rough" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_material_parms("/mat/clay", {"basecolor": [0.8, 0.4, 0.2], "rough": 0.6})
+        assert result["success"] is True
+        tuple_parm.set.assert_called_once_with((0.8, 0.4, 0.2))
+        scalar_parm.set.assert_called_once_with(0.6)
+
+    def test_connect_shader_by_name(self) -> None:
+        mod = _load_script("connect_shader.py")
+        node = _node("/mat/clay/surface", "surface", "principledshader")
+        node.inputNames.return_value = ["basecolor", "rough"]
+        src = _node("/mat/clay/tex", "tex", "texture")
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/mat/clay/surface": node,
+            "/mat/clay/tex": src,
+        }[p]
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.connect_shader("/mat/clay/surface", "/mat/clay/tex", input_name="rough")
+        assert result["success"] is True
+        node.setInput.assert_called_once_with(1, src, 0)
+
+    def test_disconnect_shader(self) -> None:
+        mod = _load_script("disconnect_shader.py")
+        src = _node("/mat/clay/tex", "tex", "texture")
+        node = _node("/mat/clay/surface", "surface", "principledshader")
+        node.inputs.return_value = [src]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.disconnect_shader("/mat/clay/surface", 0)
+        assert result["success"] is True
+        node.setInput.assert_called_once_with(0, None)
+        assert result["context"]["previous_source"] == "/mat/clay/tex"
+
+    def test_reset_material(self) -> None:
+        mod = _load_script("reset_material.py")
+        parm = MagicMock()
+        geo = _node("/obj/geo1", "geo1", "geo")
+        geo.parm.side_effect = lambda n: parm if n == "shop_materialpath" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = geo
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.reset_material(["/obj/geo1"])
+        assert result["success"] is True
+        parm.set.assert_called_once_with("")
+        assert result["context"]["affected"] == ["/obj/geo1"]
+
+
+class TestPresets:
+    def test_save_list_load_delete_roundtrip(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR", str(tmp_path))
+
+        save_mod = _load_script("save_preset.py")
+        parm = _parm("rough", 0.6)
+        node = _node("/mat/clay", "clay", "principledshader::2.0")
+        node.parms.return_value = [parm]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            save_result = save_mod.save_preset("/mat/clay", "warm_clay")
+        assert save_result["success"] is True
+
+        list_mod = _load_script("list_presets.py")
+        list_result = list_mod.list_presets()
+        assert list_result["success"] is True
+        assert list_result["context"]["count"] == 1
+        assert list_result["context"]["presets"][0]["material_type"] == "principledshader::2.0"
+
+        load_mod = _load_script("load_preset.py")
+        target_parm = MagicMock()
+        target_parm.eval.return_value = 0.0
+        target = _node("/mat/clay2", "clay2", "principledshader::2.0")
+        target.parmTuple.return_value = None
+        target.parm.side_effect = lambda n: target_parm if n == "rough" else None
+        load_hou = MagicMock()
+        load_hou.node.return_value = target
+        with patch.dict(sys.modules, {"hou": load_hou}):
+            load_result = load_mod.load_preset("warm_clay", "/mat/clay2")
+        assert load_result["success"] is True
+        target_parm.set.assert_called_once_with(0.6)
+
+        delete_mod = _load_script("delete_preset.py")
+        delete_result = delete_mod.delete_preset("warm_clay")
+        assert delete_result["success"] is True
+        assert list_mod.list_presets()["context"]["count"] == 0
+
+    def test_load_missing_preset_errors(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR", str(tmp_path))
+        load_mod = _load_script("load_preset.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = load_mod.load_preset("nope", "/mat/clay")
+        assert result["success"] is False


### PR DESCRIPTION
## Summary

Closes #17. Adds the `houdini-lookdev` authoring skill, expanding material coverage beyond the existing `houdini-materials` (create/assign) into shader-network inspection, type-aware parameter editing, and a public material-preset store.

### Tool groups
- **`lookdev-query` (read-only):** `list_materials`, `list_assignments` (object → material), `get_material_parms` (with name filter), `get_shader_connections` (input names/sources + outputs).
- **`lookdev-edit`:** `set_material_parms` (type-aware coercion, per-parm error reporting), `connect_shader` (by input index **or** name), `disconnect_shader` (destructive), `reset_material` (clear or replace assignment, reports affected/skipped).
- **`presets`:** `save_preset` / `list_presets` / `load_preset` / `delete_preset` backed by a public adapter-owned JSON store under `~/.dcc-mcp/houdini/material_presets/` (override via `DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR`). `list_presets` / `delete_preset` are `affinity: any` (pure filesystem).

### Docs & design
- SKILL.md documents Karma/MaterialX/VOP context limitations (discover parm names via `get_material_parms` first; presets store evaluated values, not graphs; cross-type loads warn).
- Registered in the `authoring` stage; lookdev chain added to `skills/SKILLS_INDEX.md`.

## Test plan
- [x] `pytest tests/test_lookdev_skills.py` — 10 mock-hou tests: query tools, parm coercion, connect-by-name, disconnect, reset, and a full save→list→load→delete preset round-trip + missing-preset error.
- [x] `pytest tests/test_skills.py` — auto `validate_skill` + `tools.yaml` contract pass.
- [x] Full suite: `147 passed, 1 skipped, 1 deselected`.
- [ ] Live Houdini smoke (create → get/set parms → assign → save/load preset) — pending a licensed session.

> Note: branched off `main`; expect a trivial `_skill_loader.py` / `SKILLS_INDEX.md` rebase against #24–#29 once those land.
