### PR TITLE
fix: update README and skill compatibility to core >=0.18.7, add version consistency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.17.26`
+- `dcc-mcp-core >= 0.18.7`
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   channels and expressions; export/import channel JSON; bake channels and
   trigger bounded simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   with typed parameters. Use when loading .hda/.otl assets or executing an HDA
   node as part of automation. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   nodes through typed HOM operations. Use when building lookdev/material
   workflows. Not for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   written_files, elapsed time, and warnings without hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,53 @@
+"""Version floor consistency checks — keep pyproject.toml, packaging script,
+and SKILL.md compatibility strings from drifting apart."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from packaging.version import Version
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+PACKAGING_SCRIPT = ROOT / "packaging" / "assemble_houdini_package.py"
+SKILLS_DIR = ROOT / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _extract_pyproject_core_floor() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    m = re.search(r'"dcc-mcp-core>=([^,"]+)', text)
+    if not m:
+        raise RuntimeError("Could not find dcc-mcp-core dependency in pyproject.toml")
+    return m.group(1).strip()
+
+
+def _extract_packaging_min_core_version() -> str:
+    text = PACKAGING_SCRIPT.read_text(encoding="utf-8")
+    m = re.search(r'MIN_CORE_VERSION\s*=\s*"([^"]+)"', text)
+    if not m:
+        raise RuntimeError("Could not find MIN_CORE_VERSION in assemble_houdini_package.py")
+    return m.group(1).strip()
+
+
+def test_pyproject_and_packaging_core_floor_match() -> None:
+    """pyproject.toml dep floor and packaging MIN_CORE_VERSION must be identical."""
+    pyproject_floor = _extract_pyproject_core_floor()
+    packaging_floor = _extract_packaging_min_core_version()
+    assert pyproject_floor == packaging_floor, (
+        f"Mismatch: pyproject.toml requires >= {pyproject_floor}, "
+        f"but packaging script pins MIN_CORE_VERSION = {packaging_floor}"
+    )
+
+
+def test_skill_compatibility_runtime_floor() -> None:
+    """Every SKILL.md compatibility string must declare dcc-mcp-core >= current floor."""
+    expected_floor = Version(_extract_pyproject_core_floor())
+    for skill_md in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        text = skill_md.read_text(encoding="utf-8")
+        m = re.search(r"dcc-mcp-core\s+([0-9]+\.[0-9]+\.[0-9]+)", text)
+        assert m, f"{skill_md.relative_to(ROOT)}: missing dcc-mcp-core compatibility"
+        declared = Version(m.group(1))
+        assert declared >= expected_floor, (
+            f"{skill_md.relative_to(ROOT)}: declares dcc-mcp-core {declared}, but project floor is >= {expected_floor}"
+        )

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
 PACKAGING_SCRIPT = ROOT / "packaging" / "assemble_houdini_package.py"
+README = ROOT / "README.md"
 SKILLS_DIR = ROOT / "src" / "dcc_mcp_houdini" / "skills"
 
 
@@ -30,6 +31,14 @@ def _extract_packaging_min_core_version() -> str:
     return m.group(1).strip()
 
 
+def _extract_readme_core_floor() -> str:
+    text = README.read_text(encoding="utf-8")
+    m = re.search(r"dcc-mcp-core\s*>=\s*([0-9]+\.[0-9]+\.[0-9]+)", text)
+    if not m:
+        raise RuntimeError("Could not find dcc-mcp-core requirement in README.md")
+    return m.group(1).strip()
+
+
 def test_pyproject_and_packaging_core_floor_match() -> None:
     """pyproject.toml dep floor and packaging MIN_CORE_VERSION must be identical."""
     pyproject_floor = _extract_pyproject_core_floor()
@@ -37,6 +46,15 @@ def test_pyproject_and_packaging_core_floor_match() -> None:
     assert pyproject_floor == packaging_floor, (
         f"Mismatch: pyproject.toml requires >= {pyproject_floor}, "
         f"but packaging script pins MIN_CORE_VERSION = {packaging_floor}"
+    )
+
+
+def test_readme_core_floor_matches_pyproject() -> None:
+    """README dependency floor must stay aligned with pyproject.toml."""
+    pyproject_floor = _extract_pyproject_core_floor()
+    readme_floor = _extract_readme_core_floor()
+    assert readme_floor == pyproject_floor, (
+        f"Mismatch: README.md says >= {readme_floor}, but pyproject.toml requires >= {pyproject_floor}"
     )
 
 


### PR DESCRIPTION
## Summary
Follow-up fixes from loonghao review (#42):
1. **README.md**: bump core requirement display from `>=0.17.26` to `>=0.18.7`
2. **20 SKILL.md**: tighten compatibility from `dcc-mcp-core 0.17+` to `0.18.7+`
3. **New test** (`test_version_consistency.py`): guards `pyproject.toml`, packaging script, and SKILL.md compatibility from drifting apart

## Linked PR
- #42 (merged, deps bump only)