### PR TITLE
chore: align Houdini core dependency to 0.18.2

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -34,7 +34,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.17.26"
+MIN_CORE_VERSION = "0.18.2"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.17.26: import-light public facade, DccServerOptions composition root,
-    # HostExecutionBridge, latest skill-management/search contracts, and
+    # 0.18.2+: Release Train anchor — import-light public facade,
+    # DccServerOptions composition root, HostExecutionBridge, and
     # adapter-ready diagnostics/readiness surfaces.
-    "dcc-mcp-core>=0.17.26,<1.0.0",
+    "dcc-mcp-core>=0.18.2,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -30,13 +30,13 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
     adapter_wheel.write_bytes(b"adapter")
     core_wheels = [
-        tmp_path / "dcc_mcp_core-0.17.26-cp37-cp37m-win_amd64.whl",
-        tmp_path / "dcc_mcp_core-0.17.26-cp38-abi3-win_amd64.whl",
+        tmp_path / "dcc_mcp_core-0.18.2-cp37-cp37m-win_amd64.whl",
+        tmp_path / "dcc_mcp_core-0.18.2-cp38-abi3-win_amd64.whl",
     ]
     for core_wheel in core_wheels:
         core_wheel.write_bytes(b"core")
 
-    monkeypatch.setattr(pkg, "resolve_core_version", lambda min_version=pkg.MIN_CORE_VERSION: "0.17.26")
+    monkeypatch.setattr(pkg, "resolve_core_version", lambda min_version=pkg.MIN_CORE_VERSION: "0.18.2")
     monkeypatch.setattr(pkg, "download_core_wheels", lambda version, platform, dest_dir: core_wheels)
 
     zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out")
@@ -58,14 +58,14 @@ def test_pick_core_wheels_includes_py37_and_abi3_for_platform() -> None:
     pkg = _load_packaging_script()
 
     files = [
-        {"filename": "dcc_mcp_core-0.17.26-cp311-cp311-win_amd64.whl"},
-        {"filename": "dcc_mcp_core-0.17.26-cp38-abi3-win_amd64.whl"},
-        {"filename": "dcc_mcp_core-0.17.26-cp37-cp37m-win_amd64.whl"},
-        {"filename": "dcc_mcp_core-0.17.26-cp38-abi3-manylinux_x86_64.whl"},
+        {"filename": "dcc_mcp_core-0.18.2-cp311-cp311-win_amd64.whl"},
+        {"filename": "dcc_mcp_core-0.18.2-cp38-abi3-win_amd64.whl"},
+        {"filename": "dcc_mcp_core-0.18.2-cp37-cp37m-win_amd64.whl"},
+        {"filename": "dcc_mcp_core-0.18.2-cp38-abi3-manylinux_x86_64.whl"},
     ]
     picked = pkg.pick_core_wheel_files(files, "win64")
     assert [item["filename"] for item in picked] == [
-        "dcc_mcp_core-0.17.26-cp38-abi3-win_amd64.whl",
-        "dcc_mcp_core-0.17.26-cp311-cp311-win_amd64.whl",
-        "dcc_mcp_core-0.17.26-cp37-cp37m-win_amd64.whl",
+        "dcc_mcp_core-0.18.2-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.18.2-cp311-cp311-win_amd64.whl",
+        "dcc_mcp_core-0.18.2-cp37-cp37m-win_amd64.whl",
     ]


### PR DESCRIPTION
## Summary
- raise dcc-mcp-core dependency floor to >=0.18.2
- keep Houdini quick-install packaging MIN_CORE_VERSION in sync
- update packaging test fixtures for the new core wheel version

## Validation
- vx uv run --no-project --with pytest --with pytest-asyncio --with pytest-mock --with pyfakefs --with requests --with pyyaml --with "dcc-mcp-core>=0.18.2,<1.0.0" pytest tests/ -v --tb=short
- vx uv run --no-project --with pytest --with packaging pytest tests/test_packaging.py -v --tb=short -m packaging
- vx uv run --no-project --with ruff ruff check src/ tests/ tools/ packaging/
- vx uv run --no-project --with ruff ruff format --check src/ tests/ tools/ packaging/
- vx uv run --no-project --with pyyaml --with "dcc-mcp-core>=0.18.2,<1.0.0" python tools/lint_skills.py --warnings-as-errors
- vx uv run --no-project python tools/check_py37_syntax.py src tests tools packaging

Note: vx uv run --extra dev currently fails to resolve because the project advertises Python >=3.7 while pytest-asyncio>=0.23 requires Python >=3.8; validation used explicit transient test dependencies instead.