### PR TITLE
chore: fix pre-existing lint and add prek hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# Pre-commit / prek configuration for dcc-mcp-houdini.
+#
+# Compatible with both `pre-commit` and the faster Rust reimplementation `prek`.
+# Install hooks with `just prek-install` (or `vx prek install`); run on demand
+# with `just prek` (or `vx prek run --all-files`). The hooks mirror the CI
+# `lint` job (ruff check, ruff format, bundled-skill validation, py37 syntax).
+default_language_version:
+  python: python3.11
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch # prevent direct commits to main branch
+      - id: check-yaml
+        args: ["--unsafe"] # tolerate SKILL.md tools.yaml custom tags
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  # Python lint + format (ruff) — keep rev in sync with pyproject + CI.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^(src|tests|tools|packaging)/
+      - id: ruff-format
+        files: ^(src|tests|tools|packaging)/
+
+  # Project-specific validators — mirror the CI `lint` job.
+  - repo: local
+    hooks:
+      - id: lint-skills
+        name: validate bundled skills (SKILL.md / tools.yaml)
+        entry: python tools/lint_skills.py --warnings-as-errors
+        language: system
+        pass_filenames: false
+        files: ^src/dcc_mcp_houdini/skills/
+      - id: check-py37-syntax
+        name: Python 3.7 syntax check
+        entry: python tools/check_py37_syntax.py src tests tools packaging
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/justfile
+++ b/justfile
@@ -7,6 +7,8 @@
 #   just test                               — pytest
 #   just lint                               — ruff check
 #   just lint-all                           — ruff + skill metadata + py37 syntax
+#   just prek-install                       — install git hooks (vx prek)
+#   just prek                               — run all hooks on every file
 #   just houdini-version=20.5 houdini-dev-build-link-core-win  — build core + symlink (Windows)
 #
 # Cross-platform: uses sh on Unix/macOS, pwsh on Windows for dev-* commands.
@@ -129,6 +131,14 @@ format:
     ruff format src/ tests/ tools/ packaging/
 
 lint-all: lint lint-format lint-skills check-py37-syntax
+
+# Install git hooks from .pre-commit-config.yaml (uses prek, falls back to pre-commit)
+prek-install:
+    vx prek install --install-hooks
+
+# Run all pre-commit/prek hooks against every file (mirrors the CI lint job)
+prek:
+    vx prek run --all-files
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 

--- a/src/dcc_mcp_houdini/_qt_inspector.py
+++ b/src/dcc_mcp_houdini/_qt_inspector.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from dcc_mcp_houdini._env import ENV_QT_UI_INSPECTOR, resolve_qt_ui_inspector_enabled
 
@@ -76,7 +76,9 @@ def _make_marshaller(dispatcher: Any) -> Callable[[Callable[[], Any]], Any]:
     return _marshal
 
 
-def _wrap_main_thread(handler: Callable[[Any], Any], marshal: Callable[[Callable[[], Any]], Any]) -> Callable[[Any], Any]:
+def _wrap_main_thread(
+    handler: Callable[[Any], Any], marshal: Callable[[Callable[[], Any]], Any]
+) -> Callable[[Any], Any]:
     def wrapper(params: Any) -> Any:
         return marshal(lambda: handler(params))
 

--- a/src/dcc_mcp_houdini/_resources.py
+++ b/src/dcc_mcp_houdini/_resources.py
@@ -84,7 +84,7 @@ def _parse_path_uri(uri: str, *, scheme: str) -> Optional[List[str]]:
     """Strip *scheme* prefix and split the rest on ``/`` (empty parts skipped)."""
     if not uri.startswith(scheme):
         return None
-    tail = uri[len(scheme):]
+    tail = uri[len(scheme) :]
     return [p for p in tail.split("/") if p]
 
 

--- a/tests/test_qt_inspector.py
+++ b/tests/test_qt_inspector.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, List
 
 import pytest
 
-from dcc_mcp_houdini import _qt_inspector
 from dcc_mcp_houdini._qt_inspector import (
     ENV_QT_UI_INSPECTOR,
     _MainThreadHandlerProxy,

--- a/tools/houdini-link-win.ps1
+++ b/tools/houdini-link-win.ps1
@@ -58,7 +58,7 @@ $CoreRepo = Resolve-Path "$ProjectRoot\..\dcc-mcp-core" -ErrorAction SilentlyCon
 if ($CoreRepo) {
     $CoreSource = "$CoreRepo\python\dcc_mcp_core"
     $CoreTarget = "$SitePackages\dcc_mcp_core"
-    
+
     if (Test-Path $CoreSource) {
         if (Test-Path $CoreTarget) {
             Remove-Item $CoreTarget -Recurse -Force

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -11,7 +11,11 @@ import sys
 from typing import List, Optional
 
 import yaml
-from dcc_mcp_core import validate_skill
+
+try:  # dcc-mcp-core is a runtime dep, but keep the structural linter usable without it
+    from dcc_mcp_core import validate_skill
+except ImportError:  # pragma: no cover - exercised only in lean (prek) environments
+    validate_skill = None
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_SKILLS_DIR = ROOT / "src" / "dcc_mcp_houdini" / "skills"
@@ -96,71 +100,130 @@ def lint_skills(
     use_cli: bool = True,
     warnings_as_errors: bool = False,
 ) -> List[str]:
-    """Return validation errors for all bundled skill directories."""
+    """Return validation errors for all bundled skill directories.
+
+    The generic SKILL.md / tools.yaml contract is validated by dcc-mcp-core,
+    which is the authoritative source of truth. Precision order:
+
+    1. ``dcc-mcp-cli lint`` — the standalone binary; matches the runtime loader
+       exactly and is the most precise (preferred locally).
+    2. ``dcc_mcp_core.validate_skill`` — the same Rust validator exposed through
+       the Python API (used in CI, where the wheel is installed but the CLI
+       binary is not).
+    3. Built-in structural heuristics — last-resort fallback when neither
+       dcc-mcp-cli nor dcc-mcp-core is importable (lean prek environments).
+
+    On top of whichever generic validator runs, Houdini-specific conventions
+    (lazy ``hou`` import, ``scripts/`` layout) are always enforced.
+    """
     errors: List[str] = []
-    if use_cli:
-        cli_errors = lint_skills_with_cli(skills_dir, warnings_as_errors=warnings_as_errors)
-        if cli_errors is not None:
-            errors.extend(cli_errors)
 
     skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir()]
     if not skill_dirs:
         return ["No skill directories found under {}".format(skills_dir)]
 
+    cli_errors = lint_skills_with_cli(skills_dir, warnings_as_errors=warnings_as_errors) if use_cli else None
+    if cli_errors is not None:
+        generic_mode = "cli"
+        errors.extend(cli_errors)
+    elif validate_skill is not None:
+        generic_mode = "core"
+    else:
+        generic_mode = "builtin"
+        print(
+            "notice: dcc-mcp-cli and dcc-mcp-core are both unavailable; "
+            "ran built-in structural checks only (install dcc-mcp-core for precise validation)",
+            file=sys.stderr,
+        )
+
     for skill_dir in sorted(skill_dirs):
-        skill_md = skill_dir / "SKILL.md"
-        if not skill_md.exists():
-            errors.append("{}: missing SKILL.md".format(skill_dir.name))
-            continue
-
-        try:
-            front = _parse_front_matter(skill_md.read_text(encoding="utf-8"))
-        except yaml.YAMLError as exc:
-            errors.append("{}: YAML parse error: {}".format(skill_dir.name, exc))
-            continue
-
-        if not front:
-            errors.append("{}: empty or missing front matter".format(skill_dir.name))
-            continue
-
-        report = validate_skill(str(skill_dir))
-        if report.has_errors:
-            for issue in report.issues:
-                errors.append("{}: {}: {}".format(skill_dir.name, issue.category, issue.message))
-
-        missing = REQUIRED_FIELDS - set(front.keys())
-        if missing:
-            errors.append("{}: missing fields: {}".format(skill_dir.name, sorted(missing)))
-
-        dcc_mcp = front.get("metadata", {}).get("dcc-mcp", {})
-        missing_dcc_mcp = REQUIRED_DCC_MCP_FIELDS - set(dcc_mcp.keys())
-        if missing_dcc_mcp:
-            errors.append("{}: missing metadata.dcc-mcp fields: {}".format(skill_dir.name, sorted(missing_dcc_mcp)))
-            continue
-
-        tools_file = skill_dir / str(dcc_mcp.get("tools", ""))
-        if not tools_file.exists():
-            errors.append("{}: tools file not found: {}".format(skill_dir.name, dcc_mcp.get("tools")))
-            continue
-
-        try:
-            tools_doc = yaml.safe_load(tools_file.read_text(encoding="utf-8")) or {}
-        except yaml.YAMLError as exc:
-            errors.append("{}: tools YAML parse error: {}".format(skill_dir.name, exc))
-            continue
-
-        tools = tools_doc.get("tools", [])
-        if not isinstance(tools, list) or not tools:
-            errors.append("{}: tools file must contain a non-empty 'tools' list".format(skill_dir.name))
-            continue
-
-        for tool in tools:
-            _lint_tool(skill_dir, tool, errors)
+        _lint_skill_dir(skill_dir, errors, generic_mode=generic_mode)
 
     return errors
 
 
-def _lint_tool(skill_dir: pathlib.Path, tool: dict, errors: List[str]) -> None:
+def _lint_skill_dir(skill_dir: pathlib.Path, errors: List[str], *, generic_mode: str) -> None:
+    name = skill_dir.name
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        # The CLI already reports missing SKILL.md; only surface it ourselves otherwise.
+        if generic_mode != "cli":
+            errors.append("{}: missing SKILL.md".format(name))
+        return
+
+    try:
+        front = _parse_front_matter(skill_md.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        if generic_mode != "cli":
+            errors.append("{}: YAML parse error: {}".format(name, exc))
+        return
+
+    if not front:
+        if generic_mode != "cli":
+            errors.append("{}: empty or missing front matter".format(name))
+        return
+
+    # Generic contract validation — delegate to dcc-mcp-core when possible.
+    if generic_mode == "core":
+        report = validate_skill(str(skill_dir))
+        if report.has_errors:
+            for issue in report.issues:
+                errors.append("{}: {}: {}".format(name, issue.category, issue.message))
+    elif generic_mode == "builtin":
+        _lint_builtin_contract(skill_dir, front, errors)
+
+    # Houdini-specific conventions always run, regardless of the generic validator.
+    _lint_houdini_conventions(skill_dir, front, errors)
+
+
+def _lint_builtin_contract(skill_dir: pathlib.Path, front: dict, errors: List[str]) -> None:
+    """Last-resort structural checks used only when dcc-mcp-core is unavailable."""
+    name = skill_dir.name
+    missing = REQUIRED_FIELDS - set(front.keys())
+    if missing:
+        errors.append("{}: missing fields: {}".format(name, sorted(missing)))
+
+    dcc_mcp = front.get("metadata", {}).get("dcc-mcp", {})
+    missing_dcc_mcp = REQUIRED_DCC_MCP_FIELDS - set(dcc_mcp.keys())
+    if missing_dcc_mcp:
+        errors.append("{}: missing metadata.dcc-mcp fields: {}".format(name, sorted(missing_dcc_mcp)))
+        return
+
+    tools_file = skill_dir / str(dcc_mcp.get("tools", ""))
+    if not tools_file.exists():
+        errors.append("{}: tools file not found: {}".format(name, dcc_mcp.get("tools")))
+        return
+
+    try:
+        tools_doc = yaml.safe_load(tools_file.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        errors.append("{}: tools YAML parse error: {}".format(name, exc))
+        return
+
+    tools = tools_doc.get("tools", [])
+    if not isinstance(tools, list) or not tools:
+        errors.append("{}: tools file must contain a non-empty 'tools' list".format(name))
+        return
+
+    for tool in tools:
+        _lint_tool_contract(skill_dir, tool, errors)
+
+
+def _load_tools(skill_dir: pathlib.Path, front: dict) -> List[dict]:
+    """Best-effort load of the tools.yaml list; returns [] on any problem."""
+    dcc_mcp = front.get("metadata", {}).get("dcc-mcp", {})
+    tools_file = skill_dir / str(dcc_mcp.get("tools", ""))
+    if not tools_file.exists():
+        return []
+    try:
+        tools_doc = yaml.safe_load(tools_file.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return []
+    tools = tools_doc.get("tools", [])
+    return tools if isinstance(tools, list) else []
+
+
+def _lint_tool_contract(skill_dir: pathlib.Path, tool: dict, errors: List[str]) -> None:
     tool_name = tool.get("name", "?")
     missing_tool = REQUIRED_TOOL_FIELDS - set(tool.keys())
     if missing_tool:
@@ -185,20 +248,29 @@ def _lint_tool(skill_dir: pathlib.Path, tool: dict, errors: List[str]) -> None:
     if source_file and pathlib.PurePosixPath(source_file).parts[:1] != ("scripts",):
         errors.append("{}/{}: source_file must be under scripts/: {}".format(skill_dir.name, tool_name, source_file))
 
-    source = skill_dir / source_file
-    if not source.exists():
-        errors.append("{}: source_file not found: {}".format(skill_dir.name, source_file))
-        return
 
-    try:
-        script_text = source.read_text(encoding="utf-8")
-    except UnicodeDecodeError as exc:
-        errors.append("{}/{}: could not read source file as UTF-8: {}".format(skill_dir.name, tool_name, exc))
-        return
+def _lint_houdini_conventions(skill_dir: pathlib.Path, front: dict, errors: List[str]) -> None:
+    """Houdini-specific rules dcc-mcp-core does not enforce (lazy ``hou`` import)."""
+    for tool in _load_tools(skill_dir, front):
+        tool_name = tool.get("name", "?")
+        source_file = tool.get("source_file", "")
+        if not source_file:
+            continue
+        source = skill_dir / source_file
+        if not source.exists():
+            continue  # missing source is reported by the generic contract validator
 
-    for forbidden in ("import hou", "from hou"):
-        if any(line.startswith(forbidden) for line in script_text.splitlines()):
-            errors.append("{}/{}: hou import must be lazy inside the tool function".format(skill_dir.name, tool_name))
+        try:
+            script_text = source.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            errors.append("{}/{}: could not read source file as UTF-8: {}".format(skill_dir.name, tool_name, exc))
+            continue
+
+        for forbidden in ("import hou", "from hou"):
+            if any(line.startswith(forbidden) for line in script_text.splitlines()):
+                errors.append(
+                    "{}/{}: hou import must be lazy inside the tool function".format(skill_dir.name, tool_name)
+                )
 
 
 def main(argv: Optional[List[str]] = None) -> int:


### PR DESCRIPTION
## Summary

`main` was lint-broken, so the CI `lint` job (and the editor lint surface)
showed errors on **every** open skill PR. This fixes the root cause and adds a
pre-commit/prek guard so it cannot recur.

- **Fix pre-existing lint on `main`** so all stacked PRs go green once rebased:
  - `ruff check`: remove unused imports (`_qt_inspector.py`, `tests/test_qt_inspector.py`)
  - `ruff format`: reformat `_qt_inspector.py`, `_resources.py`
  - trim trailing whitespace in `tools/houdini-link-win.ps1`
- **Add `.pre-commit-config.yaml`** (works with both `pre-commit` and the faster
  Rust `prek`) mirroring the CI lint job: standard hooks + `ruff` + `ruff-format`
  + local `lint-skills` and `check-py37-syntax`.
- **Add `just prek` / `just prek-install`** recipes (`vx prek`).
- **Make `tools/lint_skills.py` delegate to dcc-mcp-core's authoritative
  validator** for precision: `dcc-mcp-cli lint` when the binary is present, else
  the `dcc_mcp_core.validate_skill` Python API (used in CI), with the built-in
  structural heuristics kept only as a last-resort fallback when neither is
  available. Houdini-specific conventions (lazy `hou` import) always run on top.

## Test plan

- [x] `ruff check src/ tests/ tools/ packaging/` — clean
- [x] `ruff format --check src/ tests/ tools/ packaging/` — clean
- [x] `python tools/lint_skills.py --warnings-as-errors` — valid (CLI + core modes)
- [x] `python tools/check_py37_syntax.py src tests tools packaging` — passes
- [x] `vx prek run --all-files` — all hooks pass
- [x] `python -m pytest` — 135 passed, 1 skipped
