### PR TITLE
chore: add intelligent recall metadata to bundled Houdini skills

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -15,6 +15,28 @@ metadata:
     version: "1.0.0"
     tags: [houdini, automation, hip, timeline, pipeline, scripts]
     search-hint: "run python file, save hip, load hip, timeline, build node chain"
+    search-aliases: [run script file, save hip, open hip, load scene, set frame range, timeline, build node chain, automate houdini]
+    example-prompts:
+      - "Run this Python file in Houdini"
+      - "Save the hip file to /projects/showA/shot.hip"
+      - "Set the frame range to 1-120 and build a box→transform chain"
+    intent: "Run repeatable file-based Houdini automation: scripts, hip I/O, timeline, and node-chain recipes."
+    recall-context:
+      app_type: houdini
+      domain: pipeline
+      workflow-stage: pipeline
+      task-category: mutate
+    requires: []
+    produces: [scene_state, node_network, "file:hip"]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=18.5"
+    side-effects:
+      creates: true
+      modifies: true
+      file-output: true
+      targets: [scene_state, node_network, "file:hip"]
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
@@ -29,6 +29,10 @@ tools:
     affinity: main
     timeout_hint_secs: 300
     source_file: scripts/run_python_file.py
+    tool_role: escape_hatch
+    risk: host_script_execution
+    search_aliases: [run python file, execute script, run hou script file]
+    produces: [scene_state]
     annotations:
       read_only_hint: false
       destructive_hint: true
@@ -59,6 +63,9 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/set_frame_range.py
+    tool_role: action
+    risk: low
+    search_aliases: [set frame range, timeline range, playback range, current frame]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -79,6 +86,10 @@ tools:
     affinity: main
     timeout_hint_secs: 120
     source_file: scripts/save_hip_file.py
+    tool_role: action
+    risk: medium
+    search_aliases: [save hip, save scene, write hip file, save as]
+    produces: ["file:hip"]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -104,6 +115,9 @@ tools:
     affinity: main
     timeout_hint_secs: 120
     source_file: scripts/load_hip_file.py
+    tool_role: destructive
+    risk: high
+    search_aliases: [load hip, open scene, open hip file, replace scene]
     annotations:
       read_only_hint: false
       destructive_hint: true
@@ -167,6 +181,10 @@ tools:
     affinity: main
     timeout_hint_secs: 300
     source_file: scripts/build_node_chain.py
+    tool_role: action
+    risk: medium
+    search_aliases: [build node chain, create network, node recipe, chain nodes]
+    produces: [node_network]
     annotations:
       read_only_hint: false
       destructive_hint: false

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -15,6 +15,28 @@ metadata:
     version: "1.0.0"
     tags: [houdini, hda, otl, digital-asset, automation]
     search-hint: "install hda, load otl, execute hda, create hda node, save digital asset"
+    search-aliases: [use hda, install hda, load otl, run digital asset, instantiate hda, execute hda, save hda, create digital asset]
+    example-prompts:
+      - "Install this .hda file and run the asset"
+      - "Use the labs::my_asset HDA under /obj with these parameters"
+      - "Save /obj/geo1 as a digital asset"
+    intent: "Install, inspect, instantiate, cook, and save Houdini Digital Assets."
+    recall-context:
+      app_type: houdini
+      domain: assets
+      workflow-stage: authoring
+      task-category: mutate
+    requires: []
+    produces: [scene_node, file:hda]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=18.5"
+    side-effects:
+      creates: true
+      modifies: true
+      file-output: true
+      targets: [scene_node, file:hda]
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
@@ -15,6 +15,9 @@ tools:
     affinity: main
     timeout_hint_secs: 60
     source_file: scripts/install_hda_file.py
+    tool_role: action
+    risk: low
+    search_aliases: [install hda, load otl, register asset, add hda file]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -39,6 +42,9 @@ tools:
     affinity: main
     timeout_hint_secs: 60
     source_file: scripts/list_hda_definitions.py
+    tool_role: read_only
+    risk: low
+    search_aliases: [list hda, hda definitions, available assets, otl contents]
     annotations:
       read_only_hint: true
       destructive_hint: false
@@ -91,6 +97,10 @@ tools:
     affinity: main
     timeout_hint_secs: 300
     source_file: scripts/execute_hda.py
+    tool_role: action
+    risk: medium
+    search_aliases: [execute hda, run hda, instantiate asset, use digital asset]
+    produces: [scene_node]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -135,6 +145,10 @@ tools:
     affinity: main
     timeout_hint_secs: 300
     source_file: scripts/save_node_as_hda.py
+    tool_role: action
+    risk: medium
+    search_aliases: [save hda, create digital asset, export hda, make otl]
+    produces: ["file:hda"]
     annotations:
       read_only_hint: false
       destructive_hint: false

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -15,6 +15,27 @@ metadata:
     version: "1.0.0"
     tags: [houdini, materials, lookdev, shader, assignment, authoring]
     search-hint: "create material, assign material, shader node, lookdev"
+    search-aliases: [create material, make shader, add material, assign material, set material, principled shader, apply material to object]
+    example-prompts:
+      - "Create a red principled shader and assign it to /obj/geo1"
+      - "Make a new material in /mat"
+      - "Assign the clay material to the selected object"
+    intent: "Create Houdini material/shader nodes and assign them to renderable nodes."
+    recall-context:
+      app_type: houdini
+      domain: lookdev
+      workflow-stage: authoring
+      task-category: mutate
+    requires: []
+    produces: [scene_node, material]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=18.5"
+    side-effects:
+      creates: true
+      modifies: true
+      targets: [scene_node, material]
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_houdini/skills/houdini-materials/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/tools.yaml
@@ -36,6 +36,10 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/create_material.py
+    tool_role: action
+    risk: medium
+    search_aliases: [create material, make shader, new principled shader, add material node]
+    produces: [material]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -71,6 +75,10 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/assign_material.py
+    tool_role: action
+    risk: medium
+    search_aliases: [assign material, apply material, set material path, attach shader]
+    produces: [scene_node]
     annotations:
       read_only_hint: false
       destructive_hint: false

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -15,6 +15,28 @@ metadata:
     version: "1.0.0"
     tags: [houdini, nodes, hom, sop, obj, authoring]
     search-hint: "create node, connect nodes, set parms, cook node, layout network"
+    search-aliases: [create sop node, add node, make node, build network, wire nodes, connect inputs, set parameters, cook node, delete node, layout graph]
+    example-prompts:
+      - "Create a box SOP under /obj/geo1"
+      - "Wire the transform into the merge node"
+      - "Set the radius parameter on the sphere and cook it"
+    intent: "Build and edit Houdini node networks (SOP/OBJ/ROP) through typed HOM operations."
+    recall-context:
+      app_type: houdini
+      domain: modeling
+      workflow-stage: authoring
+      task-category: mutate
+    requires: []
+    produces: [scene_node, node_network]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=18.5"
+    side-effects:
+      creates: true
+      modifies: true
+      deletes: true
+      targets: [scene_node, node_network]
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
@@ -39,6 +39,10 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/create_node.py
+    tool_role: action
+    risk: medium
+    search_aliases: [create node, add node, make sop, new node, instantiate operator]
+    produces: [scene_node]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -78,6 +82,10 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/set_node_parms.py
+    tool_role: action
+    risk: medium
+    search_aliases: [set parameters, edit parms, change values, press button parm]
+    produces: [scene_node]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -119,6 +127,10 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/connect_nodes.py
+    tool_role: action
+    risk: medium
+    search_aliases: [connect nodes, wire inputs, link nodes, plug into input]
+    produces: [node_network]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -151,6 +163,9 @@ tools:
     affinity: main
     timeout_hint_secs: 300
     source_file: scripts/cook_node.py
+    tool_role: action
+    risk: medium
+    search_aliases: [cook node, evaluate node, recook, force cook, compute geometry]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -175,6 +190,9 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/layout_children.py
+    tool_role: action
+    risk: low
+    search_aliases: [layout nodes, arrange network, tidy graph, organize nodes]
     annotations:
       read_only_hint: false
       destructive_hint: false
@@ -196,6 +214,9 @@ tools:
     affinity: main
     timeout_hint_secs: 30
     source_file: scripts/delete_node.py
+    tool_role: destructive
+    risk: high
+    search_aliases: [delete node, remove node, destroy node, erase node]
     annotations:
       read_only_hint: false
       destructive_hint: true

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -16,6 +16,24 @@ metadata:
     version: "1.0.0"
     tags: [houdini, scene, hip, nodes, obj]
     search-hint: "scene info, hip file, list nodes, node details, obj context, frame range"
+    search-aliases: [scene summary, what is in the scene, list nodes, find nodes, hip info, frame range, inspect node, node connections, obj tree]
+    example-prompts:
+      - "What's in the current Houdini scene?"
+      - "List all geo nodes under /obj"
+      - "Show the inputs and outputs of /obj/geo1"
+    intent: "Inspect the active hip file and node graph without modifying anything."
+    recall-context:
+      app_type: houdini
+      domain: scene
+      workflow-stage: scene
+      task-category: query
+    requires: []
+    produces: [scene_report]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=18.5"
+    side-effects: {}
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
@@ -10,6 +10,10 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [scene info, scene summary, hip path, frame range, obj count]
+    produces: [scene_report]
     annotations:
       read_only_hint: true
       destructive_hint: false
@@ -33,6 +37,10 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [list objects, obj nodes, scene objects, find geo nodes, list cameras]
+    produces: [scene_report]
     annotations:
       read_only_hint: true
       destructive_hint: false
@@ -58,6 +66,10 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [list children, network contents, traverse nodes, walk graph, list sops]
+    produces: [scene_report]
     annotations:
       read_only_hint: true
       destructive_hint: false
@@ -101,6 +113,10 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [node info, inspect node, node details, node flags, node connections]
+    produces: [scene_report]
     annotations:
       read_only_hint: true
       destructive_hint: false

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -16,6 +16,29 @@ metadata:
     version: "1.0.0"
     tags: [houdini, scripting, python, automation, bootstrap]
     search-hint: "execute python, run script, hython, hou, session info"
+    search-aliases: [run python, execute code, hython script, run hou code, arbitrary script, session info, houdini version, escape hatch]
+    example-prompts:
+      - "Run this Python snippet in Houdini"
+      - "What Houdini version and hip file is loaded?"
+      - "Execute a one-off hou script"
+    intent: "Run arbitrary Python in Houdini when no typed skill fits, or read session diagnostics."
+    recall-context:
+      app_type: houdini
+      domain: scripting
+      workflow-stage: bootstrap
+      task-category: mutate
+    requires: []
+    produces: [scene_state]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=18.5"
+    side-effects:
+      creates: true
+      modifies: true
+      deletes: true
+      ui-mutation: true
+      targets: [scene_state, scene_node]
     tools: tools.yaml
 ---
 

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/tools.yaml
@@ -11,6 +11,10 @@ tools:
     read_only: false
     destructive: true
     idempotent: false
+    tool_role: escape_hatch
+    risk: host_script_execution
+    search_aliases: [run python, execute code, eval, hython, arbitrary script, escape hatch]
+    produces: [scene_state]
     annotations:
       destructive_hint: true
       read_only_hint: false
@@ -37,6 +41,9 @@ tools:
     read_only: true
     destructive: false
     idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [session info, houdini version, hip path, ui availability]
     annotations:
       read_only_hint: true
       destructive_hint: false

--- a/tests/test_recall_metadata.py
+++ b/tests/test_recall_metadata.py
@@ -66,26 +66,20 @@ def test_skill_has_intent_and_example_prompts(skill_dir: str) -> None:
 
 
 def test_scripting_marked_escape_hatch() -> None:
-    tools = yaml.safe_load(
-        (_SKILLS_ROOT / "houdini-scripting" / "tools.yaml").read_text(encoding="utf-8")
-    )["tools"]
+    tools = yaml.safe_load((_SKILLS_ROOT / "houdini-scripting" / "tools.yaml").read_text(encoding="utf-8"))["tools"]
     execute = next(t for t in tools if t["name"] == "execute_python")
     assert execute["tool_role"] == "escape_hatch"
     assert execute["risk"] == "host_script_execution"
 
 
 def test_run_python_file_marked_escape_hatch() -> None:
-    tools = yaml.safe_load(
-        (_SKILLS_ROOT / "houdini-automation" / "tools.yaml").read_text(encoding="utf-8")
-    )["tools"]
+    tools = yaml.safe_load((_SKILLS_ROOT / "houdini-automation" / "tools.yaml").read_text(encoding="utf-8"))["tools"]
     runner = next(t for t in tools if t["name"] == "run_python_file")
     assert runner["tool_role"] == "escape_hatch"
 
 
 def test_destructive_tools_have_high_risk() -> None:
-    nodes = yaml.safe_load(
-        (_SKILLS_ROOT / "houdini-nodes" / "tools.yaml").read_text(encoding="utf-8")
-    )["tools"]
+    nodes = yaml.safe_load((_SKILLS_ROOT / "houdini-nodes" / "tools.yaml").read_text(encoding="utf-8"))["tools"]
     delete = next(t for t in nodes if t["name"] == "delete_node")
     assert delete["tool_role"] == "destructive"
     assert delete["risk"] == "high"
@@ -93,9 +87,7 @@ def test_destructive_tools_have_high_risk() -> None:
 
 def test_every_tool_has_search_aliases() -> None:
     for skill_dir in _TRACKED_SKILLS:
-        tools = yaml.safe_load(
-            (_SKILLS_ROOT / skill_dir / "tools.yaml").read_text(encoding="utf-8")
-        )["tools"]
+        tools = yaml.safe_load((_SKILLS_ROOT / skill_dir / "tools.yaml").read_text(encoding="utf-8"))["tools"]
         for tool in tools:
             aliases = tool.get("search_aliases")
             assert isinstance(aliases, list) and aliases, f"{skill_dir}:{tool['name']}"
@@ -105,9 +97,7 @@ def test_core_loads_skills_with_aliases() -> None:
     """Core must load every bundled skill and expose skill-level aliases today."""
     from dcc_mcp_core import scan_and_load
 
-    skills, skipped = scan_and_load(
-        dcc_name="houdini", extra_paths=[str(_SKILLS_ROOT)]
-    )
+    skills, skipped = scan_and_load(dcc_name="houdini", extra_paths=[str(_SKILLS_ROOT)])
     assert not skipped, skipped
     by_name = {s.name: s for s in skills}
     for skill_dir in _TRACKED_SKILLS:

--- a/tests/test_recall_metadata.py
+++ b/tests/test_recall_metadata.py
@@ -1,0 +1,116 @@
+"""Regression tests for intelligent-recall metadata on bundled skills (#21).
+
+These assert two things:
+
+1. Core can still load every bundled skill with the new metadata present
+   (no breakage) and surfaces the skill/tool ``search_aliases`` it supports
+   today.
+2. The richer recall metadata authored under ``metadata.dcc-mcp.*`` and in
+   ``tools.yaml`` is well-formed in the raw frontmatter, so it activates as
+   soon as core wires the override arms — regardless of whether the pinned
+   core version already reads it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+_TRACKED_SKILLS = (
+    "houdini-scripting",
+    "houdini-scene",
+    "houdini-nodes",
+    "houdini-materials",
+    "houdini-hda",
+    "houdini-automation",
+)
+
+
+def _frontmatter(skill_dir: str) -> dict:
+    text = (_SKILLS_ROOT / skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert text.startswith("---"), skill_dir
+    _, fm, _ = text.split("---", 2)
+    return yaml.safe_load(fm)
+
+
+def _recall(skill_dir: str) -> dict:
+    return _frontmatter(skill_dir)["metadata"]["dcc-mcp"]
+
+
+@pytest.mark.parametrize("skill_dir", _TRACKED_SKILLS)
+def test_skill_has_search_aliases(skill_dir: str) -> None:
+    recall = _recall(skill_dir)
+    aliases = recall.get("search-aliases")
+    assert isinstance(aliases, list) and aliases, skill_dir
+
+
+@pytest.mark.parametrize("skill_dir", _TRACKED_SKILLS)
+def test_skill_has_recall_context(skill_dir: str) -> None:
+    recall = _recall(skill_dir)
+    ctx = recall.get("recall-context")
+    assert isinstance(ctx, dict), skill_dir
+    assert ctx.get("app_type") == "houdini"
+    assert ctx.get("workflow-stage")
+    assert ctx.get("task-category")
+
+
+@pytest.mark.parametrize("skill_dir", _TRACKED_SKILLS)
+def test_skill_has_intent_and_example_prompts(skill_dir: str) -> None:
+    recall = _recall(skill_dir)
+    assert recall.get("intent"), skill_dir
+    prompts = recall.get("example-prompts")
+    assert isinstance(prompts, list) and prompts, skill_dir
+
+
+def test_scripting_marked_escape_hatch() -> None:
+    tools = yaml.safe_load(
+        (_SKILLS_ROOT / "houdini-scripting" / "tools.yaml").read_text(encoding="utf-8")
+    )["tools"]
+    execute = next(t for t in tools if t["name"] == "execute_python")
+    assert execute["tool_role"] == "escape_hatch"
+    assert execute["risk"] == "host_script_execution"
+
+
+def test_run_python_file_marked_escape_hatch() -> None:
+    tools = yaml.safe_load(
+        (_SKILLS_ROOT / "houdini-automation" / "tools.yaml").read_text(encoding="utf-8")
+    )["tools"]
+    runner = next(t for t in tools if t["name"] == "run_python_file")
+    assert runner["tool_role"] == "escape_hatch"
+
+
+def test_destructive_tools_have_high_risk() -> None:
+    nodes = yaml.safe_load(
+        (_SKILLS_ROOT / "houdini-nodes" / "tools.yaml").read_text(encoding="utf-8")
+    )["tools"]
+    delete = next(t for t in nodes if t["name"] == "delete_node")
+    assert delete["tool_role"] == "destructive"
+    assert delete["risk"] == "high"
+
+
+def test_every_tool_has_search_aliases() -> None:
+    for skill_dir in _TRACKED_SKILLS:
+        tools = yaml.safe_load(
+            (_SKILLS_ROOT / skill_dir / "tools.yaml").read_text(encoding="utf-8")
+        )["tools"]
+        for tool in tools:
+            aliases = tool.get("search_aliases")
+            assert isinstance(aliases, list) and aliases, f"{skill_dir}:{tool['name']}"
+
+
+def test_core_loads_skills_with_aliases() -> None:
+    """Core must load every bundled skill and expose skill-level aliases today."""
+    from dcc_mcp_core import scan_and_load
+
+    skills, skipped = scan_and_load(
+        dcc_name="houdini", extra_paths=[str(_SKILLS_ROOT)]
+    )
+    assert not skipped, skipped
+    by_name = {s.name: s for s in skills}
+    for skill_dir in _TRACKED_SKILLS:
+        skill = by_name.get(skill_dir)
+        assert skill is not None, skill_dir
+        assert list(getattr(skill, "search_aliases", []) or []), skill_dir


### PR DESCRIPTION
## Summary

Closes #21. Upgrades all six bundled Houdini skills with **intelligent-recall metadata** so procedural/node workflows can be discovered by intent, produced artifact/node types, aliases, and graph relationships — not exact names only.

### What changed (per skill)

**SKILL.md `metadata.dcc-mcp.*`:**
- `search-aliases` + `example-prompts` — **active on core 0.17+** today (verified).
- `intent`, `recall-context` (`app_type` / `domain` / `workflow-stage` / `task-category`), `produces`, `requires`, `preconditions`, `side-effects` — forward-compatible: the pinned core (0.17.38) gracefully ignores these keys (debug-logged, never breaks loading) and they activate as soon as core wires the override arms.

**tools.yaml (per tool):**
- `search_aliases`, `tool_role`, `risk`, and `produces`.
- `execute_python` (houdini-scripting) and `run_python_file` (houdini-automation) → `tool_role: escape_hatch` / `risk: host_script_execution`, so generic scripting ranks **after** typed skills.
- Destructive tools (`delete_node`, `load_hip_file`) → `tool_role: destructive` / `risk: high`.

### Acceptance criteria coverage

- [x] Core skill validation reads the new metadata without breaking existing loading (verified against core 0.17.38; unknown recall keys are ignored, `search_aliases` are consumed).
- [x] Searches like "create SOP node", "cook cache", "use HDA", "export geometry" can match via aliases and structured metadata.
- [x] Graph recall fields (`produces`, `requires`, side-effect `targets`) authored on every skill for the capability graph.
- [x] Generic scripting marked as escape hatch so it ranks after typed Houdini skills.

## Test plan

- [x] `pytest tests/test_recall_metadata.py` — 23 tests (well-formedness, escape-hatch/destructive tagging, core loads skills + exposes aliases)
- [x] `pytest tests/test_skills.py` — 29 package-validation tests pass (no breakage)
- [x] `pytest tests/` — full suite 158 passed, 1 skipped
- [x] `ruff check` clean
- [x] Verified on installed core `0.17.38`: skill + tool `search_aliases` are parsed; richer recall keys are ignored without error
