### PR TITLE
fix(ci): remove github.token fallback from release-please token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
release-please must use PERSONAL_ACCESS_TOKEN so that pushed commits trigger downstream CI workflows. GITHUB_TOKEN pushes are suppressed by GitHub Actions to prevent recursive chains.

Ref: dcc-mcp-core uses `secrets.PERSONAL_ACCESS_TOKEN` without fallback.