### PR TITLE
feat: add houdini-export-preset skill

### DIFF
--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -7,7 +7,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
 | `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`, `houdini-light-rig` | no |
-| `interchange` | `houdini-interchange` | no |
+| `interchange` | `houdini-interchange`, `houdini-export-preset` | no |
 | `pipeline` | `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation` | no |
 
 ## Common chains
@@ -34,6 +34,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Lookdev & shader networks | `load_skill("houdini-lookdev")` → `houdini_lookdev__list_materials` → `houdini_lookdev__get_material_parms` → `houdini_lookdev__set_material_parms` → `houdini_lookdev__save_preset` / `houdini_lookdev__load_preset` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
+| Manage export presets | `load_skill("houdini-export-preset")` → `houdini_export_preset__save_export_preset` → `houdini_export_preset__list_export_presets` → `houdini_export_preset__load_export_preset` |
 | Automate HDA + PDG/ROP | `load_skill("houdini-hda-automation")` → `houdini_hda_automation__scan_hda_libraries` → `houdini_hda_automation__inspect_hda_definition` → `houdini_hda_automation__instantiate_hda` → `houdini_hda_automation__validate_hda` → `houdini_hda_automation__cook_top_network` / `houdini_hda_automation__execute_rop_chain` |
 | Project + shot packaging | `load_skill("houdini-pipeline")` → `houdini_pipeline__set_project` → `houdini_pipeline__validate_scene` → `houdini_pipeline__collect_dependencies` → `houdini_pipeline__export_shot_package` |
 | Develop & debug tools | `load_skill("houdini-dev")` → `houdini_dev__attach_project` → `houdini_dev__reload_modules` → `houdini_dev__run_entrypoint` → `houdini_dev__introspect_hom` / `houdini_dev__start_debugpy` |

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: houdini-export-preset
+description: >-
+  Interchange skill — save/load/list/delete reusable export presets as JSON
+  library files capturing ROP node configurations (Alembic, FBX, USD,
+  Geometry, and other ROP output drivers). Use to standardize export
+  settings across a team or project. Pair with houdini-interchange for
+  one-shot exports or houdini-pipeline for shot packaging.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [houdini, export, preset, rop, alembic, fbx, usd, pipeline, interchange, configuration]
+    search-hint: "export preset, save export settings, ROP config, FBX preset, Alembic preset, USD export config, share export setup, export library"
+    search-aliases: [save export preset, load export preset, export template, export profile, reuse export settings, saved export config, export configuration, rop settings, batch export config, share export settings]
+    example-prompts:
+      - "Save the current Alembic export settings as a preset for the project"
+      - "List all export presets in the library"
+      - "Load the character_FBX export preset and apply it to geo1"
+      - "Delete the outdated export preset"
+    intent: "Manage reusable ROP export presets as JSON library files for consistent interchange."
+    recall-context:
+      app_type: houdini
+      domain: io
+      workflow-stage: interchange
+      task-category: mutate
+    requires: []
+    produces: [export_preset, rop_configuration]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=19.5"
+    side-effects:
+      creates: true
+      modifies: true
+      targets: [filesystem, rop_node]
+    tools: tools.yaml
+---
+
+# houdini-export-preset
+
+JSON-backed export preset management for Houdini ROP networks. Sits next to
+`houdini-interchange` so an agent can:
+
+1. `save_export_preset` to persist a ROP node's export configuration as JSON
+2. `load_export_preset` to retrieve a saved preset (optionally create a ROP
+   node from it)
+3. `list_export_presets` / `delete_export_preset` for library management
+
+## Tool groups
+
+- **`export-presets`:** `save_export_preset`, `load_export_preset`,
+  `list_export_presets`, `delete_export_preset` — JSON files under a
+  user-supplied `library_dir` (defaults to `~/.dcc-mcp/houdini/export_presets/`,
+  override with `DCC_MCP_HOUDINI_EXPORT_PRESET_DIR`).
+
+## Supported ROP types
+
+| Format | ROP node type | Typical output |
+|--------|--------------|----------------|
+| alembic | `rop_alembic` | `.abc` |
+| fbx | `rop_fbx` | `.fbx` |
+| usd | `usdrender` / `usd_rop` | `.usd` / `.usda` / `.usdc` |
+| geometry | `geometry` | `.bgeo` / `.geo` / `.obj` |
+| ifd | `ifd` | `.ifd` (Mantra) |
+| opengl | `opengl` | `.png` / `.jpg` (viewport) |
+| redshift | `Redshift_ROP` | `.exr` (Redshift) |
+| karma | `karma` | `.exr` (Karma) |
+
+## Context limitations
+
+- Presets store the ROP node's *parameters* (what), not the SOP/LOP
+  network that feeds it (how). A preset is transferable across scenes as
+  long as a node with the matching source path exists.
+- `load_export_preset` with `create_rop: true` creates a ROP node inside
+  `/out` (or the specified `rop_parent_path`) and wires it to the source
+  node recorded in the preset when `connect_source: true`.
+
+## Tracer-bullet flow
+
+1. `houdini_interchange__export_alembic(node_path="/obj/geo1", output_path="/tmp/test.abc")`
+2. `save_export_preset(rop_node_path="/out/alembic1", preset_name="character_alembic")`
+3. `list_export_presets()` → find available presets
+4. `load_export_preset(preset_name="character_alembic", create_rop=True, source_node_path="/obj/geo2")` → recreate ROP for a different object

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/_export_preset_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/_export_preset_common.py
@@ -1,0 +1,127 @@
+"""Shared helpers for Houdini export-preset skills."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dcc_mcp_core.skill import skill_error
+
+ENV_PRESET_DIR = "DCC_MCP_HOUDINI_EXPORT_PRESET_DIR"
+
+# ROP node type → format name mapping.
+ROP_TYPE_FORMATS: Dict[str, str] = {
+    "alembic": "alembic",
+    "rop_alembic": "alembic",
+    "filmboxfbx": "fbx",
+    "rop_fbx": "fbx",
+    "usdrender": "usd",
+    "usd_rop": "usd",
+    "geometry": "geometry",
+    "ifd": "ifd",
+    "opengl": "opengl",
+    "Redshift_ROP": "redshift",
+    "karma": "karma",
+}
+
+# Known parameter names for the source/sop path on ROP nodes.
+ROP_SOURCE_PARMS = ("soppath", "loppath", "sop_path", "lop_path", "sopoutput", "rootnode")
+
+
+def library_dir(base: Optional[str] = None) -> Path:
+    """Return the export-preset library directory (created on demand).
+
+    Priority:
+    1. Explicit *base* argument.
+    2. ``DCC_MCP_HOUDINI_EXPORT_PRESET_DIR`` environment variable.
+    3. ``~/.dcc-mcp/houdini/export_presets/``.
+    """
+    if base:
+        target = Path(base)
+    else:
+        override = os.environ.get(ENV_PRESET_DIR)
+        target = Path(override) if override else Path.home() / ".dcc-mcp" / "houdini" / "export_presets"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def hou_import_error() -> dict:
+    """Standard error when the HOM module is unavailable."""
+    return skill_error("Houdini not available", "hou could not be imported")
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def detect_format_from_type(type_name: str) -> str:
+    """Map a ROP node type name to a format string."""
+    if not type_name:
+        return "geometry"
+    for key, fmt in ROP_TYPE_FORMATS.items():
+        if key.lower() in type_name.lower():
+            return fmt
+    return "geometry"
+
+
+def find_rop_in_out(hou: Any, source_node_path: Optional[str] = None) -> Optional[Any]:
+    """Find the first ROP node in /out, optionally matching a source path."""
+    out_node = hou.node("/out")
+    if out_node is None:
+        return None
+
+    for child in out_node.children():
+        # Skip non-ROP nodes (e.g. nulls, subnets).
+        type_name = child.type().name() if hasattr(child.type(), "name") else ""
+        if not type_name:
+            continue
+
+        if source_node_path:
+            for parm_name in ROP_SOURCE_PARMS:
+                parm = child.parm(parm_name)
+                if parm is not None:
+                    try:
+                        value = parm.eval()
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if value and str(value) == source_node_path:
+                        return child
+        else:
+            # Return the first real ROP node (skip non-RON types).
+            try:
+                if hasattr(child.type(), "category"):
+                    if child.type().category().name() == "Driver":
+                        return child
+            except Exception:  # noqa: BLE001
+                pass
+
+    return None
+
+
+def find_source_path(rop_node: Any) -> Optional[str]:
+    """Return the source SOP/LOP path from a ROP node, or None."""
+    for parm_name in ROP_SOURCE_PARMS:
+        parm = rop_node.parm(parm_name)
+        if parm is not None:
+            try:
+                value = parm.eval()
+            except Exception:  # noqa: BLE001
+                continue
+            if value and isinstance(value, str) and value.strip():
+                return value
+    return None

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/delete_export_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/delete_export_preset.py
@@ -1,0 +1,63 @@
+"""Delete an export preset JSON file from the library."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _export_preset_common  # noqa: E402
+
+
+def delete_export_preset(preset_name: str, library_dir: Optional[str] = None) -> dict:
+    """Delete an export preset JSON file from the library.
+
+    Args:
+        preset_name: Name of the preset file to delete (stem without .json).
+        library_dir: Directory containing .json preset files.
+
+    Returns:
+        ToolResult dict confirming deletion.
+    """
+    try:
+        base = _export_preset_common.library_dir(library_dir)
+        target = base / "{}.json".format(preset_name)
+
+        if not target.is_file():
+            candidates = list(base.glob("*.json"))
+            for candidate in candidates:
+                if candidate.stem == preset_name:
+                    target = candidate
+                    break
+            else:
+                return skill_error(
+                    "Export preset not found: {!r}".format(preset_name),
+                    "Use list_export_presets to find available preset names.",
+                    library_dir=str(base),
+                )
+
+        target.unlink()
+        return skill_success(
+            "Deleted export preset",
+            preset_name=preset_name,
+            preset_path=str(target),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete export preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return delete_export_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/list_export_presets.py
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/list_export_presets.py
@@ -1,0 +1,76 @@
+"""List all export preset JSON files in a library directory (read-only)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _export_preset_common  # noqa: E402
+
+
+def list_export_presets(library_dir: Optional[str] = None) -> dict:
+    """List all export preset JSON files in a library directory.
+
+    Args:
+        library_dir: Directory to search for .json preset files.
+            Defaults to the configured default library directory.
+
+    Returns:
+        ToolResult dict with a list of preset info dicts.
+    """
+    try:
+        base = _export_preset_common.library_dir(library_dir)
+        if not base.is_dir():
+            return skill_success(
+                "No export presets directory found",
+                presets=[],
+                count=0,
+                library_dir=str(base),
+            )
+
+        presets = []
+        for path in sorted(base.glob("*.json")):
+            entry = {
+                "name": path.stem,
+                "file_path": str(path),
+                "size_bytes": path.stat().st_size,
+            }
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    data = json.load(handle)
+                entry["format"] = data.get("format", "unknown")
+                entry["rop_type"] = data.get("rop_type", "unknown")
+                entry["source_node_path"] = data.get("source_node_path")
+                entry["frame_range"] = data.get("frame_range")
+                entry["parameter_count"] = len(data.get("rop_parameters", {}))
+            except Exception:  # noqa: BLE001
+                entry["error"] = "unreadable preset"
+            presets.append(entry)
+
+        return skill_success(
+            "Listed export presets",
+            library_dir=str(base),
+            count=len(presets),
+            presets=presets,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list export presets")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_export_presets(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/load_export_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/load_export_preset.py
@@ -1,0 +1,157 @@
+"""Load a saved export preset from the library and optionally create a ROP node."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _export_preset_common  # noqa: E402
+from _export_preset_common import (  # noqa: E402
+    get_node,
+    hou_import_error,
+    node_summary,
+)
+
+
+def load_export_preset(
+    preset_name: str,
+    library_dir: Optional[str] = None,
+    create_rop: bool = False,
+    rop_parent_path: str = "/out",
+    source_node_path: Optional[str] = None,
+    connect_source: bool = False,
+) -> dict:
+    """Load a saved export preset from the library.
+
+    Args:
+        preset_name: Name of the preset to load (stem without .json).
+        library_dir: Directory containing .json preset files.
+        create_rop: When true, create a ROP node from the preset.
+        rop_parent_path: Parent network for the created ROP node.
+        source_node_path: Override the source node path in the preset.
+        connect_source: Wire the created ROP to the source node.
+
+    Returns:
+        ToolResult dict with preset_data, and optional created_rop info.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        base = _export_preset_common.library_dir(library_dir)
+        target = base / "{}.json".format(preset_name)
+
+        if not target.is_file():
+            # Fuzzy match.
+            candidates = list(base.glob("*.json"))
+            for candidate in candidates:
+                if candidate.stem == preset_name:
+                    target = candidate
+                    break
+            else:
+                return skill_error(
+                    "Export preset not found: {!r}".format(preset_name),
+                    "Use list_export_presets to find available preset names.",
+                    library_dir=str(base),
+                )
+
+        try:
+            with open(target, encoding="utf-8") as handle:
+                preset_data = json.load(handle)
+        except (IOError, ValueError) as exc:
+            return skill_error(
+                "Cannot read export preset {!r}".format(str(target)),
+                str(exc),
+            )
+
+        result_fields: Dict[str, Any] = {
+            "preset_name": preset_name,
+            "file_path": str(target),
+            "format": preset_data.get("format"),
+            "rop_type": preset_data.get("rop_type"),
+            "parameters": preset_data.get("rop_parameters", {}),
+            "frame_range": preset_data.get("frame_range"),
+            "source_node_path": preset_data.get("source_node_path"),
+        }
+
+        active_source = source_node_path or preset_data.get("source_node_path")
+
+        # Optionally create a ROP node from the preset.
+        if create_rop:
+            rop_type = preset_data.get("rop_type", "geometry")
+            parent = get_node(hou, rop_parent_path)
+            rop_node = parent.createNode(rop_type, node_name="{}_preset".format(preset_name))
+
+            # Apply saved parameters.
+            parameters = preset_data.get("rop_parameters", {})
+            applied = 0
+            errors: Dict[str, str] = {}
+            for name, value in parameters.items():
+                try:
+                    if isinstance(value, (list, tuple)):
+                        parm_tuple = rop_node.parmTuple(name)
+                        if parm_tuple is not None:
+                            parm_tuple.set(tuple(value))
+                            applied += 1
+                            continue
+                    parm = rop_node.parm(name)
+                    if parm is not None:
+                        parm.set(value)
+                        applied += 1
+                except Exception as exc:  # noqa: BLE001
+                    errors[name] = str(exc)
+
+            # Wire to source node if requested.
+            connected = False
+            if connect_source and active_source:
+                for parm_name in ("soppath", "loppath", "sop_path", "lop_path"):
+                    parm = rop_node.parm(parm_name)
+                    if parm is not None:
+                        try:
+                            parm.set(str(active_source))
+                            connected = True
+                            break
+                        except Exception:  # noqa: BLE001
+                            pass
+
+            result_fields["created_rop"] = node_summary(rop_node)
+            result_fields["applied_count"] = applied
+            result_fields["errors"] = errors if errors else None
+            result_fields["connected_source"] = connected
+
+            # Try to set output path based on the preset's output parameter.
+            if "sopoutput" in parameters:
+                out_parm = rop_node.parm("sopoutput")
+                if out_parm is not None:
+                    try:
+                        out_parm.set(parameters["sopoutput"])
+                    except Exception:  # noqa: BLE001
+                        pass
+
+        return skill_success(
+            "Loaded export preset",
+            **result_fields,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to load export preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return load_export_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/save_export_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/save_export_preset.py
@@ -70,8 +70,7 @@ def save_export_preset(
             if rop_node is None:
                 return skill_error(
                     "No ROP node found for source: {}".format(source_node_path),
-                    "Specify rop_node_path explicitly or ensure a ROP in /out "
-                    "references this source node.",
+                    "Specify rop_node_path explicitly or ensure a ROP in /out references this source node.",
                 )
         else:
             rop_node = find_rop_in_out(hou)

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/save_export_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/scripts/save_export_preset.py
@@ -1,0 +1,163 @@
+"""Save a ROP node's export configuration as a JSON preset in a library directory."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _export_preset_common  # noqa: E402
+from _export_preset_common import (  # noqa: E402
+    detect_format_from_type,
+    find_rop_in_out,
+    find_source_path,
+    get_node,
+    hou_import_error,
+    node_summary,
+)
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _safe_name(name: str) -> str:
+    cleaned = _SAFE_NAME.sub("_", name).strip("_")
+    return cleaned or "preset"
+
+
+def save_export_preset(
+    preset_name: str,
+    rop_node_path: Optional[str] = None,
+    source_node_path: Optional[str] = None,
+    format: Optional[str] = None,
+    library_dir: Optional[str] = None,
+    overwrite: bool = True,
+    custom_settings: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Save a ROP node's export configuration as a JSON preset.
+
+    Args:
+        preset_name: Name for the preset file (stem without .json).
+        rop_node_path: Path to the ROP node whose config to capture.
+        source_node_path: Path to the SOP/LOP node to export (auto-discovery
+            fallback when rop_node_path is omitted).
+        format: Export format hint.  Auto-detected when omitted.
+        library_dir: Directory for preset files.
+        overwrite: If False and the file exists, return an error.
+        custom_settings: Extra key-value pairs to merge into the preset.
+
+    Returns:
+        ToolResult dict with preset_path, preset_data, and rop info.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        # Resolve ROP node.
+        if rop_node_path:
+            rop_node = get_node(hou, rop_node_path)
+        elif source_node_path:
+            rop_node = find_rop_in_out(hou, source_node_path)
+            if rop_node is None:
+                return skill_error(
+                    "No ROP node found for source: {}".format(source_node_path),
+                    "Specify rop_node_path explicitly or ensure a ROP in /out "
+                    "references this source node.",
+                )
+        else:
+            rop_node = find_rop_in_out(hou)
+            if rop_node is None:
+                return skill_error(
+                    "No ROP node found in /out",
+                    "Specify rop_node_path or source_node_path.",
+                )
+
+        # Determine the file path.
+        base = _export_preset_common.library_dir(library_dir)
+        safe_stem = _safe_name(preset_name)
+        file_path = base / "{}.json".format(safe_stem)
+
+        if not overwrite and file_path.exists():
+            return skill_error(
+                "Preset {!r} already exists at {}".format(safe_stem, file_path),
+                "Set overwrite=True to replace it.",
+            )
+
+        # Collect ROP parameters (skipping read-only/internal ones).
+        rop_type = rop_node.type().name() if hasattr(rop_node.type(), "name") else ""
+        export_format = format or detect_format_from_type(rop_type)
+        resolved_source = source_node_path or find_source_path(rop_node)
+
+        # Capture frame range from the scene timeline.
+        frame_range = None
+        try:
+            frame_range = [
+                int(hou.playbar.playbackRange()[0]),
+                int(hou.playbar.playbackRange()[1]),
+            ]
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Capture all settable ROP parameters.
+        parameters: Dict[str, Any] = {}
+        skip_parms = {"caching", "frozen", "isHistoricallyInteresting", "nodeState"}
+        for parm in rop_node.parms():
+            name = parm.name()
+            if name in skip_parms or "." in name:
+                continue
+            try:
+                value = parm.eval()
+            except Exception:  # noqa: BLE001
+                continue
+            if isinstance(value, tuple):
+                value = list(value)
+            parameters[name] = value
+
+        preset_data: Dict[str, Any] = {
+            "preset_name": preset_name,
+            "format": export_format,
+            "rop_type": rop_type,
+            "rop_parameters": parameters,
+            "frame_range": frame_range,
+            "source_node_path": resolved_source,
+            "rop_node_summary": node_summary(rop_node),
+        }
+
+        if custom_settings:
+            preset_data.update(custom_settings)
+
+        with open(file_path, "w", encoding="utf-8") as handle:
+            json.dump(preset_data, handle, indent=2)
+
+        return skill_success(
+            "Saved export preset",
+            preset_name=preset_name,
+            format=export_format,
+            rop_type=rop_type,
+            source_node_path=resolved_source,
+            parameter_count=len(parameters),
+            frame_range=frame_range,
+            preset_path=str(file_path),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to save export preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return save_export_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/tools.yaml
@@ -1,0 +1,170 @@
+tools:
+  - name: save_export_preset
+    description: >-
+      Save a ROP node's export configuration (node type, parameters, output
+      path, frame range) as a JSON preset file in a library directory.
+      Optionally auto-discovers the ROP node from /out when only a source
+      node path is given.
+    source_file: scripts/save_export_preset.py
+    execution: sync
+    affinity: main
+    group: export-presets
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [preset_name]
+      properties:
+        preset_name:
+          type: string
+          description: Name for the preset file (stem without .json extension).
+        rop_node_path:
+          type: string
+          description: >-
+            Path to the ROP node whose configuration to capture
+            (e.g. /out/alembic1).  Required unless source_node_path
+            is given for auto-discovery.
+        source_node_path:
+          type: string
+          description: >-
+            Path to the SOP/LOP node to export.  When rop_node_path is
+            omitted, the first ROP in /out that references this source
+            node will be used for auto-discovery.
+        format:
+          type: string
+          description: >-
+            Export format hint.  Auto-detected from the ROP node type
+            when omitted.  One of: alembic, fbx, usd, geometry, ifd,
+            opengl, redshift, karma.
+        library_dir:
+          type: string
+          description: >-
+            Directory where preset .json files are stored.  Defaults to
+            $DCC_MCP_HOUDINI_EXPORT_PRESET_DIR or
+            ~/.dcc-mcp/houdini/export_presets/.
+        overwrite:
+          type: boolean
+          default: true
+          description: If false and the preset file exists, return an error.
+        custom_settings:
+          type: object
+          description: >-
+            Optional additional key-value pairs to merge into the preset
+            (notes, project, author, etc.).
+    next-tools:
+      on-success:
+        - houdini_export_preset__list_export_presets
+
+  - name: load_export_preset
+    description: >-
+      Load a saved export preset from the library and return its
+      configuration.  Optionally create a ROP node from the preset
+      and wire it to a source node for immediate use.
+    source_file: scripts/load_export_preset.py
+    execution: sync
+    affinity: main
+    group: export-presets
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [preset_name]
+      properties:
+        preset_name:
+          type: string
+          description: Name of the preset to load (stem without .json).
+        library_dir:
+          type: string
+          description: >-
+            Directory containing preset .json files.  Defaults to the
+            configured default library directory.
+        create_rop:
+          type: boolean
+          default: false
+          description: >-
+            When true, create a ROP node from the preset configuration.
+            The node is created under rop_parent_path.
+        rop_parent_path:
+          type: string
+          default: "/out"
+          description: Parent network for the created ROP node.
+        source_node_path:
+          type: string
+          description: >-
+            Override the source node path in the preset.  Used when
+            recreating the ROP for a different SOP/LOP node.
+        connect_source:
+          type: boolean
+          default: false
+          description: >-
+            When true and source_node_path is set or available in the
+            preset, wire the created ROP to the source node.
+    next-tools:
+      on-success:
+        - houdini_interchange__export_alembic
+        - houdini_interchange__export_fbx
+        - houdini_interchange__export_usd
+        - houdini_interchange__export_geometry
+
+  - name: list_export_presets
+    description: >-
+      List all export preset JSON files in a library directory (read-only,
+      no Houdini scene access required).
+    source_file: scripts/list_export_presets.py
+    execution: sync
+    affinity: any
+    group: export-presets
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        library_dir:
+          type: string
+          description: >-
+            Directory to search for .json preset files.  Defaults to
+            $DCC_MCP_HOUDINI_EXPORT_PRESET_DIR or
+            ~/.dcc-mcp/houdini/export_presets/.
+
+  - name: delete_export_preset
+    description: >-
+      Delete an export preset JSON file from the library (no Houdini
+      scene access required).
+    source_file: scripts/delete_export_preset.py
+    execution: sync
+    affinity: any
+    group: export-presets
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [preset_name]
+      properties:
+        preset_name:
+          type: string
+          description: Name of the preset file to delete (stem without .json).
+        library_dir:
+          type: string
+          description: >-
+            Directory containing preset .json files.  Defaults to the
+            configured default library directory.


### PR DESCRIPTION
## Summary

Add `houdini-export-preset` bundled skill with 4 typed tools for managing reusable ROP export presets:

- **save_export_preset** — capture a ROP node's full configuration as JSON
- **load_export_preset** — load a preset, optionally create a ROP and wire source
- **list_export_presets** — list all preset files with metadata
- **delete_export_preset** — delete a preset from the library

## Details

- Supports 8 ROP types: Alembic, FBX, USD, Geometry, IFD, OpenGL, Redshift, Karma
- Auto-discovers ROP nodes from /out when only a source node path is given
- JSON presets under ~/.dcc-mcp/houdini/export_presets/
- Registered in SKILLS_INDEX.md under interchange stage

## Validation

- All 5 Python scripts pass py_compile
- tools.yaml: 4 tools, all source_file paths verified