### PR TITLE
docs: update AGENTS.md/README.md/llms.txt with all 20 skills, add CLAUDE.md and GEMINI.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,14 +49,47 @@ When adding or changing bundled skills, load the project skill:
 
 ## Bundled Skills
 
+### bootstrap stage (default loaded)
 | Skill | Tools |
 |-------|-------|
 | `houdini-scripting` | `execute_python`, `get_session_info` |
+
+### scene stage (default loaded)
+| Skill | Tools |
+|-------|-------|
 | `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
+| `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` |
+
+### authoring stage (load on demand)
+| Skill | Tools |
+|-------|-------|
 | `houdini-nodes` | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
+| `houdini-object-ops` | `rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform` |
+| `houdini-parameters` | `list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression` |
+| `houdini-node-graph` | `get_connections`, `connect_input`, `disconnect_input` |
+| `houdini-geometry` | `create_primitive`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
+| `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
+| `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material` |
+| `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
 | `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
+
+### interchange stage (load on demand)
+| Skill | Tools |
+|-------|-------|
+| `houdini-interchange` | `probe_file`, `import_geometry`, `export_geometry`, `export_alembic`, `export_fbx`, `export_usd` |
+
+### pipeline stage (load on demand)
+| Skill | Tools |
+|-------|-------|
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop` |
+| `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
+| `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
+| `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
+| `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
+
+**Total: 20 skill packages, ~70+ tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 
@@ -71,6 +104,15 @@ When adding or changing bundled skills, load the project skill:
 | `DCC_MCP_HOUDINI_METRICS` | `0` | Enable `/metrics` |
 | `DCC_MCP_HOUDINI_ENABLE_WORKFLOWS` | `0` | Enable core workflow engine |
 | `DCC_MCP_HOUDINI_JOB_STORAGE_PATH` | user data | Job DB path |
+| `DCC_MCP_HOUDINI_RESOURCES` | `1` | Enable MCP resources |
+| `DCC_MCP_HOUDINI_PROJECT_TOOLS` | `1` | Enable project state tools |
+| `DCC_MCP_HOUDINI_QT_UI_INSPECTOR` | `1` | Enable Qt UI inspector |
+| `DCC_MCP_HOUDINI_SEMANTIC_INDEX` | `0` | Enable semantic recall |
+| `DCC_MCP_HOUDINI_SEMANTIC_EMBEDDER` | `hashed` | Embedder type |
+| `DCC_MCP_HOUDINI_DEV_ROOTS` | — | Trusted project roots for dev skill |
+| `DCC_MCP_HOUDINI_MATERIAL_PRESET_DIR` | user data | Material preset directory |
+| `DCC_MCP_HOUDINI_HYTHON` | — | hython path for setup scripts |
+| `DCC_MCP_SKILL_PATHS` | — | Extra skill paths (cross-adapter) |
 
 ## File Index
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,11 @@ When adding or changing bundled skills, load the project skill:
 |-------|-------|
 | `houdini-scripting` | `execute_python`, `get_session_info` |
 
-### scene stage (default loaded)
-| Skill | Tools |
-|-------|-------|
-| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
-| `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` |
+### scene stage (partial default — `houdini-scene` only)
+| Skill | Tools | Load |
+|-------|-------|------|
+| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` | default |
+| `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` | on demand |
 
 ### authoring stage (load on demand)
 | Skill | Tools |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md — Claude Desktop / Anthropic API Integration Guide
+
+> Claude-specific integration notes for `dcc-mcp-houdini`.
+> For the full project map, see [AGENTS.md](AGENTS.md).
+
+---
+
+## What This Project Does
+
+`dcc-mcp-houdini` embeds an MCP Streamable HTTP server directly inside SideFX Houdini. Claude Desktop (or any Anthropic API client using MCP) can call ~70+ Houdini tools over HTTP — scene inspection, node authoring, HDA execution, rendering, and more.
+
+---
+
+## Claude Desktop Configuration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "houdini": {
+      "url": "http://127.0.0.1:8765/mcp"
+    }
+  }
+}
+```
+
+**File locations:**
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+If running gateway mode, use `http://127.0.0.1:9765/mcp` instead.
+
+Restart Claude Desktop after editing.
+
+---
+
+## Progressive Loading — Important for Claude
+
+By default, `dcc-mcp-houdini` starts in **minimal mode** with only 2 skills loaded:
+- `houdini-scripting`
+- `houdini-scene`
+
+**All other skills must be loaded on demand.** When Claude needs a tool from an unloaded skill:
+
+1. Call `load_skill("houdini-nodes")` to expand the skill.
+2. Then call the typed tool (e.g., `houdini_nodes__create_node`).
+
+---
+
+## Claude-Specific Tips
+
+- **Viewport feedback:** Ask Claude to call `houdini_render__capture_viewport` after scene changes. The base64 PNG lets Claude "see" the current state.
+- **Node networks:** Claude excels at building SOP/OBJ networks. Chain `create_node` → `set_node_parms` → `connect_nodes` → `cook_node`.
+- **Code execution:** Prefer `search_skills` → `load_skill` → typed tools. Use `execute_python` only as last resort.
+- **HDA automation:** Use `houdini_hda_automation__instantiate_hda` and `houdini_hda_automation__cook_top_network` for HDA workflows.
+- **Cancellation:** Claude can send `notifications/cancelled` for long renders.
+
+---
+
+## Quick Test Prompts
+
+> "List all OBJ nodes in the current Houdini scene"
+> "Create a sphere, connect it to a null, and cook the network"
+> "Capture the viewport so I can see the current state"
+> "Load the animation skill and set a keyframe on the sphere's ty at frame 24"
+
+---
+
+## See Also
+
+- [AGENTS.md](AGENTS.md) — Shared agent navigation map
+- [llms.txt](llms.txt) — One-page core reference
+- [README.md](README.md) — Human-facing installation and overview

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,52 @@
+# GEMINI.md — Google Gemini / Vertex AI Integration Guide
+
+> Gemini-specific integration notes for `dcc-mcp-houdini`.
+> For the full project map, see [AGENTS.md](AGENTS.md).
+
+---
+
+## What This Project Does
+
+`dcc-mcp-houdini` embeds an MCP Streamable HTTP server directly inside SideFX Houdini. Gemini (via an MCP-compatible client or custom integration) can discover and invoke ~70+ Houdini tools over HTTP.
+
+---
+
+## Integration Setup
+
+If your Gemini client supports MCP over HTTP, configure:
+
+```
+Endpoint: http://127.0.0.1:8765/mcp
+Protocol: MCP Streamable HTTP (2025-03-26 spec)
+```
+
+For multi-instance gateway mode:
+```
+Endpoint: http://127.0.0.1:9765/mcp
+```
+
+---
+
+## Gemini-Specific Tips
+
+- **Code-first workflows:** Gemini excels at generating structured Houdini networks. Ask it to build complete SOP chains with `houdini_nodes__create_node` → `connect_nodes` → `cook_node`.
+- **Lookdev & materials:** Gemini's structured output handling makes it ideal for `houdini-lookdev` chains — set material parameters, save/load presets.
+- **Viewport capture:** Feed `capture_viewport` base64 PNGs back to Gemini for visual state verification.
+- **Pipeline automation:** Use `houdini-pipeline` skills for shot packaging and scene validation workflows.
+
+---
+
+## Quick Test Prompts
+
+> "Create a camera and a three-point lighting setup"
+> "List all materials in the scene and export their presets"
+> "Import an alembic cache from /path/to/file.abc"
+> "Validate the scene and collect all dependencies"
+
+---
+
+## See Also
+
+- [AGENTS.md](AGENTS.md) — Shared agent navigation map
+- [llms.txt](llms.txt) — One-page core reference
+- [README.md](README.md) — Human-facing installation and overview

--- a/README.md
+++ b/README.md
@@ -130,16 +130,49 @@ manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
 PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
 available.
 
-## Bundled Skills
+## Bundled Skills (20 packages, ~70+ tools)
 
-| Skill | Stage | Tools |
-|-------|-------|-------|
-| `houdini-scripting` | bootstrap | `execute_python`, `get_session_info` |
-| `houdini-scene` | scene | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
-| `houdini-nodes` | authoring | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
-| `houdini-materials` | authoring | `create_material`, `assign_material` |
-| `houdini-hda` | authoring | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
-| `houdini-automation` | pipeline | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
+Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md`
+
+### bootstrap (default loaded)
+| Skill | Tools |
+|-------|-------|
+| `houdini-scripting` | `execute_python`, `get_session_info` |
+
+### scene (default loaded)
+| Skill | Tools |
+|-------|-------|
+| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
+| `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` |
+
+### authoring (load on demand)
+| Skill | Tools |
+|-------|-------|
+| `houdini-nodes` | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
+| `houdini-object-ops` | `rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform` |
+| `houdini-parameters` | `list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression` |
+| `houdini-node-graph` | `get_connections`, `connect_input`, `disconnect_input` |
+| `houdini-geometry` | `create_primitive`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
+| `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
+| `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
+| `houdini-materials` | `create_material`, `assign_material` |
+| `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
+| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
+
+### interchange (load on demand)
+| Skill | Tools |
+|-------|-------|
+| `houdini-interchange` | `probe_file`, `import_geometry`, `export_geometry`, `export_alembic`, `export_fbx`, `export_usd` |
+
+### pipeline (load on demand)
+| Skill | Tools |
+|-------|-------|
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop` |
+| `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
+| `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
+| `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
+| `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
+| `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
 ## CI and Houdini Docker
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 |-------|-------|
 | `houdini-scripting` | `execute_python`, `get_session_info` |
 
-### scene (default loaded)
-| Skill | Tools |
-|-------|-------|
-| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` |
-| `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` |
+### scene (partial default — `houdini-scene` only)
+| Skill | Tools | Load |
+|-------|-------|------|
+| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` | default |
+| `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` | on demand |
 
 ### authoring (load on demand)
 | Skill | Tools |

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,12 @@ server.mcp_url  # http://127.0.0.1:8765/mcp
 dcc_mcp_houdini.stop_server()
 ```
 
+## MCP host config
+
+```json
+{"mcpServers": {"houdini": {"url": "http://127.0.0.1:8765/mcp"}}}
+```
+
 ## Progressive loading
 
 ```python
@@ -26,34 +32,45 @@ server.list_skills()
 - `houdini_success`, `houdini_error`, `with_houdini`
 - `build_minimal_mode_config`, `build_minimal_mode_for_stages`, `MINIMAL_SKILLS`, `STAGES`, `STAGE_SKILLS`
 
-## Bundled tools
+## Bundled tools (20 skills, ~70+ tools)
 
-- `houdini_scripting__execute_python`
-- `houdini_scripting__get_session_info`
-- `houdini_scene__get_scene_info`
-- `houdini_scene__list_obj_nodes`
-- `houdini_nodes__create_node`
-- `houdini_nodes__set_node_parms`
-- `houdini_nodes__connect_nodes`
-- `houdini_nodes__cook_node`
-- `houdini_nodes__layout_children`
-- `houdini_nodes__delete_node`
-- `houdini_hda__install_hda_file`
-- `houdini_hda__list_hda_definitions`
-- `houdini_hda__execute_hda`
-- `houdini_hda__save_node_as_hda`
-- `houdini_automation__run_python_file`
-- `houdini_automation__set_frame_range`
-- `houdini_automation__save_hip_file`
-- `houdini_automation__load_hip_file`
-- `houdini_automation__build_node_chain`
+### bootstrap (default)
+- `houdini_scripting__execute_python`, `get_session_info`
+
+### scene (default)
+- `houdini_scene__get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info`
+- `houdini_scene_edit__new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box`
+
+### authoring (load on demand)
+- `houdini_nodes__create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node`
+- `houdini_object_ops__rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform`
+- `houdini_parameters__list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression`
+- `houdini_node_graph__get_connections`, `connect_input`, `disconnect_input`
+- `houdini_geometry__create_primitive`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status`
+- `houdini_mesh_ops__transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry`
+- `houdini_camera_light__list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light`
+- `houdini_materials__create_material`, `assign_material`
+- `houdini_lookdev__list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset`
+- `houdini_hda__install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`
+
+### interchange (load on demand)
+- `houdini_interchange__probe_file`, `import_geometry`, `export_geometry`, `export_alembic`, `export_fbx`, `export_usd`
+
+### pipeline (load on demand)
+- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`
+- `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`
+- `houdini_hda_automation__scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain`
+- `houdini_pipeline__set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package`
+- `houdini_dev__attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action`
+- `houdini_automation__run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain`
 
 ## Skill stages
 
 - `bootstrap`: `houdini-scripting` (default loaded)
-- `scene`: `houdini-scene` (default loaded)
-- `authoring`: `houdini-nodes`, `houdini-hda`
-- `pipeline`: `houdini-automation`
+- `scene`: `houdini-scene`, `houdini-scene-edit` (partial default)
+- `authoring`: `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`
+- `interchange`: `houdini-interchange`
+- `pipeline`: `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`
 
 ## Dev (Windows)
 


### PR DESCRIPTION
## Summary

Updated the dcc-mcp-houdini documentation to reflect the full scope of the project. Previously README.md and AGENTS.md only listed 6 of the 20 bundled skills, and no AI platform integration files existed.

### Changes
- **AGENTS.md** — Expanded skills table from 6 → 20 skill packages across all 5 stages (bootstrap, scene, authoring, interchange, pipeline)
- **README.md** — Updated skills table to show all 20 skills with stage information
- **llms.txt** — Expanded tool listing to include all ~70+ tools from all 20 skills
- **CLAUDE.md** (new) — Claude Desktop integration guide with config, progressive loading tips, test prompts
- **GEMINI.md** (new) — Google Gemini/Vertex AI integration guide

### Impact
Complete parity with the dcc-mcp-maya documentation structure across the ecosystem.