### PR TITLE
chore: align with dcc-mcp-core 0.18.2, bump to v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcc-mcp-houdini"
-version = "0.3.0"
+version = "0.4.0"
 description = "SideFX Houdini adapter for the DCC Model Context Protocol (MCP) ecosystem — exposes Houdini tools via MCP"
 authors = [{ name = "Long Hao", email = "hal.long@outlook.com" }]
 readme = "README.md"
@@ -28,10 +28,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.17.26: import-light public facade, DccServerOptions composition root,
-    # HostExecutionBridge, latest skill-management/search contracts, and
-    # adapter-ready diagnostics/readiness surfaces.
-    "dcc-mcp-core>=0.17.26,<1.0.0",
+    # 0.18.2: gateway daemon mode (launch_detached, build_gateway_daemon_command,
+    # ensure_gateway_daemon), Marketplace admin API, Sentry monitoring,
+    # expanded sidecar/readiness contracts.
+    "dcc-mcp-core>=0.18.2,<1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bump dcc-mcp-core lower bound from 0.17.26 to 0.18.2
- Enable gateway daemon mode (launch_detached, build_gateway_daemon_command)
- Bump adapter version to v0.4.0

## Changes

- Update dependency pin in pyproject.toml
- Update version to 0.4.0

## Test Plan

- [ ] CI passes
- [ ] Verify existing Houdini skills still work with core 0.18.2