### PR TITLE
feat(lint): validate bundled skills with the dcc-mcp-cli runtime validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,12 @@ jobs:
         run: ruff check src/ tests/ tools/ packaging/
       - name: Ruff format check
         run: ruff format --check src/ tests/ tools/ packaging/
-      - name: Validate bundled skills
-        run: python tools/lint_skills.py --warnings-as-errors
+      - name: Install dcc-mcp-cli (runtime skill validator)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python tools/install_dcc_mcp_cli.py
+      - name: Validate bundled skills (dcc-mcp-cli)
+        run: python tools/lint_skills.py --require-cli --warnings-as-errors
       - name: Python 3.7 syntax check
         run: python tools/check_py37_syntax.py src tests tools packaging
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ htmlcov/
 
 # Just
 .justfile-recipe-cmd*
+
+# Downloaded dev tools (dcc-mcp-cli binary fetched by tools/install_dcc_mcp_cli.py)
+.tools-bin/

--- a/justfile
+++ b/justfile
@@ -121,6 +121,14 @@ lint-format:
 lint-skills:
     python tools/lint_skills.py --warnings-as-errors
 
+# Download the standalone dcc-mcp-cli runtime validator into .tools-bin/
+install-cli:
+    python tools/install_dcc_mcp_cli.py
+
+# Validate skills with the authoritative dcc-mcp-cli binary (matches CI exactly)
+lint-skills-cli:
+    python tools/lint_skills.py --require-cli --warnings-as-errors
+
 check-py37-syntax:
     python tools/check_py37_syntax.py src tests tools packaging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,20 @@ line-length = 120
 target-version = "py37"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "B", "C4"]
+# Rule families kept deliberately py37-safe. Broader families such as `UP`
+# (pyupgrade) are intentionally excluded: with target-version = py37 they force
+# runtime-unsafe PEP 585/604 annotation rewrites (list[...]/X | None) and a
+# repo-wide .format -> f-string churn. Skill packages get their own, stronger,
+# runtime-accurate validation via dcc-mcp-cli (see tools/lint_skills.py).
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "W",    # pycodestyle warnings
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "PIE",  # flake8-pie (small, py37-safe simplifications)
+]
 ignore = [
     "E501",   # line too long (handled by formatter)
     "B008",   # Do not perform function calls in default arguments

--- a/src/dcc_mcp_houdini/_capability_manifest.py
+++ b/src/dcc_mcp_houdini/_capability_manifest.py
@@ -470,7 +470,7 @@ def _slugify_tool_slug(dcc_name: str, tool_name: str) -> str:
 
 
 def _is_stub(name: str) -> bool:
-    return name.startswith(_SKILL_STUB_PREFIX) or name.startswith(_GROUP_STUB_PREFIX)
+    return name.startswith((_SKILL_STUB_PREFIX, _GROUP_STUB_PREFIX))
 
 
 def _derive_skill(tool_name: str) -> Optional[str]:

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -70,8 +70,8 @@ def _skill(name: str, *, tags: List[str] = None, summary: str = "") -> Dict[str,
 
 def test_builder_empty_catalog_returns_empty_records():
     builder = HoudiniCapabilityManifestBuilder(
-        skill_lister=lambda: [],
-        action_lister=lambda: [],
+        skill_lister=list,
+        action_lister=list,
         is_loaded=lambda _: False,
     )
     assert builder.build() == []
@@ -152,7 +152,7 @@ def test_builder_truncates_long_summary():
 def test_builder_infers_skill_from_tool_name_convention():
     actions = [_action("houdini_scene__get_scene_info")]
     builder = HoudiniCapabilityManifestBuilder(
-        skill_lister=lambda: [],
+        skill_lister=list,
         action_lister=lambda: actions,
         is_loaded=lambda _: False,
     )

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -1,0 +1,104 @@
+"""Unit tests for the bundled-skill linter wrapper (``tools/lint_skills.py``).
+
+These focus on the dcc-mcp-cli integration the runtime loader relies on:
+parsing the CLI's structured JSON report and the ``--require-cli`` guard that
+keeps CI from silently dropping to a weaker validator.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import types
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_SPEC = importlib.util.spec_from_file_location("lint_skills_under_test", ROOT / "tools" / "lint_skills.py")
+lint_skills = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(lint_skills)  # type: ignore[union-attr]
+
+
+def _fake_completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["dcc-mcp-cli"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_require_cli_fails_when_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lint_skills, "_find_dcc_mcp_cli", lambda: None)
+
+    errors = lint_skills.lint_skills(require_cli=True)
+
+    assert len(errors) == 1
+    assert "dcc-mcp-cli is required" in errors[0]
+
+
+def test_cli_result_parses_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = (
+        '{"checked": 3, "errors": 0, "warnings": 0, "failed": false, '
+        '"reports": [{"skill_dir": "houdini-scene", "issues": [], "errors": 0, "warnings": 0}]}'
+    )
+    monkeypatch.setattr(lint_skills, "_find_dcc_mcp_cli", lambda: "dcc-mcp-cli")
+    monkeypatch.setattr(lint_skills, "_dcc_mcp_cli_version", lambda _cli: "dcc-mcp-cli 9.9.9")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(payload))
+
+    result = lint_skills.lint_skills_with_cli(pathlib.Path("skills"))
+
+    assert result is not None
+    assert result.errors == []
+    assert result.checked == 3
+    assert result.failed is False
+    assert result.version == "dcc-mcp-cli 9.9.9"
+
+
+def test_cli_result_surfaces_errors_and_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = (
+        '{"checked": 1, "errors": 1, "warnings": 0, "failed": true, '
+        '"reports": [{"skill_dir": "houdini-broken", "errors": 1, "warnings": 0, '
+        '"issues": [{"severity": "error", "category": "schema", "message": "missing tools"}]}]}'
+    )
+    monkeypatch.setattr(lint_skills, "_find_dcc_mcp_cli", lambda: "dcc-mcp-cli")
+    monkeypatch.setattr(lint_skills, "_dcc_mcp_cli_version", lambda _cli: "")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(payload, returncode=1))
+
+    result = lint_skills.lint_skills_with_cli(pathlib.Path("skills"))
+
+    assert result is not None
+    assert result.failed is True
+    assert result.error_count == 1
+    assert any("missing tools" in e for e in result.errors)
+
+
+def test_cli_warnings_promoted_when_warnings_as_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = (
+        '{"checked": 1, "errors": 0, "warnings": 1, "failed": true, '
+        '"reports": [{"skill_dir": "houdini-warn", "errors": 0, "warnings": 1, '
+        '"issues": [{"severity": "warning", "category": "style", "message": "prefer lazy import"}]}]}'
+    )
+    monkeypatch.setattr(lint_skills, "_find_dcc_mcp_cli", lambda: "dcc-mcp-cli")
+    monkeypatch.setattr(lint_skills, "_dcc_mcp_cli_version", lambda _cli: "")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed(payload, returncode=1))
+
+    result = lint_skills.lint_skills_with_cli(pathlib.Path("skills"), warnings_as_errors=True)
+
+    assert result is not None
+    assert result.warning_count == 1
+    assert any("prefer lazy import" in e for e in result.errors)
+
+
+def test_non_json_cli_output_is_treated_as_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lint_skills, "_find_dcc_mcp_cli", lambda: "dcc-mcp-cli")
+    monkeypatch.setattr(lint_skills, "_dcc_mcp_cli_version", lambda _cli: "")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_completed("panic: boom", returncode=101))
+
+    result = lint_skills.lint_skills_with_cli(pathlib.Path("skills"))
+
+    assert result is not None
+    assert result.failed is True
+    assert result.errors == ["panic: boom"]
+
+
+def test_module_exposes_expected_symbols() -> None:
+    assert isinstance(lint_skills, types.ModuleType)
+    assert hasattr(lint_skills, "CliLintResult")
+    assert hasattr(lint_skills, "lint_skills_with_cli")

--- a/tools/install_dcc_mcp_cli.py
+++ b/tools/install_dcc_mcp_cli.py
@@ -1,0 +1,140 @@
+"""Download the standalone ``dcc-mcp-cli`` binary from dcc-mcp-core releases.
+
+The skill linter (:mod:`tools.lint_skills`) prefers the standalone
+``dcc-mcp-cli`` binary because it is the exact validator the runtime skill
+loader uses. The binary is published as a per-platform asset on the
+``loonghao/dcc-mcp-core`` GitHub releases, so CI and contributors can fetch it
+with nothing more than the Python standard library.
+
+Usage::
+
+    python tools/install_dcc_mcp_cli.py                 # latest release -> ./.tools-bin
+    python tools/install_dcc_mcp_cli.py --tag v0.17.47  # pin a release
+    python tools/install_dcc_mcp_cli.py --install-dir /usr/local/bin
+
+When ``GITHUB_PATH`` is set (i.e. inside GitHub Actions) the install directory
+is appended to it automatically so later steps find the binary on ``PATH``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import stat
+import sys
+import urllib.error
+import urllib.request
+from typing import Optional
+
+REPO = "loonghao/dcc-mcp-core"
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_INSTALL_DIR = ROOT / ".tools-bin"
+
+
+def _asset_name() -> str:
+    """Return the release asset name for the current platform."""
+    platform = sys.platform
+    if platform == "win32":
+        return "dcc-mcp-cli-windows-x86_64.exe"
+    if platform == "darwin":
+        return "dcc-mcp-cli-macos-universal2"
+    if platform.startswith("linux"):
+        return "dcc-mcp-cli-linux-x86_64"
+    raise SystemExit(f"unsupported platform: {platform!r}")
+
+
+def _binary_name() -> str:
+    return "dcc-mcp-cli.exe" if sys.platform == "win32" else "dcc-mcp-cli"
+
+
+def _request(url: str) -> urllib.request.Request:
+    headers = {"Accept": "application/json", "User-Agent": "dcc-mcp-houdini-installer"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def _release_api_url(tag: Optional[str]) -> str:
+    if tag:
+        return f"https://api.github.com/repos/{REPO}/releases/tags/{tag}"
+    return f"https://api.github.com/repos/{REPO}/releases/latest"
+
+
+def _resolve_download_url(tag: Optional[str], asset_name: str) -> str:
+    api_url = _release_api_url(tag)
+    try:
+        with urllib.request.urlopen(_request(api_url), timeout=60) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
+        raise SystemExit(f"failed to query {api_url}: HTTP {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+        raise SystemExit(f"failed to query {api_url}: {exc.reason}") from exc
+
+    for asset in payload.get("assets", []):
+        if asset.get("name") == asset_name:
+            return asset["browser_download_url"]
+
+    available = ", ".join(sorted(a.get("name", "?") for a in payload.get("assets", [])))
+    raise SystemExit(f"asset {asset_name!r} not found in release {payload.get('tag_name')!r}. available: {available}")
+
+
+def _download(url: str, dest: pathlib.Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        with urllib.request.urlopen(_request(url), timeout=300) as resp, tmp.open("wb") as fh:
+            while True:
+                chunk = resp.read(1 << 16)
+                if not chunk:
+                    break
+                fh.write(chunk)
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:  # pragma: no cover - network failure path
+        raise SystemExit(f"failed to download {url}: {exc}") from exc
+    tmp.replace(dest)
+
+
+def _make_executable(path: pathlib.Path) -> None:
+    if sys.platform == "win32":
+        return
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _export_to_github_path(install_dir: pathlib.Path) -> None:
+    github_path = os.environ.get("GITHUB_PATH")
+    if not github_path:
+        return
+    with open(github_path, "a", encoding="utf-8") as fh:
+        fh.write(str(install_dir) + "\n")
+    print(f"added {install_dir} to GITHUB_PATH")
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", default=None, help="Release tag to pin (default: latest release).")
+    parser.add_argument(
+        "--install-dir",
+        type=pathlib.Path,
+        default=DEFAULT_INSTALL_DIR,
+        help=f"Directory to install the binary into (default: {DEFAULT_INSTALL_DIR}).",
+    )
+    args = parser.parse_args(argv)
+
+    asset_name = _asset_name()
+    dest = args.install_dir / _binary_name()
+
+    url = _resolve_download_url(args.tag, asset_name)
+    print(f"downloading {asset_name} -> {dest}")
+    _download(url, dest)
+    _make_executable(dest)
+    _export_to_github_path(args.install_dir)
+
+    print(f"installed dcc-mcp-cli at {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -49,8 +49,44 @@ def _find_dcc_mcp_cli() -> Optional[str]:
     return None
 
 
-def lint_skills_with_cli(skills_dir: pathlib.Path, warnings_as_errors: bool = False) -> Optional[List[str]]:
-    """Run the standalone dcc-mcp-cli linter when it is installed."""
+class CliLintResult:
+    """Structured outcome of a ``dcc-mcp-cli lint`` invocation."""
+
+    def __init__(
+        self,
+        *,
+        errors: List[str],
+        checked: int = 0,
+        error_count: int = 0,
+        warning_count: int = 0,
+        failed: bool = False,
+        version: str = "",
+    ) -> None:
+        self.errors = errors
+        self.checked = checked
+        self.error_count = error_count
+        self.warning_count = warning_count
+        self.failed = failed
+        self.version = version
+
+
+def _dcc_mcp_cli_version(cli: str) -> str:
+    try:
+        proc = subprocess.run([cli, "--version"], check=False, capture_output=True, text=True)
+    except OSError:
+        return ""
+    return (proc.stdout or proc.stderr).strip()
+
+
+def lint_skills_with_cli(skills_dir: pathlib.Path, warnings_as_errors: bool = False) -> Optional[CliLintResult]:
+    """Run the standalone dcc-mcp-cli linter when it is installed.
+
+    Returns ``None`` when the CLI is not available so callers can fall back to
+    the in-process ``dcc-mcp-core`` validator. Otherwise the parsed
+    :class:`CliLintResult` carries the human-readable errors plus the structured
+    counts the CLI reports (``checked`` / ``errors`` / ``warnings`` / ``failed``)
+    so the caller can surface an accurate summary.
+    """
     cli = _find_dcc_mcp_cli()
     if cli is None:
         return None
@@ -61,12 +97,14 @@ def lint_skills_with_cli(skills_dir: pathlib.Path, warnings_as_errors: bool = Fa
     cmd.append(str(skills_dir))
     proc = subprocess.run(cmd, cwd=str(ROOT), check=False, capture_output=True, text=True)
     output = (proc.stdout or proc.stderr).strip()
+    version = _dcc_mcp_cli_version(cli)
     try:
         payload = json.loads(output) if output else {}
     except json.JSONDecodeError:
-        return (
-            [output or "dcc-mcp-cli lint failed with exit code {}".format(proc.returncode)] if proc.returncode else []
-        )
+        # The CLI did not emit JSON (older build or hard failure): treat any
+        # non-zero exit as a single opaque error so CI still fails loudly.
+        message = output or "dcc-mcp-cli lint failed with exit code {}".format(proc.returncode)
+        return CliLintResult(errors=[message] if proc.returncode else [], failed=bool(proc.returncode), version=version)
 
     errors: List[str] = []
     for report in payload.get("reports", []):
@@ -75,9 +113,18 @@ def lint_skills_with_cli(skills_dir: pathlib.Path, warnings_as_errors: bool = Fa
             if severity == "error" or warnings_as_errors:
                 errors.append("{}: {}: {}".format(report.get("skill_dir"), issue.get("category"), issue.get("message")))
 
-    if proc.returncode != 0 and not errors:
+    failed = bool(payload.get("failed", False)) or proc.returncode != 0
+    if failed and not errors:
         errors.append(output or "dcc-mcp-cli lint failed with exit code {}".format(proc.returncode))
-    return errors
+
+    return CliLintResult(
+        errors=errors,
+        checked=int(payload.get("checked", 0) or 0),
+        error_count=int(payload.get("errors", 0) or 0),
+        warning_count=int(payload.get("warnings", 0) or 0),
+        failed=failed,
+        version=version,
+    )
 
 
 def _parse_front_matter(text: str) -> dict:
@@ -99,6 +146,7 @@ def lint_skills(
     *,
     use_cli: bool = True,
     warnings_as_errors: bool = False,
+    require_cli: bool = False,
 ) -> List[str]:
     """Return validation errors for all bundled skill directories.
 
@@ -106,12 +154,17 @@ def lint_skills(
     which is the authoritative source of truth. Precision order:
 
     1. ``dcc-mcp-cli lint`` — the standalone binary; matches the runtime loader
-       exactly and is the most precise (preferred locally).
+       exactly and is the most precise (preferred locally and in CI).
     2. ``dcc_mcp_core.validate_skill`` — the same Rust validator exposed through
-       the Python API (used in CI, where the wheel is installed but the CLI
-       binary is not).
+       the Python API (used when the wheel is installed but the CLI binary is
+       not).
     3. Built-in structural heuristics — last-resort fallback when neither
        dcc-mcp-cli nor dcc-mcp-core is importable (lean prek environments).
+
+    Pass ``require_cli=True`` to fail hard when the standalone ``dcc-mcp-cli``
+    binary is unavailable instead of silently dropping to a weaker validator —
+    use this in CI to guarantee the runtime loader's validator is what gates the
+    skills.
 
     On top of whichever generic validator runs, Houdini-specific conventions
     (lazy ``hou`` import, ``scripts/`` layout) are always enforced.
@@ -122,12 +175,27 @@ def lint_skills(
     if not skill_dirs:
         return ["No skill directories found under {}".format(skills_dir)]
 
-    cli_errors = lint_skills_with_cli(skills_dir, warnings_as_errors=warnings_as_errors) if use_cli else None
-    if cli_errors is not None:
+    cli_result = lint_skills_with_cli(skills_dir, warnings_as_errors=warnings_as_errors) if use_cli else None
+    if cli_result is not None:
         generic_mode = "cli"
-        errors.extend(cli_errors)
+        errors.extend(cli_result.errors)
+        version = " ({})".format(cli_result.version) if cli_result.version else ""
+        print(
+            "validator: dcc-mcp-cli{ver} — checked={checked} errors={errs} warnings={warns}".format(
+                ver=version,
+                checked=cli_result.checked,
+                errs=cli_result.error_count,
+                warns=cli_result.warning_count,
+            )
+        )
+    elif require_cli:
+        return [
+            "dcc-mcp-cli is required (--require-cli) but was not found on PATH. "
+            "Install it with `python tools/install_dcc_mcp_cli.py` or remove --require-cli."
+        ]
     elif validate_skill is not None:
         generic_mode = "core"
+        print("validator: dcc-mcp-core.validate_skill (Python API; dcc-mcp-cli not found)")
     else:
         generic_mode = "builtin"
         print(
@@ -278,12 +346,21 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--skills-dir", type=pathlib.Path, default=DEFAULT_SKILLS_DIR)
     parser.add_argument("--no-cli", action="store_true", help="Use Python validation even when dcc-mcp-cli exists.")
     parser.add_argument("--warnings-as-errors", action="store_true")
+    parser.add_argument(
+        "--require-cli",
+        action="store_true",
+        help="Fail if the standalone dcc-mcp-cli binary is not available instead of falling back to a weaker validator.",
+    )
     args = parser.parse_args(argv)
+
+    if args.no_cli and args.require_cli:
+        parser.error("--no-cli and --require-cli are mutually exclusive")
 
     errors = lint_skills(
         args.skills_dir,
         use_cli=not args.no_cli,
         warnings_as_errors=args.warnings_as_errors,
+        require_cli=args.require_cli,
     )
     if errors:
         print("SKILL.md validation errors:")


### PR DESCRIPTION
## Summary

Enhances linting so the **authoritative `dcc-mcp-cli` runtime validator** gates the bundled Houdini skills in CI, instead of silently falling back to the weaker in-process check. Addresses the request to "增强 lint，使用 dcc-mcp-cli 的能力去 lint skills，并确保 CI 转绿".

- **`tools/install_dcc_mcp_cli.py`** (new): stdlib-only, cross-platform installer that downloads the `dcc-mcp-cli` binary from `loonghao/dcc-mcp-core` GitHub Releases (Windows/macOS/Linux), marks it executable, and appends its dir to `GITHUB_PATH` on CI.
- **`tools/lint_skills.py`**: adds `--require-cli` (fails hard if the binary is missing rather than degrading), parses the CLI's structured JSON report (`checked` / `errors` / `warnings` / `failed`), and prints which validator actually ran (with version).
- **`.github/workflows/ci.yml`**: the `lint` job now installs `dcc-mcp-cli` and runs `python tools/lint_skills.py --require-cli --warnings-as-errors`.
- **`pyproject.toml`**: adds the small, py37-safe `PIE` ruff family. `UP`/`RUF` were evaluated but deferred — under `target-version = py37` they force PEP 585/604 annotation rewrites (`list[...]`, `X | None`) that are runtime-unsafe on 3.7–3.9, plus ~1000 lines of `.format`→f-string churn.
- **`justfile`**: `install-cli` and `lint-skills-cli` recipes.
- **Tests**: `tests/test_lint_skills.py` covers CLI JSON parsing, `--require-cli`, warnings-as-errors promotion, and non-JSON failure handling.

Local dev keeps the graceful auto-detect path (CLI → `dcc_mcp_core.validate_skill` → builtin); only CI enforces `--require-cli`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `python tools/check_py37_syntax.py` passes
- [x] `tools/lint_skills.py --require-cli --warnings-as-errors` → `validator: dcc-mcp-cli … checked=20 errors=0 warnings=0`
- [x] `tools/lint_skills.py --no-cli` core fallback still validates
- [x] `install_dcc_mcp_cli.py` downloads + runs the real binary end-to-end
- [x] `pytest` → 318 passed, 1 skipped
- [ ] CI green on this PR
