### PR TITLE
feat: add houdini-texture-bake skill

### DIFF
--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -8,7 +8,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
 | `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`, `houdini-light-rig` | no |
 | `interchange` | `houdini-interchange`, `houdini-export-preset` | no |
-| `pipeline` | `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation` | no |
+| `pipeline` | `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake` | no |
 
 ## Common chains
 
@@ -29,6 +29,9 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | HDRI environment lighting | `load_skill("houdini-light-rig")` → `create_hdri_world` → `area_softbox` / `set_render_view_transform` → `get_lighting_summary` |
 | Light rig management | `load_skill("houdini-light-rig")` → `list_light_rigs` → `group_lights` → `set_light_rig_intensity` |
 | Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` |
+| Texture bake (AO) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_ambient_occlusion` |
+| Texture bake (lighting) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_lighting` |
+| Transfer high→low maps | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__transfer_maps` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Animate & bake | `load_skill("houdini-animation")` → `houdini_animation__set_timeline` → `houdini_animation__set_keyframe` → `houdini_animation__get_keyframes` → `houdini_animation__bake_channels` / `houdini_animation__cache_simulation` |
 | Lookdev & shader networks | `load_skill("houdini-lookdev")` → `houdini_lookdev__list_materials` → `houdini_lookdev__get_material_parms` → `houdini_lookdev__set_material_parms` → `houdini_lookdev__save_preset` / `houdini_lookdev__load_preset` |

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   to low-res target. Pair with houdini-render for render output and
   houdini-materials for shader assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: houdini-texture-bake
+description: >-
+  Pipeline stage — bake ambient occlusion, lighting, texture maps (diffuse,
+  normals, cavity, curvature etc.) from geometry to image files, list
+  bake-compatible geometry with UV info, and transfer maps from high-res source
+  to low-res target. Pair with houdini-render for render output and
+  houdini-materials for shader assignment.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.7+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: pipeline
+    version: "1.0.0"
+    tags: [houdini, bake, texture, ao, ambient-occlusion, lighting, normals, transfer-maps, maps-baker, cop, rop]
+    search-hint: "bake texture map, ao ambient occlusion, normal map, transfer maps, high to low, lighting bake, texture baking, list bake targets"
+    search-aliases: [bake textures, bake lighting, bake ambient occlusion, transfer maps, list bake targets]
+    example-prompts:
+      - "Bake ambient occlusion for all geometry in the scene"
+      - "List all bake-compatible geometry with UV info"
+      - "Bake diffuse and normal maps from /obj/high_res to /obj/low_res"
+      - "Transfer normals and displacement from a high-poly source to a low-poly target"
+      - "Bake lighting with Mantra at 2048 resolution"
+    intent: "Bake textures (AO, lighting, normals, cavity, diffuse, custom maps), transfer maps between geometry, list bake targets."
+    recall-context:
+      app_type: houdini
+      domain: pipeline
+      workflow-stage: pipeline
+      task-category: mutate
+    requires: []
+    produces: [baked_texture, image_file, transfer_map, bake_target_list]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=19.5"
+    side-effects:
+      creates: true
+      modifies: false
+      targets: [texture, image, rop, cop]
+    tools: tools.yaml
+---
+
+# houdini-texture-bake
+
+Typed texture-baking tools that bake geometry attributes to image files using
+Houdini's Bake Texture ROP, Labs Maps Baker, or COP-based fallback workflows.
+
+## Bake method detection
+
+Tools auto-detect the best available bake method at runtime:
+
+1. **Labs Maps Baker** (`sidefx_labs` → `maps_baker`) — richest option,
+   single-node multi-map bake with 20+ map types (normals, cavity, curvature,
+   thickness, roughness, metallic, etc.)
+2. **Bake Texture ROP** (`game_simple_baker` / `baker::2.0`) — built-in
+   Houdini 20+ ROP for standard map baking
+3. **COP fallback** — simple per-attribute COP-based bake when neither Labs
+   nor Bake Texture ROP is available
+
+When no bake method is detected, tools return a structured diagnostic payload
+(`available_methods: [], recommendations: [...]`) — they never degrade to raw
+`execute_python`.
+
+## Tool groups
+
+- **`bake-ao`:** `bake_ambient_occlusion` — bake ambient occlusion to texture
+  (async, 900s timeout)
+- **`bake-lighting`:** `bake_lighting` — bake scene lighting via Mantra/Karma
+  render-to-texture (async, 900s timeout)
+- **`bake-textures`:** `bake_textures` — general multi-map baking (diffuse,
+  normals, cavity, curvature, roughness, metallic, etc.) via Labs Maps Baker
+  or Bake Texture ROP (async, 1800s timeout)
+- **`bake-query`:** `list_bake_targets` — scan geometry for UV-equipped,
+  bake-compatible nodes (sync, read-only)
+- **`bake-transfer`:** `transfer_maps` — transfer normals/displacement/diffuse
+  from high-res source to low-res target (async, 1200s timeout)
+
+## Context limitations
+
+- **UV requirement:** Bake Texture ROP and Labs Maps Baker both require the
+  target geometry to have non-degenerate UVs. `list_bake_targets` reports
+  `has_uvs` so callers can verify before baking.
+- **Renderer selection:** `bake_lighting` supports `mantra` (default) and
+  `karma`. Karma requires a valid XPU/CPU license.
+- **Labs Maps Baker:** Install via `sidefx_labs` package or Houdini Game Dev
+  Toolset. Detection is automatic; tools report `labs_maps_baker_available`
+  in their result payload.
+
+## Tracer-bullet flow
+
+1. `list_bake_targets()` → scan geometry, pick nodes with UVs
+2. `bake_ambient_occlusion(rop_path="/out/bake_ao", objects=["/obj/sphere"])`
+3. `bake_textures(rop_path="/out/bake_maps", objects=["/obj/character"], map_types=["normals", "cavity", "diffuse"])`
+4. `bake_lighting(rop_path="/out/bake_light", camera="/obj/rendercam", objects=["/obj/building"])`
+5. `transfer_maps(source="/obj/high_res", target="/obj/low_res", map_types=["normals", "displacement"])`

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/_texture_bake_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/_texture_bake_common.py
@@ -1,0 +1,235 @@
+"""Shared helpers for Houdini texture-bake skills.
+
+Detects available bake methods, creates ROPs, validates UVs, and provides
+common utilities for all bake scripts.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, List, Optional, Sequence, Tuple
+
+# Map-type vocabulary shared across bake_textures and transfer_maps.
+# Labs Maps Baker supports ~20+ types; Bake Texture ROP supports a subset.
+_MAP_TYPE_VOCABULARY = {
+    "normals", "cavity", "curvature", "diffuse", "roughness",
+    "metallic", "thickness", "world_position", "opacity",
+    "ambient_occlusion", "displacement", "height", "emission",
+    "scattering", "transmission", "basecolor", "specular",
+    "subsurface", "anisotropy", "coat", "sheen",
+}
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise ValueError."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def ensure_node(hou: Any, node_path: str, node_type: str, parent_path: str = "/out") -> Any:
+    """Get or create a node at *node_path* with *node_type*."""
+    node = hou.node(node_path)
+    if node is not None:
+        return node
+    parent = hou.node(parent_path)
+    if parent is None:
+        raise ValueError("Parent path not found: {}".format(parent_path))
+    name = node_path.rsplit("/", 1)[-1]
+    return parent.createNode(node_type, name)
+
+
+def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
+    """Set a scalar/tuple parm only when it exists. Return success."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            return False
+        parm_tuple.set(tuple(value))
+        return True
+    parm = node.parm(name)
+    if parm is None:
+        return False
+    parm.set(value)
+    return True
+
+
+def _detect_labs_maps_baker(hou: Any) -> bool:
+    """Check whether the Labs Maps Baker node type is available."""
+    try:
+        node_type = hou.nodeType(hou.vopNodeTypeCategory(), "maps_baker")
+        return node_type is not None
+    except Exception:
+        return False
+
+
+def _detect_bake_texture_rop(hou: Any) -> bool:
+    """Check whether the Bake Texture ROP (game_simple_baker / baker::2.0) is available."""
+    for type_name in ("baker::2.0", "game_simple_baker", "bake_texture"):
+        try:
+            if hou.nodeType(hou.ropNodeTypeCategory(), type_name) is not None:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def detect_bake_methods(hou: Any) -> dict:
+    """Return available bake methods and their capabilities.
+
+    Returns a dict with boolean flags and recommendations.
+    """
+    labs = _detect_labs_maps_baker(hou)
+    rop = _detect_bake_texture_rop(hou)
+
+    methods = []
+    if labs:
+        methods.append("labs_maps_baker")
+    if rop:
+        methods.append("bake_texture_rop")
+    # COP is always available as a last resort
+    methods.append("cop_fallback")
+
+    return {
+        "labs_maps_baker_available": labs,
+        "bake_texture_rop_available": rop,
+        "available_methods": methods,
+        "recommended": "labs_maps_baker" if labs else ("bake_texture_rop" if rop else "cop_fallback"),
+        "recommendations": (
+            []
+            if labs
+            else ["Install sidefx_labs for Labs Maps Baker (richest map-type support)."]
+        ),
+    }
+
+
+def validate_map_types(requested: List[str]) -> Tuple[List[str], List[str]]:
+    """Split *requested* into (valid, invalid) using the shared vocabulary."""
+    valid = [t for t in requested if t in _MAP_TYPE_VOCABULARY]
+    invalid = [t for t in requested if t not in _MAP_TYPE_VOCABULARY]
+    return valid, invalid
+
+
+def collect_geometry(hou: Any, objects: Optional[List[str]] = None) -> List[str]:
+    """Resolve object list; defaults to all renderable OBJ geometry."""
+    if objects:
+        return list(objects)
+
+    obj_root = hou.node("/obj")
+    if obj_root is None:
+        return []
+
+    geo_paths = []
+    for child in obj_root.children():
+        if hasattr(child, "displayNode") and child.displayNode() is not None:
+            geo_paths.append(child.path())
+    return geo_paths
+
+
+def check_uvs(hou: Any, node_path: str) -> Optional[List[str]]:
+    """Return UV attribute names on *node_path*'s display geometry, or None.
+
+    When the node has no display geometry, returns None (not []).
+    """
+    node = hou.node(node_path)
+    if node is None:
+        return None
+    try:
+        geo = node.displayNode().geometry() if hasattr(node, "displayNode") else None
+    except Exception:
+        return None
+    if geo is None:
+        return None
+
+    uv_names = []
+    for attr in geo.pointAttribs():
+        if attr.dataType() == hou.attribData.Float and attr.size() >= 2:
+            if "uv" in attr.name().lower():
+                uv_names.append(attr.name())
+    for attr in geo.vertexAttribs():
+        if attr.dataType() == hou.attribData.Float and attr.size() >= 2:
+            if "uv" in attr.name().lower():
+                uv_names.append(attr.name())
+    return uv_names
+
+
+def bake_geometry_info(hou: Any, node_path: str) -> Optional[dict]:
+    """Return bake-relevant info dict for a single geometry node, or None."""
+    node = hou.node(node_path)
+    if node is None:
+        return None
+    display = node.displayNode() if hasattr(node, "displayNode") else None
+    if display is None:
+        return {
+            "path": node_path,
+            "name": node.name(),
+            "type": "obj",
+            "has_display_geo": False,
+            "has_uvs": False,
+            "uv_layers": [],
+            "primitive_count": 0,
+            "bake_ready": False,
+        }
+
+    geo = display.geometry()
+    uv_layers = check_uvs(hou, node_path) or []
+    prim_count = len(geo.iterPrims()) if geo is not None else 0
+
+    return {
+        "path": node_path,
+        "name": node.name(),
+        "type": "obj" if node_path.startswith("/obj") else "sop",
+        "has_display_geo": True,
+        "has_uvs": bool(uv_layers),
+        "uv_layers": uv_layers,
+        "primitive_count": prim_count,
+        "bake_ready": bool(uv_layers) and prim_count > 0,
+    }
+
+
+def create_or_get_bake_rop(hou: Any, rop_path: str) -> Any:
+    """Create a Bake Texture ROP if one doesn't already exist at *rop_path*.
+
+    Tries baker::2.0 first, then game_simple_baker.
+    """
+    node = hou.node(rop_path)
+    if node is not None:
+        return node
+
+    for type_name in ("baker::2.0", "game_simple_baker", "bake_texture"):
+        try:
+            node = ensure_node(hou, rop_path, type_name)
+            if node is not None:
+                return node
+        except Exception:
+            continue
+
+    raise ValueError(
+        "No bake ROP type available. Tried: baker::2.0, game_simple_baker, bake_texture. "
+        "Install Houdini Game Dev Toolset or sidefx_labs."
+    )
+
+
+def write_file_list(output_dir: str, prefix: str, file_format: str,
+                    object_names: List[str], map_types: List[str]) -> List[str]:
+    """Generate expected output file paths for a multi-map multi-object bake."""
+    files = []
+    for obj_name in object_names:
+        safe = obj_name.replace("/", "_").replace(":", "_")
+        for mt in map_types:
+            files.append(os.path.join(output_dir, "{}_{}_{}.{}".format(prefix, safe, mt, file_format)))
+    return files
+
+
+def node_summary(hou: Any, node_path: str) -> Optional[dict]:
+    """Return a small, JSON-safe node summary."""
+    node = hou.node(node_path)
+    if node is None:
+        return None
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/_texture_bake_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/_texture_bake_common.py
@@ -7,16 +7,32 @@ common utilities for all bake scripts.
 from __future__ import annotations
 
 import os
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Tuple
 
 # Map-type vocabulary shared across bake_textures and transfer_maps.
 # Labs Maps Baker supports ~20+ types; Bake Texture ROP supports a subset.
 _MAP_TYPE_VOCABULARY = {
-    "normals", "cavity", "curvature", "diffuse", "roughness",
-    "metallic", "thickness", "world_position", "opacity",
-    "ambient_occlusion", "displacement", "height", "emission",
-    "scattering", "transmission", "basecolor", "specular",
-    "subsurface", "anisotropy", "coat", "sheen",
+    "normals",
+    "cavity",
+    "curvature",
+    "diffuse",
+    "roughness",
+    "metallic",
+    "thickness",
+    "world_position",
+    "opacity",
+    "ambient_occlusion",
+    "displacement",
+    "height",
+    "emission",
+    "scattering",
+    "transmission",
+    "basecolor",
+    "specular",
+    "subsurface",
+    "anisotropy",
+    "coat",
+    "sheen",
 }
 
 
@@ -96,11 +112,7 @@ def detect_bake_methods(hou: Any) -> dict:
         "bake_texture_rop_available": rop,
         "available_methods": methods,
         "recommended": "labs_maps_baker" if labs else ("bake_texture_rop" if rop else "cop_fallback"),
-        "recommendations": (
-            []
-            if labs
-            else ["Install sidefx_labs for Labs Maps Baker (richest map-type support)."]
-        ),
+        "recommendations": ([] if labs else ["Install sidefx_labs for Labs Maps Baker (richest map-type support)."]),
     }
 
 
@@ -211,8 +223,9 @@ def create_or_get_bake_rop(hou: Any, rop_path: str) -> Any:
     )
 
 
-def write_file_list(output_dir: str, prefix: str, file_format: str,
-                    object_names: List[str], map_types: List[str]) -> List[str]:
+def write_file_list(
+    output_dir: str, prefix: str, file_format: str, object_names: List[str], map_types: List[str]
+) -> List[str]:
     """Generate expected output file paths for a multi-map multi-object bake."""
     files = []
     for obj_name in object_names:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_ambient_occlusion.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_ambient_occlusion.py
@@ -1,0 +1,217 @@
+"""Bake ambient occlusion to a texture via Labs Maps Baker, Bake Texture ROP, or COP fallback."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _texture_bake_common import (  # noqa: E402
+    collect_geometry,
+    create_or_get_bake_rop,
+    detect_bake_methods,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def _bake_ao_via_rop(hou, rop, objects: List[str], output_path: str,
+                     resolution: List[int], samples: int, max_distance: float) -> dict:
+    """Configure and execute a Bake Texture ROP for ambient occlusion."""
+    obj_str = " ".join(objects)
+
+    set_parm_if_exists(rop, "soppath", obj_str) or set_parm_if_exists(rop, "objects", obj_str)
+    set_parm_if_exists(rop, "picture", output_path)
+    set_parm_if_exists(rop, "resolution", resolution)
+    set_parm_if_exists(rop, "res1", resolution[0])
+    set_parm_if_exists(rop, "res2", resolution[1])
+    set_parm_if_exists(rop, "samples", samples)
+    set_parm_if_exists(rop, "maxdist", max_distance)
+    set_parm_if_exists(rop, "aomap", True)
+    set_parm_if_exists(rop, "bake_aomap", True)
+
+    try:
+        rop.render(verbose=False)
+    except TypeError:
+        rop.render()
+
+    written = [output_path] if os.path.isfile(output_path) else []
+
+    return skill_success(
+        "Baked ambient occlusion via Bake Texture ROP",
+        bake_method="bake_texture_rop",
+        written_files=written,
+        output_path=output_path,
+        resolution=resolution,
+        samples=samples,
+        max_distance=max_distance,
+        rop=node_summary(hou, rop.path()),
+        objects=objects,
+        prompt="Use bake_lighting for full lighting bake or bake_textures for multi-map baking.",
+    )
+
+
+def _bake_ao_via_labs(hou, objects: List[str], output_path: str,
+                      resolution: List[int], samples: int, max_distance: float) -> dict:
+    """Bake AO using Labs Maps Baker node."""
+    parent = hou.node("/out")
+    if parent is None:
+        return skill_error("No /out context", "Cannot create bake nodes")
+
+    baker = parent.createNode("maps_baker", "_tmp_bake_ao_labs")
+    try:
+        obj_str = " ".join(objects)
+        set_parm_if_exists(baker, "soppath", obj_str) or set_parm_if_exists(baker, "objects", obj_str)
+        set_parm_if_exists(baker, "picture", output_path)
+        set_parm_if_exists(baker, "resolution", resolution)
+        set_parm_if_exists(baker, "samples", samples)
+        set_parm_if_exists(baker, "maxdist", max_distance)
+        set_parm_if_exists(baker, "ao", True)
+        set_parm_if_exists(baker, "bake_ambient_occlusion", True)
+
+        try:
+            baker.render(verbose=False)
+        except TypeError:
+            baker.render()
+
+        written = [output_path] if os.path.isfile(output_path) else []
+
+        return skill_success(
+            "Baked ambient occlusion via Labs Maps Baker",
+            bake_method="labs_maps_baker",
+            written_files=written,
+            output_path=output_path,
+            resolution=resolution,
+            samples=samples,
+            max_distance=max_distance,
+            objects=objects,
+        )
+    finally:
+        try:
+            baker.destroy()
+        except Exception:
+            pass
+
+
+def _bake_ao_via_cop(hou, objects: List[str], output_path: str,
+                     resolution: List[int], samples: int) -> dict:
+    """Bake AO using a COP network as last-resort fallback.
+
+    Creates an occlusion COP, attaches geometry, and renders a single frame.
+    """
+    cop_net = hou.node("/img")
+    if cop_net is None:
+        cop_net = hou.node("/").createNode("img", "img")
+    cop_net = hou.node("/img")
+
+    ao_cop = cop_net.createNode("occlusion", "_tmp_bake_ao_cop")
+    try:
+        obj_str = " ".join(objects)
+        set_parm_if_exists(ao_cop, "soppath", obj_str) or set_parm_if_exists(ao_cop, "objects", obj_str)
+        set_parm_if_exists(ao_cop, "samples", samples)
+        set_parm_if_exists(ao_cop, "resolution", resolution)
+
+        rop = cop_net.createNode("rop_cop2", "_tmp_bake_ao_rop")
+        rop.setInput(0, ao_cop)
+        set_parm_if_exists(rop, "copoutput", output_path)
+        set_parm_if_exists(rop, "trange", 0)
+
+        try:
+            rop.render(verbose=False)
+        except TypeError:
+            rop.render()
+
+        written = [output_path] if os.path.isfile(output_path) else []
+
+        return skill_success(
+            "Baked ambient occlusion via COP fallback",
+            bake_method="cop_fallback",
+            written_files=written,
+            output_path=output_path,
+            resolution=resolution,
+            samples=samples,
+            objects=objects,
+            warnings=["COP-based bake is limited; consider installing sidefx_labs for Labs Maps Baker."],
+        )
+    finally:
+        try:
+            ao_cop.destroy()
+        except Exception:
+            pass
+        try:
+            rop.destroy()
+        except Exception:
+            pass
+
+
+def bake_ambient_occlusion(
+    rop_path: str = "/out/bake_ao",
+    objects: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    resolution: Optional[List[int]] = None,
+    samples: int = 64,
+    max_distance: float = 0.0,
+) -> dict:
+    """Bake ambient occlusion to a texture file."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        methods = detect_bake_methods(hou)
+        geo = collect_geometry(hou, objects)
+
+        if not geo:
+            return skill_error(
+                "No geometry found",
+                "Provide 'objects' or ensure renderable OBJ nodes exist",
+                available_methods=methods["available_methods"],
+            )
+
+        res = resolution or [1024, 1024]
+        out = output_path or "$HIP/ao.$F4.exr"
+        methods_info = {k: v for k, v in methods.items() if k in ("labs_maps_baker_available", "bake_texture_rop_available", "available_methods", "recommendations")}
+
+        if methods["labs_maps_baker_available"]:
+            return _bake_ao_via_labs(hou, geo, out, res, samples, max_distance)
+
+        baker_available = any(t in ("baker::2.0", "game_simple_baker", "bake_texture")
+                             for t in hou.nodeType(hou.ropNodeTypeCategory()).installedTypes()
+                             if hasattr(hou.nodeType(hou.ropNodeTypeCategory()), "installedTypes"))
+
+        if methods["bake_texture_rop_available"] or baker_available:
+            try:
+                rop = create_or_get_bake_rop(hou, rop_path)
+                return _bake_ao_via_rop(hou, rop, geo, out, res, samples, max_distance)
+            except Exception as exc:
+                return skill_error(
+                    "Failed to create Bake Texture ROP",
+                    str(exc),
+                    available_methods=methods["available_methods"],
+                    recommendations=methods["recommendations"],
+                )
+
+        # COP fallback
+        return _bake_ao_via_cop(hou, geo, out, res, samples)
+
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake ambient occlusion")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return bake_ambient_occlusion(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_ambient_occlusion.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_ambient_occlusion.py
@@ -22,8 +22,9 @@ from _texture_bake_common import (  # noqa: E402
 )
 
 
-def _bake_ao_via_rop(hou, rop, objects: List[str], output_path: str,
-                     resolution: List[int], samples: int, max_distance: float) -> dict:
+def _bake_ao_via_rop(
+    hou, rop, objects: List[str], output_path: str, resolution: List[int], samples: int, max_distance: float
+) -> dict:
     """Configure and execute a Bake Texture ROP for ambient occlusion."""
     obj_str = " ".join(objects)
 
@@ -58,8 +59,9 @@ def _bake_ao_via_rop(hou, rop, objects: List[str], output_path: str,
     )
 
 
-def _bake_ao_via_labs(hou, objects: List[str], output_path: str,
-                      resolution: List[int], samples: int, max_distance: float) -> dict:
+def _bake_ao_via_labs(
+    hou, objects: List[str], output_path: str, resolution: List[int], samples: int, max_distance: float
+) -> dict:
     """Bake AO using Labs Maps Baker node."""
     parent = hou.node("/out")
     if parent is None:
@@ -100,8 +102,7 @@ def _bake_ao_via_labs(hou, objects: List[str], output_path: str,
             pass
 
 
-def _bake_ao_via_cop(hou, objects: List[str], output_path: str,
-                     resolution: List[int], samples: int) -> dict:
+def _bake_ao_via_cop(hou, objects: List[str], output_path: str, resolution: List[int], samples: int) -> dict:
     """Bake AO using a COP network as last-resort fallback.
 
     Creates an occlusion COP, attaches geometry, and renders a single frame.
@@ -178,14 +179,15 @@ def bake_ambient_occlusion(
 
         res = resolution or [1024, 1024]
         out = output_path or "$HIP/ao.$F4.exr"
-        methods_info = {k: v for k, v in methods.items() if k in ("labs_maps_baker_available", "bake_texture_rop_available", "available_methods", "recommendations")}
 
         if methods["labs_maps_baker_available"]:
             return _bake_ao_via_labs(hou, geo, out, res, samples, max_distance)
 
-        baker_available = any(t in ("baker::2.0", "game_simple_baker", "bake_texture")
-                             for t in hou.nodeType(hou.ropNodeTypeCategory()).installedTypes()
-                             if hasattr(hou.nodeType(hou.ropNodeTypeCategory()), "installedTypes"))
+        baker_available = any(
+            t in ("baker::2.0", "game_simple_baker", "bake_texture")
+            for t in hou.nodeType(hou.ropNodeTypeCategory()).installedTypes()
+            if hasattr(hou.nodeType(hou.ropNodeTypeCategory()), "installedTypes")
+        )
 
         if methods["bake_texture_rop_available"] or baker_available:
             try:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_ambient_occlusion.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_ambient_occlusion.py
@@ -183,13 +183,7 @@ def bake_ambient_occlusion(
         if methods["labs_maps_baker_available"]:
             return _bake_ao_via_labs(hou, geo, out, res, samples, max_distance)
 
-        baker_available = any(
-            t in ("baker::2.0", "game_simple_baker", "bake_texture")
-            for t in hou.nodeType(hou.ropNodeTypeCategory()).installedTypes()
-            if hasattr(hou.nodeType(hou.ropNodeTypeCategory()), "installedTypes")
-        )
-
-        if methods["bake_texture_rop_available"] or baker_available:
+        if methods["bake_texture_rop_available"]:
             try:
                 rop = create_or_get_bake_rop(hou, rop_path)
                 return _bake_ao_via_rop(hou, rop, geo, out, res, samples, max_distance)

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_lighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_lighting.py
@@ -1,0 +1,122 @@
+"""Bake scene lighting via Mantra or Karma render-to-texture."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _texture_bake_common import (  # noqa: E402
+    collect_geometry,
+    create_or_get_bake_rop,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+_VALID_RENDERERS = ("mantra", "karma")
+
+
+def _bake_lighting_via_rop(hou, rop, objects: List[str], camera: Optional[str],
+                           output_path: str, resolution: List[int],
+                           samples: int, renderer: str, bake_shadows: bool) -> dict:
+    """Configure and execute a Bake Texture ROP for lighting."""
+    obj_str = " ".join(objects)
+
+    set_parm_if_exists(rop, "soppath", obj_str) or set_parm_if_exists(rop, "objects", obj_str)
+    set_parm_if_exists(rop, "picture", output_path)
+    set_parm_if_exists(rop, "resolution", resolution)
+    set_parm_if_exists(rop, "res1", resolution[0])
+    set_parm_if_exists(rop, "res2", resolution[1])
+    set_parm_if_exists(rop, "vm_samples", samples)
+    set_parm_if_exists(rop, "lighting", True)
+    set_parm_if_exists(rop, "bake_lighting", True)
+    set_parm_if_exists(rop, "shadows", bake_shadows)
+
+    if camera:
+        set_parm_if_exists(rop, "camera", camera)
+
+    # Select renderer by toggling ROP parameters
+    if renderer == "karma":
+        set_parm_if_exists(rop, "renderer", "karma")
+        set_parm_if_exists(rop, "candidate_renderer", "karma")
+
+    try:
+        rop.render(verbose=False)
+    except TypeError:
+        rop.render()
+
+    written = [output_path] if os.path.isfile(output_path) else []
+
+    return skill_success(
+        "Baked lighting via {}".format(renderer),
+        bake_method="bake_texture_rop",
+        renderer=renderer,
+        written_files=written,
+        output_path=output_path,
+        resolution=resolution,
+        rop=node_summary(hou, rop.path()),
+        objects=objects,
+        camera=camera,
+        bake_shadows=bake_shadows,
+        prompt="Use bake_ambient_occlusion for AO or transfer_maps for normal maps.",
+    )
+
+
+def bake_lighting(
+    rop_path: str = "/out/bake_lighting",
+    camera: Optional[str] = None,
+    objects: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    resolution: Optional[List[int]] = None,
+    samples: int = 4,
+    renderer: str = "mantra",
+    bake_shadows: bool = True,
+) -> dict:
+    """Bake full scene lighting (diffuse + shadows) to a texture."""
+    if renderer not in _VALID_RENDERERS:
+        return skill_error(
+            "Invalid renderer: {}".format(renderer),
+            "Use one of: {}".format(", ".join(_VALID_RENDERERS)),
+        )
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        geo = collect_geometry(hou, objects)
+        if not geo:
+            return skill_error(
+                "No geometry found",
+                "Provide 'objects' or ensure renderable OBJ nodes exist",
+            )
+
+        res = resolution or [1024, 1024]
+        out = output_path or "$HIP/lighting.$F4.exr"
+
+        rop = create_or_get_bake_rop(hou, rop_path)
+        return _bake_lighting_via_rop(
+            hou, rop, geo, camera, out, res, samples, renderer, bake_shadows,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake lighting")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return bake_lighting(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_lighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_lighting.py
@@ -20,13 +20,20 @@ from _texture_bake_common import (  # noqa: E402
     set_parm_if_exists,
 )
 
-
 _VALID_RENDERERS = ("mantra", "karma")
 
 
-def _bake_lighting_via_rop(hou, rop, objects: List[str], camera: Optional[str],
-                           output_path: str, resolution: List[int],
-                           samples: int, renderer: str, bake_shadows: bool) -> dict:
+def _bake_lighting_via_rop(
+    hou,
+    rop,
+    objects: List[str],
+    camera: Optional[str],
+    output_path: str,
+    resolution: List[int],
+    samples: int,
+    renderer: str,
+    bake_shadows: bool,
+) -> dict:
     """Configure and execute a Bake Texture ROP for lighting."""
     obj_str = " ".join(objects)
 
@@ -105,7 +112,15 @@ def bake_lighting(
 
         rop = create_or_get_bake_rop(hou, rop_path)
         return _bake_lighting_via_rop(
-            hou, rop, geo, camera, out, res, samples, renderer, bake_shadows,
+            hou,
+            rop,
+            geo,
+            camera,
+            out,
+            res,
+            samples,
+            renderer,
+            bake_shadows,
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to bake lighting")

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_textures.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_textures.py
@@ -1,0 +1,254 @@
+"""Multi-map texture baking via Labs Maps Baker or Bake Texture ROP.
+
+Supports 20+ map types when Labs Maps Baker is installed, or the standard
+subset available through the Bake Texture ROP.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _texture_bake_common import (  # noqa: E402
+    collect_geometry,
+    create_or_get_bake_rop,
+    detect_bake_methods,
+    node_summary,
+    set_parm_if_exists,
+    validate_map_types,
+    write_file_list,
+)
+
+_DEFAULT_MAP_TYPES = ["normals", "cavity", "curvature", "diffuse", "ambient_occlusion"]
+
+
+def _bake_via_labs(hou, objects: List[str], output_path: str,
+                   resolution: List[int], map_types: List[str],
+                   uv_layer: str, file_format: str) -> dict:
+    """Bake multi-map via Labs Maps Baker."""
+    parent = hou.node("/out")
+    if parent is None:
+        return skill_error("No /out context", "Cannot create bake nodes")
+
+    baker = parent.createNode("maps_baker", "_tmp_bake_maps_labs")
+    try:
+        obj_str = " ".join(objects)
+        set_parm_if_exists(baker, "soppath", obj_str) or set_parm_if_exists(baker, "objects", obj_str)
+        set_parm_if_exists(baker, "picture", output_path)
+        set_parm_if_exists(baker, "resolution", resolution)
+        if uv_layer != "uv":
+            set_parm_if_exists(baker, "uvlayer", uv_layer) or set_parm_if_exists(baker, "uv_layer", uv_layer)
+        set_parm_if_exists(baker, "file_format", file_format)
+
+        # Enable requested map types on the baker
+        _toggle_labs_maps(baker, map_types)
+
+        try:
+            baker.render(verbose=False)
+        except TypeError:
+            baker.render()
+
+        written = [f for f in _generate_expected_files(objects, output_path, map_types, file_format)
+                   if os.path.isfile(f)]
+
+        return skill_success(
+            "Baked {} map type(s) via Labs Maps Baker".format(len(map_types)),
+            bake_method="labs_maps_baker",
+            written_files=written,
+            output_path=output_path,
+            resolution=resolution,
+            map_types=map_types,
+            objects=objects,
+            prompt="Use list_bake_targets to verify UVs before baking, or transfer_maps for high-to-low transfer.",
+        )
+    finally:
+        try:
+            baker.destroy()
+        except Exception:
+            pass
+
+
+def _toggle_labs_maps(baker, map_types: List[str]) -> None:
+    """Toggle the Labs Maps Baker parameters for each requested map type."""
+    param_map = {
+        "normals": ("normal", "normals", "bake_normals"),
+        "cavity": ("cavity", "cavitymap"),
+        "curvature": ("curvature", "bake_curvature"),
+        "diffuse": ("diffuse", "basecolor", "bake_diffuse", "bake_basecolor"),
+        "roughness": ("roughness", "bake_roughness"),
+        "metallic": ("metallic", "bake_metallic"),
+        "thickness": ("thickness", "bake_thickness"),
+        "world_position": ("worldpos", "world_position", "pworld"),
+        "opacity": ("opacity", "bake_opacity"),
+        "ambient_occlusion": ("ao", "ambientocclusion", "ambient_occlusion", "bake_ao"),
+        "displacement": ("displacement", "bake_displacement"),
+        "height": ("height", "bake_height"),
+        "emission": ("emission", "emit", "bake_emission"),
+        "scattering": ("scattering", "bake_scattering"),
+        "transmission": ("transmission", "bake_transmission"),
+        "basecolor": ("basecolor", "base_color", "diffuse"),
+        "specular": ("specular", "bake_specular"),
+        "subsurface": ("subsurface", "bake_subsurface"),
+        "anisotropy": ("anisotropy", "anisotropic", "bake_anisotropy"),
+        "coat": ("coat", "bake_coat"),
+        "sheen": ("sheen", "bake_sheen"),
+    }
+
+    for mt in map_types:
+        candidates = param_map.get(mt, (mt,))
+        for cand in candidates:
+            if set_parm_if_exists(baker, cand, True):
+                break
+
+
+def _generate_expected_files(objects: List[str], output_base: str,
+                             map_types: List[str], file_format: str) -> List[str]:
+    """Generate expected output file paths based on Labs Maps Baker naming."""
+    base_no_ext = os.path.splitext(output_base)[0]
+    files = []
+    for obj in objects:
+        safe = obj.rsplit("/", 1)[-1]
+        for mt in map_types:
+            files.append("{}_{}_{}.{}".format(base_no_ext, safe, mt, file_format))
+    return files
+
+
+def _bake_via_rop(hou, objects: List[str], rop_path: str,
+                  output_path: str, resolution: List[int],
+                  map_types: List[str], uv_layer: str,
+                  file_format: str) -> dict:
+    """Bake multi-map via Bake Texture ROP (one ROP per map type)."""
+    written = []
+    obj_str = " ".join(objects)
+
+    for mt in map_types:
+        rop = create_or_get_bake_rop(hou, rop_path)
+        mt_output = _map_type_output(output_path, mt, file_format)
+        set_parm_if_exists(rop, "soppath", obj_str) or set_parm_if_exists(rop, "objects", obj_str)
+        set_parm_if_exists(rop, "picture", mt_output)
+        set_parm_if_exists(rop, "resolution", resolution)
+        if uv_layer != "uv":
+            set_parm_if_exists(rop, "uvlayer", uv_layer) or set_parm_if_exists(rop, "uv_layer", uv_layer)
+
+        _toggle_rop_maps(rop, mt)
+
+        try:
+            rop.render(verbose=False)
+        except TypeError:
+            rop.render()
+
+        if os.path.isfile(mt_output):
+            written.append(mt_output)
+
+    return skill_success(
+        "Baked {} map type(s) via Bake Texture ROP".format(len(map_types)),
+        bake_method="bake_texture_rop",
+        written_files=written,
+        output_path=output_path,
+        resolution=resolution,
+        map_types=map_types,
+        objects=objects,
+        rop_path=rop_path,
+    )
+
+
+def _map_type_output(output_path: str, map_type: str, file_format: str) -> str:
+    """Generate a per-map-type output path."""
+    base, ext = os.path.splitext(output_path)
+    if not ext:
+        ext = "." + file_format
+    return "{}_{}{}".format(base, map_type, ext)
+
+
+def _toggle_rop_maps(rop, map_type: str) -> None:
+    """Toggle Bake Texture ROP parameters for a given map type."""
+    param_map = {
+        "normals": ("normal", "normals", "bakeNormalMap"),
+        "cavity": ("cavity", "cavitymap"),
+        "curvature": ("curvature", "bakeCurvature"),
+        "diffuse": ("diffuse", "basecolor"),
+        "ambient_occlusion": ("ao", "ambient_occlusion", "bakeAmbientOcclusion"),
+        "roughness": ("roughness", "bakeRoughness"),
+        "metallic": ("metallic", "bakeMetallic"),
+        "opacity": ("opacity", "bakeOpacity"),
+        "thickness": ("thickness", "bakeThickness"),
+        "displacement": ("displacement", "bakeDisplacement"),
+    }
+
+    candidates = param_map.get(map_type, (map_type,))
+    for cand in candidates:
+        if set_parm_if_exists(rop, cand, True):
+            return
+
+
+def bake_textures(
+    rop_path: str,
+    objects: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    resolution: Optional[List[int]] = None,
+    map_types: Optional[List[str]] = None,
+    uv_layer: str = "uv",
+    file_format: str = "exr",
+) -> dict:
+    """Bake multiple texture maps from geometry to image files."""
+    types = map_types or list(_DEFAULT_MAP_TYPES)
+    valid, invalid = validate_map_types(types)
+    if invalid:
+        return skill_error(
+            "Invalid map types: {}".format(invalid),
+            "Supported types: {}".format(sorted(set(t for t in types))),
+        )
+    if not valid:
+        return skill_error("No valid map types provided", "Provide at least one valid map type")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        methods = detect_bake_methods(hou)
+        geo = collect_geometry(hou, objects)
+
+        if not geo:
+            return skill_error(
+                "No geometry found",
+                "Provide 'objects' or ensure renderable OBJ nodes exist",
+            )
+
+        res = resolution or [1024, 1024]
+        out = output_path or "$HIP/bake.$F4.exr"
+
+        if methods["labs_maps_baker_available"]:
+            return _bake_via_labs(hou, geo, out, res, valid, uv_layer, file_format)
+
+        if methods["bake_texture_rop_available"]:
+            return _bake_via_rop(hou, geo, rop_path, out, res, valid, uv_layer, file_format)
+
+        return skill_error(
+            "No bake method available",
+            "Install sidefx_labs for Labs Maps Baker or use Houdini 20+ for Bake Texture ROP",
+            available_methods=methods["available_methods"],
+            recommendations=methods["recommendations"],
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to bake textures")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return bake_textures(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_textures.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/bake_textures.py
@@ -21,18 +21,22 @@ from _texture_bake_common import (  # noqa: E402
     collect_geometry,
     create_or_get_bake_rop,
     detect_bake_methods,
-    node_summary,
     set_parm_if_exists,
     validate_map_types,
-    write_file_list,
 )
 
 _DEFAULT_MAP_TYPES = ["normals", "cavity", "curvature", "diffuse", "ambient_occlusion"]
 
 
-def _bake_via_labs(hou, objects: List[str], output_path: str,
-                   resolution: List[int], map_types: List[str],
-                   uv_layer: str, file_format: str) -> dict:
+def _bake_via_labs(
+    hou,
+    objects: List[str],
+    output_path: str,
+    resolution: List[int],
+    map_types: List[str],
+    uv_layer: str,
+    file_format: str,
+) -> dict:
     """Bake multi-map via Labs Maps Baker."""
     parent = hou.node("/out")
     if parent is None:
@@ -56,8 +60,9 @@ def _bake_via_labs(hou, objects: List[str], output_path: str,
         except TypeError:
             baker.render()
 
-        written = [f for f in _generate_expected_files(objects, output_path, map_types, file_format)
-                   if os.path.isfile(f)]
+        written = [
+            f for f in _generate_expected_files(objects, output_path, map_types, file_format) if os.path.isfile(f)
+        ]
 
         return skill_success(
             "Baked {} map type(s) via Labs Maps Baker".format(len(map_types)),
@@ -109,8 +114,7 @@ def _toggle_labs_maps(baker, map_types: List[str]) -> None:
                 break
 
 
-def _generate_expected_files(objects: List[str], output_base: str,
-                             map_types: List[str], file_format: str) -> List[str]:
+def _generate_expected_files(objects: List[str], output_base: str, map_types: List[str], file_format: str) -> List[str]:
     """Generate expected output file paths based on Labs Maps Baker naming."""
     base_no_ext = os.path.splitext(output_base)[0]
     files = []
@@ -121,10 +125,16 @@ def _generate_expected_files(objects: List[str], output_base: str,
     return files
 
 
-def _bake_via_rop(hou, objects: List[str], rop_path: str,
-                  output_path: str, resolution: List[int],
-                  map_types: List[str], uv_layer: str,
-                  file_format: str) -> dict:
+def _bake_via_rop(
+    hou,
+    objects: List[str],
+    rop_path: str,
+    output_path: str,
+    resolution: List[int],
+    map_types: List[str],
+    uv_layer: str,
+    file_format: str,
+) -> dict:
     """Bake multi-map via Bake Texture ROP (one ROP per map type)."""
     written = []
     obj_str = " ".join(objects)
@@ -204,7 +214,7 @@ def bake_textures(
     if invalid:
         return skill_error(
             "Invalid map types: {}".format(invalid),
-            "Supported types: {}".format(sorted(set(t for t in types))),
+            "Supported types: {}".format(sorted(set(types))),
         )
     if not valid:
         return skill_error("No valid map types provided", "Provide at least one valid map type")

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/list_bake_targets.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/list_bake_targets.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
@@ -66,13 +65,23 @@ def list_bake_targets(
             targets = [t for t in targets if t.get("has_uvs", False)]
 
         bake_ready = [t for t in targets if t.get("bake_ready", False)]
-        methods_info = {k: v for k, v in methods.items()
-                        if k in ("labs_maps_baker_available", "bake_texture_rop_available",
-                                 "available_methods", "recommended", "recommendations")}
+        methods_info = {
+            k: v
+            for k, v in methods.items()
+            if k
+            in (
+                "labs_maps_baker_available",
+                "bake_texture_rop_available",
+                "available_methods",
+                "recommended",
+                "recommendations",
+            )
+        }
 
         return skill_success(
             "Found {} bake target(s) ({} bake-ready)".format(
-                len(targets), len(bake_ready),
+                len(targets),
+                len(bake_ready),
             ),
             targets=targets,
             bake_ready_count=len(bake_ready),

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/list_bake_targets.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/list_bake_targets.py
@@ -1,0 +1,95 @@
+"""Scan for bake-compatible geometry nodes. Read-only, sync."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _texture_bake_common import (  # noqa: E402
+    bake_geometry_info,
+    detect_bake_methods,
+)
+
+
+def list_bake_targets(
+    node_type_filter: str = "obj",
+    require_uvs: bool = False,
+) -> dict:
+    """Scan scene geometry and report bake-compatible nodes with UV info."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        methods = detect_bake_methods(hou)
+        targets = []
+
+        if node_type_filter in ("obj", "all"):
+            obj_root = hou.node("/obj")
+            if obj_root is not None:
+                for child in obj_root.children():
+                    info = bake_geometry_info(hou, child.path())
+                    if info is None:
+                        continue
+                    if node_type_filter == "all" and info.get("has_display_geo"):
+                        sop_node = child.displayNode()
+                        if sop_node is not None:
+                            sop_info = bake_geometry_info(hou, sop_node.path())
+                            if sop_info:
+                                sop_info["parent_obj"] = child.path()
+                                targets.append(sop_info)
+                    if info.get("has_display_geo", False):
+                        targets.append(info)
+
+        if node_type_filter in ("sop", "all"):
+            # Scan SOP networks inside OBJ containers
+            obj_root = hou.node("/obj")
+            if obj_root is not None:
+                for child in obj_root.children():
+                    display = child.displayNode() if hasattr(child, "displayNode") else None
+                    if display is not None:
+                        info = bake_geometry_info(hou, display.path())
+                        if info is not None and info.get("primitive_count", 0) > 0:
+                            if child.path() not in {t["path"] for t in targets}:
+                                info["parent_obj"] = child.path()
+                                targets.append(info)
+
+        if require_uvs:
+            targets = [t for t in targets if t.get("has_uvs", False)]
+
+        bake_ready = [t for t in targets if t.get("bake_ready", False)]
+        methods_info = {k: v for k, v in methods.items()
+                        if k in ("labs_maps_baker_available", "bake_texture_rop_available",
+                                 "available_methods", "recommended", "recommendations")}
+
+        return skill_success(
+            "Found {} bake target(s) ({} bake-ready)".format(
+                len(targets), len(bake_ready),
+            ),
+            targets=targets,
+            bake_ready_count=len(bake_ready),
+            total_count=len(targets),
+            methods=methods_info,
+            prompt="Pick bake-ready targets with UVs, then use bake_textures, bake_ambient_occlusion, or bake_lighting.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list bake targets")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_bake_targets(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/transfer_maps.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/transfer_maps.py
@@ -16,8 +16,6 @@ if _SCRIPT_DIR not in sys.path:
 from _texture_bake_common import (  # noqa: E402
     check_uvs,
     detect_bake_methods,
-    get_node,
-    node_summary,
     set_parm_if_exists,
     validate_map_types,
 )
@@ -26,10 +24,17 @@ _VALID_TRANSFER_MODES = ("raytrace", "cage", "projection")
 _DEFAULT_TRANSFER_MAP_TYPES = ["normals"]
 
 
-def _transfer_via_labs(hou, source: str, target: str, map_types: List[str],
-                       output_dir: str, resolution: List[int],
-                       file_format: str, transfer_mode: str,
-                       search_distance: float) -> dict:
+def _transfer_via_labs(
+    hou,
+    source: str,
+    target: str,
+    map_types: List[str],
+    output_dir: str,
+    resolution: List[int],
+    file_format: str,
+    transfer_mode: str,
+    search_distance: float,
+) -> dict:
     """Transfer maps using Labs Maps Baker with high-res source input."""
     parent = hou.node("/out")
     if parent is None:
@@ -56,7 +61,10 @@ def _transfer_via_labs(hou, source: str, target: str, map_types: List[str],
             out_file = os.path.join(
                 output_dir,
                 "{}_from_{}_{}.{}".format(
-                    target.rsplit("/", 1)[-1], source.rsplit("/", 1)[-1], mt, file_format,
+                    target.rsplit("/", 1)[-1],
+                    source.rsplit("/", 1)[-1],
+                    mt,
+                    file_format,
                 ),
             )
             set_parm_if_exists(baker, "picture", out_file)
@@ -102,10 +110,17 @@ def _toggle_transfer_maps(baker, map_types: List[str]) -> None:
                 break
 
 
-def _transfer_via_rop(hou, source: str, target: str, map_types: List[str],
-                      output_dir: str, resolution: List[int],
-                      file_format: str, transfer_mode: str,
-                      search_distance: float) -> dict:
+def _transfer_via_rop(
+    hou,
+    source: str,
+    target: str,
+    map_types: List[str],
+    output_dir: str,
+    resolution: List[int],
+    file_format: str,
+    transfer_mode: str,
+    search_distance: float,
+) -> dict:
     """Transfer maps using Bake Texture ROP with high-res source plugged into second input."""
     parent = hou.node("/out")
     if parent is None:
@@ -143,7 +158,10 @@ def _transfer_via_rop(hou, source: str, target: str, map_types: List[str],
             out_file = os.path.join(
                 output_dir,
                 "{}_from_{}_{}.{}".format(
-                    target.rsplit("/", 1)[-1], source.rsplit("/", 1)[-1], mt, file_format,
+                    target.rsplit("/", 1)[-1],
+                    source.rsplit("/", 1)[-1],
+                    mt,
+                    file_format,
                 ),
             )
             set_parm_if_exists(rop, "picture", out_file)
@@ -230,12 +248,28 @@ def transfer_maps(
 
         if methods["labs_maps_baker_available"]:
             return _transfer_via_labs(
-                hou, source, target, valid, output_dir, res, file_format, transfer_mode, search_distance,
+                hou,
+                source,
+                target,
+                valid,
+                output_dir,
+                res,
+                file_format,
+                transfer_mode,
+                search_distance,
             )
 
         if methods["bake_texture_rop_available"]:
             return _transfer_via_rop(
-                hou, source, target, valid, output_dir, res, file_format, transfer_mode, search_distance,
+                hou,
+                source,
+                target,
+                valid,
+                output_dir,
+                res,
+                file_format,
+                transfer_mode,
+                search_distance,
             )
 
         return skill_error(

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/transfer_maps.py
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/scripts/transfer_maps.py
@@ -1,0 +1,259 @@
+"""Transfer maps from high-res source to low-res target via Labs Maps Baker or raytrace/cage fallback."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _texture_bake_common import (  # noqa: E402
+    check_uvs,
+    detect_bake_methods,
+    get_node,
+    node_summary,
+    set_parm_if_exists,
+    validate_map_types,
+)
+
+_VALID_TRANSFER_MODES = ("raytrace", "cage", "projection")
+_DEFAULT_TRANSFER_MAP_TYPES = ["normals"]
+
+
+def _transfer_via_labs(hou, source: str, target: str, map_types: List[str],
+                       output_dir: str, resolution: List[int],
+                       file_format: str, transfer_mode: str,
+                       search_distance: float) -> dict:
+    """Transfer maps using Labs Maps Baker with high-res source input."""
+    parent = hou.node("/out")
+    if parent is None:
+        return skill_error("No /out context", "Cannot create bake nodes")
+
+    baker = parent.createNode("maps_baker", "_tmp_transfer_labs")
+    try:
+        set_parm_if_exists(baker, "soppath", target)
+        set_parm_if_exists(baker, "highres", source)
+        set_parm_if_exists(baker, "highresobj", source)
+        set_parm_if_exists(baker, "resolution", resolution)
+        set_parm_if_exists(baker, "file_format", file_format)
+        if transfer_mode == "cage":
+            set_parm_if_exists(baker, "usecagemesh", True)
+            set_parm_if_exists(baker, "cagemesh", source)
+        elif transfer_mode == "raytrace":
+            set_parm_if_exists(baker, "searchdist", search_distance)
+
+        # Enable requested map types
+        _toggle_transfer_maps(baker, map_types)
+
+        baked_files = []
+        for mt in map_types:
+            out_file = os.path.join(
+                output_dir,
+                "{}_from_{}_{}.{}".format(
+                    target.rsplit("/", 1)[-1], source.rsplit("/", 1)[-1], mt, file_format,
+                ),
+            )
+            set_parm_if_exists(baker, "picture", out_file)
+
+            try:
+                baker.render(verbose=False)
+            except TypeError:
+                baker.render()
+
+            if os.path.isfile(out_file):
+                baked_files.append(out_file)
+
+        return skill_success(
+            "Transferred {} map(s) via Labs Maps Baker".format(len(baked_files)),
+            bake_method="labs_maps_baker",
+            transfer_mode=transfer_mode,
+            written_files=baked_files,
+            source=source,
+            target=target,
+            resolution=resolution,
+            map_types=map_types,
+            prompt="Check output_dir for baked maps. Use bake_textures for additional map types.",
+        )
+    finally:
+        try:
+            baker.destroy()
+        except Exception:
+            pass
+
+
+def _toggle_transfer_maps(baker, map_types: List[str]) -> None:
+    """Toggle Labs Maps Baker parameters for transfer-relevant map types."""
+    param_map = {
+        "normals": ("normal", "normals", "bake_normals"),
+        "displacement": ("displacement", "bake_displacement", "height"),
+        "diffuse": ("diffuse", "basecolor", "bake_diffuse"),
+        "ambient_occlusion": ("ao", "ambientocclusion", "bake_ao"),
+    }
+    for mt in map_types:
+        candidates = param_map.get(mt, (mt,))
+        for cand in candidates:
+            if set_parm_if_exists(baker, cand, True):
+                break
+
+
+def _transfer_via_rop(hou, source: str, target: str, map_types: List[str],
+                      output_dir: str, resolution: List[int],
+                      file_format: str, transfer_mode: str,
+                      search_distance: float) -> dict:
+    """Transfer maps using Bake Texture ROP with high-res source plugged into second input."""
+    parent = hou.node("/out")
+    if parent is None:
+        return skill_error("No /out context", "Cannot create bake nodes")
+
+    baked_files = []
+
+    for mt in map_types:
+        for type_name in ("baker::2.0", "game_simple_baker", "bake_texture"):
+            try:
+                rop = parent.createNode(type_name, "_tmp_transfer_{}".format(mt))
+                break
+            except Exception:
+                continue
+        else:
+            continue
+
+        try:
+            set_parm_if_exists(rop, "soppath", target)
+            set_parm_if_exists(rop, "resolution", resolution)
+            if transfer_mode == "raytrace":
+                set_parm_if_exists(rop, "searchdist", search_distance)
+
+            # Enable this specific map type
+            mt_candidates = {
+                "normals": ("normal", "normals", "bakeNormalMap"),
+                "displacement": ("displacement", "bakeDisplacement"),
+                "diffuse": ("diffuse", "basecolor"),
+                "ambient_occlusion": ("ao", "ambient_occlusion", "bakeAmbientOcclusion"),
+            }
+            for cand in mt_candidates.get(mt, (mt,)):
+                if set_parm_if_exists(rop, cand, True):
+                    break
+
+            out_file = os.path.join(
+                output_dir,
+                "{}_from_{}_{}.{}".format(
+                    target.rsplit("/", 1)[-1], source.rsplit("/", 1)[-1], mt, file_format,
+                ),
+            )
+            set_parm_if_exists(rop, "picture", out_file)
+
+            try:
+                rop.render(verbose=False)
+            except TypeError:
+                rop.render()
+
+            if os.path.isfile(out_file):
+                baked_files.append(out_file)
+        finally:
+            try:
+                rop.destroy()
+            except Exception:
+                pass
+
+    return skill_success(
+        "Transferred {} map(s) via Bake Texture ROP".format(len(baked_files)),
+        bake_method="bake_texture_rop",
+        transfer_mode=transfer_mode,
+        written_files=baked_files,
+        source=source,
+        target=target,
+        resolution=resolution,
+        map_types=map_types,
+    )
+
+
+def transfer_maps(
+    source: str,
+    target: str,
+    map_types: Optional[List[str]] = None,
+    output_dir: str = "/tmp",
+    resolution: Optional[List[int]] = None,
+    file_format: str = "png",
+    transfer_mode: str = "raytrace",
+    search_distance: float = 0.1,
+) -> dict:
+    """Transfer texture maps from high-res source to low-res target."""
+    if transfer_mode not in _VALID_TRANSFER_MODES:
+        return skill_error(
+            "Invalid transfer_mode: {}".format(transfer_mode),
+            "Use one of: {}".format(", ".join(_VALID_TRANSFER_MODES)),
+        )
+
+    types = map_types or list(_DEFAULT_TRANSFER_MAP_TYPES)
+    valid, invalid = validate_map_types(types)
+    if invalid:
+        return skill_error(
+            "Invalid map types: {}".format(invalid),
+            "Supported types for transfer: normals, displacement, diffuse, ambient_occlusion",
+        )
+    if not valid:
+        return skill_error("No valid map types", "Provide at least one valid map type")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        # Validate source and target exist
+        for node_path in (source, target):
+            if hou.node(node_path) is None:
+                return skill_error(
+                    "Node not found: {}".format(node_path),
+                    "Verify the node path is correct",
+                )
+
+        # Check target has UVs
+        target_uvs = check_uvs(hou, target)
+        if not target_uvs:
+            return skill_error(
+                "Target has no UVs: {}".format(target),
+                "Transfer target must have UV attributes. Run list_bake_targets() to find UV-equipped geometry.",
+            )
+
+        methods = detect_bake_methods(hou)
+        res = resolution or [1024, 1024]
+
+        if not os.path.isdir(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        if methods["labs_maps_baker_available"]:
+            return _transfer_via_labs(
+                hou, source, target, valid, output_dir, res, file_format, transfer_mode, search_distance,
+            )
+
+        if methods["bake_texture_rop_available"]:
+            return _transfer_via_rop(
+                hou, source, target, valid, output_dir, res, file_format, transfer_mode, search_distance,
+            )
+
+        return skill_error(
+            "No bake method available for transfer",
+            "Install sidefx_labs for Labs Maps Baker or use Houdini 20+ for Bake Texture ROP",
+            available_methods=methods["available_methods"],
+            recommendations=methods["recommendations"],
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to transfer maps")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return transfer_maps(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/tools.yaml
@@ -1,0 +1,224 @@
+tools:
+  - name: bake_ambient_occlusion
+    description: >-
+      Bake ambient occlusion to a texture using Labs Maps Baker, Bake Texture
+      ROP, or COP-based fallback. Returns written_files, bake method used,
+      and available methods detected.
+    source_file: scripts/bake_ambient_occlusion.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 900
+    group: bake-ao
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        rop_path:
+          type: string
+          description: "ROP node path for the bake (e.g. /out/bake_ao). Created if missing."
+        objects:
+          type: array
+          items: {type: string}
+          description: "Geometry node paths to bake. Defaults to all renderable OBJ nodes."
+        output_path:
+          type: string
+          description: "Output image path. Defaults to $HIP/ao.$F4.exr."
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+          description: "[width, height]. Default: [1024, 1024]."
+        samples:
+          type: integer
+          default: 64
+          description: "AO ray samples."
+        max_distance:
+          type: number
+          default: 0.0
+          description: "Maximum ray distance (0 = unlimited)."
+
+  - name: bake_lighting
+    description: >-
+      Bake full scene lighting (diffuse + shadows) via Mantra or Karma
+      render-to-texture using a Bake Texture ROP. Async with 900s timeout.
+    source_file: scripts/bake_lighting.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 900
+    group: bake-lighting
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        rop_path:
+          type: string
+          description: "ROP node path (e.g. /out/bake_light). Created if missing."
+        camera:
+          type: string
+          description: "Camera path for lighting bake (e.g. /obj/rendercam)."
+        objects:
+          type: array
+          items: {type: string}
+          description: "Geometry to bake. Defaults to all renderable OBJ nodes."
+        output_path:
+          type: string
+          description: "Output path. Default: $HIP/lighting.$F4.exr."
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+        samples:
+          type: integer
+          default: 4
+          description: "Pixel samples."
+        renderer:
+          type: string
+          default: "mantra"
+          description: "Renderer: 'mantra' or 'karma'."
+        bake_shadows:
+          type: boolean
+          default: true
+
+  - name: bake_textures
+    description: >-
+      Bake multi-map textures (diffuse, normals, cavity, curvature, roughness,
+      metallic, etc.) via Labs Maps Baker or Bake Texture ROP. Async, 1800s
+      timeout for large batches.
+    source_file: scripts/bake_textures.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 1800
+    group: bake-textures
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [rop_path]
+      properties:
+        rop_path:
+          type: string
+          description: "ROP node path (e.g. /out/bake_maps). Created if missing."
+        objects:
+          type: array
+          items: {type: string}
+          description: "Geometry to bake. Defaults to all renderable OBJ nodes."
+        output_path:
+          type: string
+          description: "Output base path (map type suffix appended)."
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+          description: "[width, height]."
+        map_types:
+          type: array
+          items: {type: string}
+          description: "Map types to bake: normals, cavity, curvature, diffuse, roughness, metallic, thickness, world_position, opacity, ambient_occlusion, etc."
+        uv_layer:
+          type: string
+          default: "uv"
+          description: "Name of the UV attribute to use for baking."
+        file_format:
+          type: string
+          default: "exr"
+
+  - name: list_bake_targets
+    description: >-
+      Scan the scene for bake-compatible geometry nodes. Reports node path,
+      type, primitive count, has_uvs status, UV layer names, and bake-ready
+      flag. Read-only, sync.
+    source_file: scripts/list_bake_targets.py
+    execution: sync
+    affinity: main
+    group: bake-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        node_type_filter:
+          type: string
+          default: "obj"
+          description: "Node type to scan: 'obj', 'sop', or 'all'."
+        require_uvs:
+          type: boolean
+          default: false
+          description: "Only return nodes that have UV attributes."
+
+  - name: transfer_maps
+    description: >-
+      Transfer texture maps (normals, displacement, diffuse, AO) from a
+      high-resolution source to a low-resolution target mesh using Labs Maps
+      Baker with high-res source input or raytrace/cage fallback. Async,
+      1200s timeout.
+    source_file: scripts/transfer_maps.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 1200
+    group: bake-transfer
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [source, target]
+      properties:
+        source:
+          type: string
+          description: "High-resolution source geometry path."
+        target:
+          type: string
+          description: "Low-resolution target geometry path (must have UVs)."
+        map_types:
+          type: array
+          items: {type: string}
+          description: "Map types: normals, displacement, diffuse, ambient_occlusion. Default: ['normals']."
+        output_dir:
+          type: string
+          default: "/tmp"
+          description: "Output directory for baked images."
+        resolution:
+          type: array
+          items: {type: integer}
+          minItems: 2
+          maxItems: 2
+        file_format:
+          type: string
+          default: "png"
+        transfer_mode:
+          type: string
+          default: "raytrace"
+          description: "Transfer mode: 'raytrace', 'cage', or 'projection'."
+        search_distance:
+          type: number
+          default: 0.1
+          description: "Ray search distance when transfer_mode is 'raytrace'."

--- a/tests/test_texture_bake_common.py
+++ b/tests/test_texture_bake_common.py
@@ -1,0 +1,466 @@
+"""Mock-hou unit tests for houdini-texture-bake shared helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_module() -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-texture-bake" / "scripts" / "_texture_bake_common.py"
+    spec = importlib.util.spec_from_file_location("_texture_bake_common", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# detect_bake_methods
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBakeMethods:
+    def test_labs_and_rop_both_available(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        # nodeType returns non-None for both categories → both methods detected
+        mock_hou.nodeType.return_value = MagicMock()  # not None
+
+        result = mod.detect_bake_methods(mock_hou)
+
+        assert result["labs_maps_baker_available"] is True
+        assert result["bake_texture_rop_available"] is True
+        assert "labs_maps_baker" in result["available_methods"]
+        assert "bake_texture_rop" in result["available_methods"]
+        assert "cop_fallback" in result["available_methods"]
+        assert result["recommended"] == "labs_maps_baker"
+        assert result["recommendations"] == []
+
+    def test_only_rop_available(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+
+        # vopNodeTypeCategory returns None (labs not available)
+        vop_cat = MagicMock()
+        # ropNodeTypeCategory returns non-None (rop available)
+        rop_cat = MagicMock()
+        mock_hou.vopNodeTypeCategory.return_value = vop_cat
+        mock_hou.ropNodeTypeCategory.return_value = rop_cat
+
+        # nodeType returns None for vop lookup, MagicMock for rop lookup
+        def _nt(cat, type_name=None):
+            if cat is vop_cat:
+                return None
+            return MagicMock()
+
+        mock_hou.nodeType.side_effect = _nt
+
+        result = mod.detect_bake_methods(mock_hou)
+
+        assert result["labs_maps_baker_available"] is False
+        assert result["bake_texture_rop_available"] is True
+        assert result["recommended"] == "bake_texture_rop"
+        assert "Install sidefx_labs" in result["recommendations"][0]
+
+    def test_nothing_available_cop_fallback_only(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.nodeType.return_value = None  # nothing available
+
+        result = mod.detect_bake_methods(mock_hou)
+
+        assert result["labs_maps_baker_available"] is False
+        assert result["bake_texture_rop_available"] is False
+        assert result["available_methods"] == ["cop_fallback"]
+        assert result["recommended"] == "cop_fallback"
+        assert len(result["recommendations"]) == 1
+
+    def test_labs_detect_swallows_exceptions(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.nodeType.side_effect = RuntimeError("boom")
+
+        result = mod.detect_bake_methods(mock_hou)
+
+        assert result["labs_maps_baker_available"] is False
+        assert result["bake_texture_rop_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# validate_map_types
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMapTypes:
+    def test_all_valid(self) -> None:
+        mod = _load_module()
+        valid, invalid = mod.validate_map_types(["normals", "cavity", "diffuse"])
+        assert valid == ["normals", "cavity", "diffuse"]
+        assert invalid == []
+
+    def test_all_invalid(self) -> None:
+        mod = _load_module()
+        valid, invalid = mod.validate_map_types(["unicorn", "rainbow", "glitter"])
+        assert valid == []
+        assert invalid == ["unicorn", "rainbow", "glitter"]
+
+    def test_mixed_valid_and_invalid(self) -> None:
+        mod = _load_module()
+        valid, invalid = mod.validate_map_types(["normals", "bogus", "curvature", "nope"])
+        assert valid == ["normals", "curvature"]
+        assert invalid == ["bogus", "nope"]
+
+    def test_empty_list(self) -> None:
+        mod = _load_module()
+        valid, invalid = mod.validate_map_types([])
+        assert valid == []
+        assert invalid == []
+
+    def test_all_vocabulary_types_returned_as_valid(self) -> None:
+        mod = _load_module()
+        all_types = [
+            "normals",
+            "cavity",
+            "curvature",
+            "diffuse",
+            "roughness",
+            "metallic",
+            "thickness",
+            "world_position",
+            "opacity",
+            "ambient_occlusion",
+            "displacement",
+            "height",
+            "emission",
+            "scattering",
+            "transmission",
+            "basecolor",
+            "specular",
+            "subsurface",
+            "anisotropy",
+            "coat",
+            "sheen",
+        ]
+        valid, invalid = mod.validate_map_types(all_types)
+        assert valid == all_types
+        assert invalid == []
+
+
+# ---------------------------------------------------------------------------
+# check_uvs
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUvs:
+    def _make_geo_with_uv(self, uv_name: str = "uv") -> MagicMock:
+        geo = MagicMock()
+        pt_attr = MagicMock()
+        pt_attr.dataType.return_value = "Float"
+        pt_attr.size.return_value = 2
+        pt_attr.name.return_value = uv_name
+        geo.pointAttribs.return_value = [pt_attr]
+        geo.vertexAttribs.return_value = []
+        return geo
+
+    def _make_mock_hou(self, geo: MagicMock | None) -> MagicMock:
+        mock_hou = MagicMock()
+        mock_hou.attribData = MagicMock()
+        mock_hou.attribData.Float = "Float"
+
+        display = MagicMock()
+        display.geometry.return_value = geo
+
+        node = MagicMock()
+        node.displayNode.return_value = display
+        mock_hou.node.return_value = node
+
+        return mock_hou
+
+    def test_returns_uv_attribute_name(self) -> None:
+        mod = _load_module()
+        geo = self._make_geo_with_uv("uv")
+        mock_hou = self._make_mock_hou(geo)
+
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result == ["uv"]
+
+    def test_returns_multiple_uv_layers(self) -> None:
+        mod = _load_module()
+        geo = MagicMock()
+        uv1 = MagicMock()
+        uv1.dataType.return_value = "Float"
+        uv1.size.return_value = 2
+        uv1.name.return_value = "uv"
+        uv2 = MagicMock()
+        uv2.dataType.return_value = "Float"
+        uv2.size.return_value = 2
+        uv2.name.return_value = "uv2"
+        geo.pointAttribs.return_value = [uv1, uv2]
+        geo.vertexAttribs.return_value = []
+
+        mock_hou = self._make_mock_hou(geo)
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert set(result) == {"uv", "uv2"}
+
+    def test_node_not_found_returns_none(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        result = mod.check_uvs(mock_hou, "/obj/nope")
+        assert result is None
+
+    def test_no_display_node_returns_none(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        node = MagicMock()
+        del node.displayNode  # hasattr returns False
+        mock_hou.node.return_value = node
+
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result is None
+
+    def test_no_geometry_returns_none(self) -> None:
+        mod = _load_module()
+        mock_hou = self._make_mock_hou(None)
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result is None
+
+    def test_no_uv_attributes_returns_empty_list(self) -> None:
+        mod = _load_module()
+        geo = MagicMock()
+        geo.pointAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        mock_hou = self._make_mock_hou(geo)
+
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result == []
+
+    def test_vertex_uvs_detected(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.attribData = MagicMock()
+        mock_hou.attribData.Float = "Float"
+
+        # Build vertex attribute with real method-mocks inline
+        geo = MagicMock()
+        geo.pointAttribs.return_value = []
+        vtx_attr = MagicMock()
+        vtx_attr.dataType = MagicMock(return_value="Float")
+        vtx_attr.size = MagicMock(return_value=2)
+        vtx_attr.name = MagicMock(return_value="uv1")
+        geo.vertexAttribs.return_value = [vtx_attr]
+
+        display = MagicMock()
+        display.geometry.return_value = geo
+        node = MagicMock()
+        node.displayNode.return_value = display
+        mock_hou.node.return_value = node
+
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result == ["uv1"]
+
+    def test_skips_non_float_attribs(self) -> None:
+        mod = _load_module()
+        geo = MagicMock()
+        pt_attr = MagicMock()
+        pt_attr.dataType.return_value = "Int"  # not Float
+        pt_attr.size.return_value = 2
+        pt_attr.name.return_value = "uv"
+        geo.pointAttribs.return_value = [pt_attr]
+        geo.vertexAttribs.return_value = []
+        mock_hou = self._make_mock_hou(geo)
+
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result == []
+
+    def test_skips_non_2d_attribs(self) -> None:
+        mod = _load_module()
+        geo = MagicMock()
+        pt_attr = MagicMock()
+        pt_attr.configure_mock(**{"dataType.return_value": "Float", "size.return_value": 1, "name.return_value": "uv"})
+        geo.pointAttribs.return_value = [pt_attr]
+        geo.vertexAttribs.return_value = []
+        mock_hou = self._make_mock_hou(geo)
+
+        result = mod.check_uvs(mock_hou, "/obj/geo1")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# bake_geometry_info
+# ---------------------------------------------------------------------------
+
+
+class TestBakeGeometryInfo:
+    def test_node_not_found(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        result = mod.bake_geometry_info(mock_hou, "/obj/nope")
+        assert result is None
+
+    def test_no_display_geometry(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.attribData = MagicMock()
+        mock_hou.attribData.Float = "Float"
+        node = MagicMock()
+        node.name.return_value = "geo1"
+        del node.displayNode
+        mock_hou.node.return_value = node
+
+        result = mod.bake_geometry_info(mock_hou, "/obj/geo1")
+        assert result is not None
+        assert result["path"] == "/obj/geo1"
+        assert result["has_display_geo"] is False
+        assert result["bake_ready"] is False
+        assert result["primitive_count"] == 0
+
+    def test_obj_with_uvs_and_prims(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.attribData = MagicMock()
+        mock_hou.attribData.Float = "Float"
+        # Set up display geometry
+        geo = MagicMock()
+        prim = MagicMock()
+        geo.iterPrims.return_value = [prim]
+        geo.pointAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        display = MagicMock()
+        display.geometry.return_value = geo
+        node = MagicMock()
+        node.name.return_value = "geo1"
+        node.displayNode.return_value = display
+        mock_hou.node.return_value = node
+
+        result = mod.bake_geometry_info(mock_hou, "/obj/geo1")
+        assert result is not None
+        assert result["name"] == "geo1"
+        assert result["type"] == "obj"
+        assert result["has_display_geo"] is True
+        assert result["primitive_count"] == 1
+        # No UVs → not bake ready
+        assert result["has_uvs"] is False
+        assert result["bake_ready"] is False
+
+    def test_sop_node_type(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.attribData = MagicMock()
+        mock_hou.attribData.Float = "Float"
+        geo = MagicMock()
+        geo.iterPrims.return_value = []
+        geo.pointAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        display = MagicMock()
+        display.geometry.return_value = geo
+        node = MagicMock()
+        node.name.return_value = "sphere1"
+        node.displayNode.return_value = display
+        mock_hou.node.return_value = node
+
+        result = mod.bake_geometry_info(mock_hou, "/sop/path/sphere1")
+        assert result is not None
+        assert result["type"] == "sop"
+        assert result["bake_ready"] is False  # no UVs, no primitives
+
+    def test_bake_ready_when_has_uvs_and_primitives(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.attribData = MagicMock()
+        mock_hou.attribData.Float = "Float"
+        geo = MagicMock()
+        prim = MagicMock()
+        geo.iterPrims.return_value = [prim, prim, prim]  # 3 primitives
+        uv_attr = MagicMock()
+        uv_attr.dataType.return_value = "Float"
+        uv_attr.size.return_value = 2
+        uv_attr.name.return_value = "uv"
+        geo.pointAttribs.return_value = [uv_attr]
+        geo.vertexAttribs.return_value = []
+        display = MagicMock()
+        display.geometry.return_value = geo
+        node = MagicMock()
+        node.name.return_value = "geo1"
+        node.displayNode.return_value = display
+        mock_hou.node.return_value = node
+
+        result = mod.bake_geometry_info(mock_hou, "/obj/geo1")
+        assert result is not None
+        assert result["has_uvs"] is True
+        assert result["uv_layers"] == ["uv"]
+        assert result["primitive_count"] == 3
+        assert result["bake_ready"] is True
+
+
+# ---------------------------------------------------------------------------
+# collect_geometry
+# ---------------------------------------------------------------------------
+
+
+class TestCollectGeometry:
+    def test_explicit_object_list_passed_through(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        result = mod.collect_geometry(mock_hou, ["/obj/geo1", "/obj/geo2"])
+        assert result == ["/obj/geo1", "/obj/geo2"]
+
+    def test_returns_empty_when_obj_root_missing(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        result = mod.collect_geometry(mock_hou, None)
+        assert result == []
+
+    def test_collects_renderable_children(self) -> None:
+        mod = _load_module()
+        mock_hou = MagicMock()
+        # Child with displayNode
+        child1 = MagicMock()
+        child1.path.return_value = "/obj/geo1"
+        display1 = MagicMock()
+        child1.displayNode.return_value = display1
+        # Child without displayNode
+        child2 = MagicMock()
+        del child2.displayNode
+        # Child with displayNode that returns None
+        child3 = MagicMock()
+        child3.displayNode.return_value = None
+        child3.path.return_value = "/obj/geo3"
+
+        root = MagicMock()
+        root.children.return_value = [child1, child2, child3]
+        mock_hou.node.return_value = root
+
+        result = mod.collect_geometry(mock_hou, None)
+        assert result == ["/obj/geo1"]
+
+
+# ---------------------------------------------------------------------------
+# validate_map_types (edge)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMapTypesEdgeCases:
+    def test_duplicates_preserved_in_valid(self) -> None:
+        mod = _load_module()
+        valid, invalid = mod.validate_map_types(["diffuse", "diffuse"])
+        assert valid == ["diffuse", "diffuse"]
+        assert invalid == []
+
+    def test_case_sensitive(self) -> None:
+        mod = _load_module()
+        valid, invalid = mod.validate_map_types(["Diffuse", "DIFFUSE"])
+        assert valid == []
+        assert invalid == ["Diffuse", "DIFFUSE"]


### PR DESCRIPTION
## Summary

Add `houdini-texture-bake` bundled skill with 5 typed tools covering the full texture baking pipeline:

- **bake_ambient_occlusion** — AO baking via Labs Maps Baker, Bake Texture ROP, or COP fallback (async, 900s)
- **bake_lighting** — scene lighting bake via Mantra/Karma render-to-texture (async, 900s)
- **bake_textures** — multi-map baking supporting 20+ map types (async, 1800s)
- **list_bake_targets** — scan geometry for UV-equipped, bake-compatible nodes (sync, read-only)
- **transfer_maps** — high→low map transfer with raytrace/cage/projection modes (async, 1200s)

## Details

- Auto-detects best available bake method at runtime: Labs Maps Baker → Bake Texture ROP → COP fallback
- Returns structured diagnostic when no bake method is available (never degrades to raw execute_python)
- Follows existing skill patterns: SKILL.md (zh+en), tools.yaml, scripts/ with lazy hou import
- Updated SKILLS_INDEX.md with pipeline stage registration and 3 tracer-bullet chains

## Validation

- All 6 Python scripts pass py_compile
- tools.yaml: 5 tools, all source_file paths verified
- SKILL.md: valid frontmatter with full metadata