### PR TITLE
chore: bump dcc-mcp-core dependency floor to >=0.18.7

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -34,7 +34,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.18.2"
+MIN_CORE_VERSION = "0.18.7"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # 0.18.2+: Release Train anchor — import-light public facade,
     # DccServerOptions composition root, HostExecutionBridge, and
     # adapter-ready diagnostics/readiness surfaces.
-    "dcc-mcp-core>=0.18.2,<1.0.0",
+    "dcc-mcp-core>=0.18.7,<1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump `dcc-mcp-core` dependency from `>=0.18.2` to `>=0.18.7` in `pyproject.toml`
- Update `MIN_CORE_VERSION` in packaging script to `0.18.7`
- Aligns with core v0.18.7 Release Train: marketplace `icon` field, gateway discovery optimization, model `call_examples`, and SSE notification budget fixes

## Verification
- All adapter tests pass: 318 passed, 1 skipped
- No marketplace schema or model description changes needed — houdini adapter uses core API pass-through
- Gateway discovery API signatures compatible (`update_gateway_metadata`, `DccServerOptions.from_env`)

## Linked GitHub issues
- Refs dcc-mcp/dcc-mcp-core release v0.18.7