### PR TITLE
feat: add houdini-light-rig skill (3-point lighting, HDRI, area softbox)

### DIFF
--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,7 +6,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
-| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda` | no |
+| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`, `houdini-light-rig` | no |
 | `interchange` | `houdini-interchange` | no |
 | `pipeline` | `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation` | no |
 
@@ -25,6 +25,9 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Create & inspect geometry | `load_skill("houdini-geometry")` → `houdini_geometry__create_primitive` → `houdini_geometry__get_geometry_info` → `houdini_geometry__list_attributes` / `houdini_geometry__list_groups` |
 | Edit a mesh procedurally | `load_skill("houdini-mesh-ops")` → `houdini_mesh_ops__transform_geometry` / `merge_geometry` / `blast_geometry` / `group_geometry` / `add_normals` / `triangulate_geometry` / `convert_geometry` → `houdini_geometry__get_cook_status` |
 | Set up cameras & lights | `load_skill("houdini-camera-light")` → `houdini_camera_light__create_camera` → `houdini_camera_light__create_light` → `houdini_camera_light__frame_view` |
+| Three-point studio lighting | `load_skill("houdini-light-rig")` → `create_three_point_light_rig` → `aim_light_at_object` → `set_light_rig_intensity` → `get_lighting_summary` |
+| HDRI environment lighting | `load_skill("houdini-light-rig")` → `create_hdri_world` → `area_softbox` / `set_render_view_transform` → `get_lighting_summary` |
+| Light rig management | `load_skill("houdini-light-rig")` → `list_light_rigs` → `group_lights` → `set_light_rig_intensity` |
 | Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Animate & bake | `load_skill("houdini-animation")` → `houdini_animation__set_timeline` → `houdini_animation__set_keyframe` → `houdini_animation__get_keyframes` → `houdini_animation__bake_channels` / `houdini_animation__cache_simulation` |

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: houdini-light-rig
+description: >-
+  Authoring skill — pre-configured lighting templates: three-point rigs,
+  HDRI worlds, area softboxes, rig-level intensity controls, and view
+  transform management.  Builds on top of houdini-camera-light (individual
+  light create/update) to provide higher-level lighting automation.  Pair
+  with houdini-camera-light for individual light control and houdini-render
+  for render output.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, light-rig, three-point, hdri, area-light, softbox, lighting, lookdev, ocio, view-transform, authoring]
+    search-hint: "three point light rig, key fill rim, HDRI dome world, area softbox, lighting template, studio setup, environment light, aim light, group lights, lighting summary, render view transform, OCIO color transform"
+    tools: tools.yaml
+---
+
+# houdini-light-rig
+
+Typed light-rig authoring tools for agents.  All tools are `affinity: main`.
+Complements `houdini-camera-light` (individual light create/update) with
+higher-level lighting automation: three-point rigs, HDRI worlds, area
+softboxes, rig grouping, and intensity controls.
+
+## Tool groups
+
+- **`light-rig-create`:** `create_three_point_light_rig`, `create_hdri_world`,
+  `create_area_softbox`.
+- **`light-rig-edit`:** `aim_light_at_object`, `set_light_rig_intensity`,
+  `group_lights`, `set_render_view_transform`.
+- **`light-rig-query`** (read-only): `get_lighting_summary`, `list_light_rigs`.
+
+## Rig conventions
+
+- A **light rig** is a null node at `/obj` level whose children are `hlight::2.0`
+  nodes.  The null name ends with `_rig` by convention.
+- `list_light_rigs` scans for nulls matching this pattern; `set_light_rig_intensity`
+  and `group_lights` operate on these rig groups.
+- Three-point rigs create a null named `<name>` with `_key`, `_fill`, `_rim` lights
+  parented underneath.
+
+## Context limitations
+
+- **Karma / Solaris:** This skill operates at `/obj` level with `hlight::2.0`
+  nodes.  For USD/Solaris lighting use `houdini-lookdev` and the LOP context.
+- **HDRI:** `create_hdri_world` creates an `environment` light with a texture
+  map (`envmap` parm).  Ensure the HDRI file path is accessible to the Houdini
+  session.
+- **View transform:** `set_render_view_transform` configures OCIO-based color
+  transforms.  Requires a valid OCIO configuration in the Houdini environment.
+- **Aim:** `aim_light_at_object` uses Houdini's built-in `lookatpath` parameter
+  — only effective for light types that support look-at (point, spot, area,
+  distant).
+
+## Tracer-bullet flow
+
+1. `houdini_camera_light__create_light(light_type="distant", name="key_light")`
+2. `create_three_point_light_rig(name="studio_rig", key_intensity=1.2)`
+3. `aim_light_at_object(light_path="/obj/studio_rig/studio_rig_key", target_path="/obj/geo1")`
+4. `create_hdri_world(hdri_path="/path/to/studio.hdr", intensity=0.8)`
+5. `get_lighting_summary()` → review all lights
+6. `set_render_view_transform(view_transform="ACES 1.0 SDR-video")`
+7. `set_light_rig_intensity(rig_group="/obj/studio_rig", intensity=1.5, multiply=true)`
+8. Hand off to `houdini-render` for viewport capture / ROP render

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/_light_rig_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/_light_rig_common.py
@@ -1,0 +1,151 @@
+"""Shared helpers for Houdini light-rig skills."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+# Friendly light type -> hlight 'light_type' menu index (hlight::2.0).
+LIGHT_TYPES = {
+    "point": 0,
+    "line": 1,
+    "grid": 2,
+    "disk": 3,
+    "sphere": 4,
+    "tube": 5,
+    "geometry": 6,
+    "distant": 7,
+    "sun": 7,
+    "environment": 8,
+}
+
+# Shape types that support area light parameters (areasize, etc.)
+AREA_SHAPES = {"grid", "disk", "sphere", "tube"}
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
+    """Set a scalar/tuple parm only when it exists. Return whether it was set."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            return False
+        parm_tuple.set(tuple(value))
+        return True
+    parm = node.parm(name)
+    if parm is None:
+        return False
+    parm.set(value)
+    return True
+
+
+def eval_parm(node: Any, name: str) -> Optional[Any]:
+    """Eval a scalar parm or parm tuple if present, else None."""
+    parm_tuple = node.parmTuple(name)
+    if parm_tuple is not None:
+        try:
+            return list(parm_tuple.eval())
+        except Exception:  # noqa: BLE001
+            return None
+    parm = node.parm(name)
+    if parm is not None:
+        try:
+            return parm.eval()
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def apply_transform(
+    node: Any,
+    translate: Optional[Sequence[float]],
+    rotate: Optional[Sequence[float]],
+    scale: Optional[Sequence[float]] = None,
+) -> dict:
+    """Set t/r/s parm tuples defensively; return what was applied."""
+    applied: dict = {}
+    if translate is not None and set_parm_if_exists(node, "t", translate):
+        applied["t"] = list(translate)
+    if rotate is not None and set_parm_if_exists(node, "r", rotate):
+        applied["r"] = list(rotate)
+    if scale is not None and set_parm_if_exists(node, "s", scale):
+        applied["s"] = list(scale)
+    return applied
+
+
+def get_light_parms(light: Any) -> dict:
+    """Read common hlight parameters and return a JSON-safe dict."""
+    type_index = eval_parm(light, "light_type")
+    type_name = None
+    if type_index is not None:
+        for name, idx in LIGHT_TYPES.items():
+            if idx == int(type_index) and name != "sun":
+                type_name = name
+                break
+
+    parms = {
+        "path": light.path(),
+        "name": light.name(),
+        "type": type_name,
+        "type_index": type_index,
+        "intensity": eval_parm(light, "light_intensity"),
+        "color": eval_parm(light, "light_color"),
+        "exposure": eval_parm(light, "light_exposure"),
+        "translate": eval_parm(light, "t"),
+        "rotate": eval_parm(light, "r"),
+        "enabled": eval_parm(light, "light_enable"),
+    }
+
+    if type_name in AREA_SHAPES:
+        parms["area_size"] = eval_parm(light, "areasize")
+
+    if type_name == "environment":
+        parms["env_map"] = eval_parm(light, "envmap")
+
+    parms["contrib_diffuse"] = eval_parm(light, "light_contribdiffuse")
+    parms["contrib_specular"] = eval_parm(light, "light_contribspecular")
+
+    return parms
+
+
+def is_light_node(node: Any) -> bool:
+    """Check if a node is a hlight (or hlight::2.0) node."""
+    type_name = node.type().name() if hasattr(node.type(), "name") else ""
+    return "hlight" in type_name.lower()
+
+
+def is_rig_null(node: Any) -> bool:
+    """Check if a node is a null node that acts as a light rig parent."""
+    type_name = node.type().name() if hasattr(node.type(), "name") else ""
+    if "null" not in type_name.lower():
+        return False
+    # A rig null has at least one hlight child
+    for child in node.children():
+        if is_light_node(child):
+            return True
+    return False
+
+
+def get_rig_members(rig_node: Any) -> list:
+    """Return all hlight children under a rig null node."""
+    lights = []
+    for child in rig_node.children():
+        if is_light_node(child):
+            lights.append(child)
+    return lights

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/aim_light_at_object.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/aim_light_at_object.py
@@ -126,9 +126,7 @@ def aim_light_at_object(
             applied=applied,
         )
     except Exception as exc:
-        return skill_exception(
-            exc, message="Failed to aim light '{}' at '{}'".format(light_path, target_path)
-        )
+        return skill_exception(exc, message="Failed to aim light '{}' at '{}'".format(light_path, target_path))
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/aim_light_at_object.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/aim_light_at_object.py
@@ -1,0 +1,142 @@
+"""Point a light at a target object using Houdini's look-at mechanism."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    get_node,
+    is_light_node,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def aim_light_at_object(
+    light_path: str,
+    target_path: str,
+    up_vector: Optional[List[float]] = None,
+) -> dict:
+    """Point a light at a target object using Houdini's ``lookatpath`` parameter.
+
+    Sets the light's look-at target so it automatically orients toward the
+    specified node.  Also applies an optional up-vector for finer control
+    of the light's roll.
+
+    Note:
+        The ``lookatpath`` parameter is only effective for light types that
+        support look-at (point, spot, area, distant, environment).  For lights
+        that lack this parameter, falls back to a manual world-space aim via
+        rotation calculation.
+
+    Args:
+        light_path: Path to the ``hlight`` node to aim.
+        target_path: Path to the target node the light should point at.
+        up_vector: Up vector [x, y, z] for the look-at constraint.
+            Default ``[0, 1, 0]``.
+
+    Returns:
+        ToolResult with the light path, target path, and applied method.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        light = get_node(hou, light_path)
+
+        if not is_light_node(light):
+            return skill_error(
+                "Node is not a light",
+                "light_path must point to an hlight node",
+                node_path=light_path,
+                node_type=light.type().name(),
+            )
+
+        target = get_node(hou, target_path)
+        up = list(up_vector) if up_vector else [0.0, 1.0, 0.0]
+
+        applied = {}
+        method = None
+
+        # Primary method: use the built-in lookatpath parameter
+        if set_parm_if_exists(light, "lookatpath", target.path()):
+            applied["lookatpath"] = target.path()
+            method = "lookatpath"
+        else:
+            # Fallback: manual world-space aim via vector math
+            light_pos_world = light.worldTransform().extractTranslates()
+            target_pos_world = target.worldTransform().extractTranslates()
+
+            direction = hou.Vector3(target_pos_world) - hou.Vector3(light_pos_world)
+            if direction.length() < 0.0001:
+                return skill_error(
+                    "Light and target are at the same position",
+                    "Cannot aim — light and target world positions are identical.",
+                    light_pos=list(light_pos_world),
+                    target_pos=list(target_pos_world),
+                )
+            direction.normalize()
+
+            # Build a rotation matrix from direction + up vector
+            up_vec = hou.Vector3(up)
+            if abs(direction.dot(up_vec)) > 0.9999:
+                # Direction parallel to up — pick an alternative up
+                up_vec = hou.Vector3(0, 0, 1) if abs(up_vec.y()) > 0.5 else hou.Vector3(0, 1, 0)
+
+            side = direction.cross(up_vec)
+            side.normalize()
+            new_up = side.cross(direction)
+            new_up.normalize()
+
+            rot_matrix = hou.Matrix3(
+                hou.Vector3(side.x(), new_up.x(), -direction.x()),
+                hou.Vector3(side.y(), new_up.y(), -direction.y()),
+                hou.Vector3(side.z(), new_up.z(), -direction.z()),
+            )
+            rot_degrees = rot_matrix.extractRotates()
+            rot_list = [rot_degrees[0], rot_degrees[1], rot_degrees[2]]
+
+            if set_parm_if_exists(light, "r", tuple(rot_list)):
+                applied["rotate"] = rot_list
+                method = "world_space_aim"
+
+        if method is None:
+            return skill_error(
+                "Could not aim light",
+                "Could not set lookatpath or compute world-space rotation.",
+                light_path=light_path,
+                target_path=target_path,
+            )
+
+        return skill_success(
+            "Aimed light '{}' at '{}' ({})".format(light.name(), target.name(), method),
+            node=node_summary(light),
+            target_path=target.path(),
+            method=method,
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(
+            exc, message="Failed to aim light '{}' at '{}'".format(light_path, target_path)
+        )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return aim_light_at_object(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_area_softbox.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_area_softbox.py
@@ -1,0 +1,137 @@
+"""Create an area light configured as a softbox for studio-style soft lighting."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    AREA_SHAPES,
+    LIGHT_TYPES,
+    apply_transform,
+    get_node,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def create_area_softbox(
+    name: str = "softbox",
+    parent_path: str = "/obj",
+    shape: str = "grid",
+    size: Optional[List[float]] = None,
+    intensity: float = 2.0,
+    color: Optional[List[float]] = None,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    exposure: Optional[float] = None,
+) -> dict:
+    """Create an area light configured as a softbox with large area and soft quality.
+
+    Creates a ``hlight::2.0`` node with the specified shape (grid/disk/sphere/tube),
+    sets a generous area size for soft shadows, and configures intensity, color,
+    exposure, and transform.
+
+    Args:
+        name: Name for the area light node. Default ``softbox``.
+        parent_path: Parent network. Default ``/obj``.
+        shape: Area light shape (grid, disk, sphere, tube). Default ``grid``.
+        size: [width, height] for grid, or [radius, radius] for disk/sphere.
+            Default [5, 5] for grid, [3, 3] for others.
+        intensity: Light intensity. Default 2.0 (brighter than default for softbox).
+        color: RGB light color. Default neutral white [1.0, 1.0, 1.0].
+        translate: World-space position [x, y, z].
+        rotate: World-space rotation [rx, ry, rz] in degrees.
+        exposure: Optional exposure compensation value.
+
+    Returns:
+        ToolResult with light path and applied parameters.
+    """
+    shape_lower = shape.lower()
+    if shape_lower not in AREA_SHAPES:
+        return skill_error(
+            "Unsupported area shape",
+            "shape must be one of: {}".format(", ".join(sorted(AREA_SHAPES))),
+            requested=shape,
+        )
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    # Default sizes per shape
+    if size is None:
+        size = [5.0, 5.0] if shape_lower == "grid" else [3.0, 3.0]
+
+    col = list(color) if color else [1.0, 1.0, 1.0]
+
+    try:
+        parent = get_node(hou, parent_path)
+
+        try:
+            light = parent.createNode("hlight::2.0", node_name=name)
+        except Exception:  # noqa: BLE001
+            light = parent.createNode("hlight", node_name=name)
+
+        applied = {}
+
+        # Set light type
+        type_index = LIGHT_TYPES.get(shape_lower, 2)
+        if set_parm_if_exists(light, "light_type", type_index):
+            applied["light_type"] = shape_lower
+
+        # Intensity (softboxes are typically brighter)
+        if set_parm_if_exists(light, "light_intensity", float(intensity)):
+            applied["intensity"] = float(intensity)
+
+        # Color
+        if set_parm_if_exists(light, "light_color", list(col)):
+            applied["color"] = list(col)
+
+        # Area size — the key softbox parameter
+        if set_parm_if_exists(light, "areasize", list(size)):
+            applied["area_size"] = list(size)
+
+        # Exposure
+        if exposure is not None and set_parm_if_exists(light, "light_exposure", float(exposure)):
+            applied["exposure"] = float(exposure)
+
+        # Transform
+        transform_applied = apply_transform(
+            light,
+            list(translate) if translate else None,
+            list(rotate) if rotate else None,
+        )
+        applied.update(transform_applied)
+
+        # Soft quality hints — set diffuse/specular contribution to full
+        set_parm_if_exists(light, "light_contribdiffuse", 1.0)
+        set_parm_if_exists(light, "light_contribspecular", 1.0)
+
+        return skill_success(
+            "Created area softbox '{}' ({} shape)".format(light.name(), shape_lower),
+            node=node_summary(light),
+            applied=applied,
+            prompt="Use aim_light_at_object to orient the softbox toward a subject, or adjust the area_size for softer/wider illumination.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create area softbox '{}'".format(name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_area_softbox(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_hdri_world.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_hdri_world.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_hdri_world.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_hdri_world.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Optional
-
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_hdri_world.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_hdri_world.py
@@ -1,0 +1,121 @@
+"""Create an environment light with an HDRI texture map for image-based lighting."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    LIGHT_TYPES,
+    apply_transform,
+    get_node,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def create_hdri_world(
+    hdri_path: str,
+    name: str = "hdri_world",
+    parent_path: str = "/obj",
+    intensity: float = 1.0,
+    rotation: float = 0.0,
+    visible_in_diffuse: bool = True,
+    visible_in_specular: bool = True,
+) -> dict:
+    """Create an environment light (type=environment) loaded with an HDRI map.
+
+    The environment light wraps the scene with image-based lighting from an
+    ``.hdr`` or ``.exr`` file.  Configure intensity, Y-axis rotation, and
+    diffuse/specular visibility.
+
+    Args:
+        hdri_path: Absolute path to the ``.hdr`` or ``.exr`` environment map.
+        name: Name for the environment light node. Default ``hdri_world``.
+        parent_path: Parent network. Default ``/obj``.
+        intensity: Light intensity multiplier. Default 1.0.
+        rotation: Y-axis rotation in degrees for the HDRI. Default 0.0.
+        visible_in_diffuse: Enable diffuse contribution. Default True.
+        visible_in_specular: Enable specular contribution. Default True.
+
+    Returns:
+        ToolResult with light path, HDRI path, and applied configuration.
+    """
+    if not hdri_path:
+        return skill_error("No HDRI path provided", "hdri_path is required")
+
+    if not os.path.exists(hdri_path):
+        return skill_error(
+            "HDRI file not found",
+            "The specified HDRI path does not exist: {}".format(hdri_path),
+            hdri_path=hdri_path,
+        )
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+
+        try:
+            light = parent.createNode("hlight::2.0", node_name=name)
+        except Exception:  # noqa: BLE001
+            light = parent.createNode("hlight", node_name=name)
+
+        applied = {}
+
+        # Set to environment light type
+        env_index = LIGHT_TYPES["environment"]
+        if set_parm_if_exists(light, "light_type", env_index):
+            applied["light_type"] = "environment"
+
+        if set_parm_if_exists(light, "light_intensity", float(intensity)):
+            applied["intensity"] = float(intensity)
+
+        # Set environment map texture
+        if set_parm_if_exists(light, "envmap", hdri_path):
+            applied["envmap"] = hdri_path
+
+        # Apply Y-axis rotation for HDRI orientation
+        apply_transform(light, [0, 0, 0], [0, float(rotation), 0])
+        applied["rotation_y"] = float(rotation)
+
+        # Diffuse/specular contribution
+        if set_parm_if_exists(light, "light_contribdiffuse", float(int(visible_in_diffuse))):
+            applied["contrib_diffuse"] = visible_in_diffuse
+        if set_parm_if_exists(light, "light_contribspecular", float(int(visible_in_specular))):
+            applied["contrib_specular"] = visible_in_specular
+
+        # Set the environment map color space hint (scene-linear for HDR)
+        set_parm_if_exists(light, "envmap_colorSpace", "scene-linear Rec.709-sRGB")
+
+        return skill_success(
+            "Created HDRI world '{}' from '{}'".format(light.name(), hdri_path),
+            node=node_summary(light),
+            applied=applied,
+            hdri_path=hdri_path,
+            prompt="Use set_light_rig_intensity to adjust brightness or rotate the light node in Y to reorient the HDRI.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create HDRI world from '{}'".format(hdri_path))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_hdri_world(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_three_point_light_rig.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_three_point_light_rig.py
@@ -1,0 +1,155 @@
+"""Create a standard three-point key/fill/rim lighting rig."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    LIGHT_TYPES,
+    apply_transform,
+    get_node,
+    node_summary,
+    set_parm_if_exists,
+)
+
+
+def _create_rig_light(
+    parent: "hou.Node",
+    name: str,
+    light_type: str,
+    intensity: float,
+    color: List[float],
+    translate: List[float],
+    rotate: List[float],
+) -> tuple:
+    """Create a single light inside a rig group and configure it."""
+    try:
+        light = parent.createNode("hlight::2.0", node_name=name)
+    except Exception:  # noqa: BLE001
+        light = parent.createNode("hlight", node_name=name)
+
+    type_index = LIGHT_TYPES.get(light_type.lower(), 7)  # default distant
+    set_parm_if_exists(light, "light_type", type_index)
+    set_parm_if_exists(light, "light_intensity", float(intensity))
+    set_parm_if_exists(light, "light_color", list(color))
+    apply_transform(light, list(translate), list(rotate))
+
+    return light, {
+        "name": light.name(),
+        "path": light.path(),
+        "light_type": light_type,
+        "intensity": intensity,
+        "color": list(color),
+        "translate": list(translate),
+        "rotate": list(rotate),
+    }
+
+
+def create_three_point_light_rig(
+    name: str = "threePoint_rig",
+    parent_path: str = "/obj",
+    key_intensity: float = 1.0,
+    fill_intensity: float = 0.5,
+    rim_intensity: float = 0.75,
+    light_type: str = "distant",
+    key_color: Optional[List[float]] = None,
+    fill_color: Optional[List[float]] = None,
+    rim_color: Optional[List[float]] = None,
+    key_position: Optional[List[float]] = None,
+    fill_position: Optional[List[float]] = None,
+    rim_position: Optional[List[float]] = None,
+) -> dict:
+    """Create a standard three-point (key/fill/rim) lighting rig.
+
+    Positions the three lights at classic three-point lighting angles:
+    - Key light: 45° horizontal, -30° vertical
+    - Fill light: -45° horizontal, -15° vertical
+    - Rim light: behind (180°), slightly above
+
+    Args:
+        name: Base name for the rig null group and lights.
+        parent_path: Parent network for the rig null node. Default ``/obj``.
+        key_intensity: Key light intensity. Default 1.0.
+        fill_intensity: Fill light intensity. Default 0.5.
+        rim_intensity: Rim/back light intensity. Default 0.75.
+        light_type: hlight type for all three lights (point, distant, spot, etc.).
+        key_color: RGB for key light. Default warm white [1.0, 0.95, 0.85].
+        fill_color: RGB for fill light. Default cool white [0.85, 0.90, 1.0].
+        rim_color: RGB for rim light. Default neutral white [1.0, 1.0, 1.0].
+        key_position: Override key light world position.
+        fill_position: Override fill light world position.
+        rim_position: Override rim light world position.
+
+    Returns:
+        ToolResult with rig_group, key_light, fill_light, rim_light paths.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if light_type.lower() not in LIGHT_TYPES:
+        return skill_error(
+            "Unsupported light type",
+            "light_type must be one of: {}".format(", ".join(sorted(LIGHT_TYPES))),
+            requested=light_type,
+        )
+
+    key_col = list(key_color) if key_color else [1.0, 0.95, 0.85]
+    fill_col = list(fill_color) if fill_color else [0.85, 0.90, 1.0]
+    rim_col = list(rim_color) if rim_color else [1.0, 1.0, 1.0]
+
+    # Classic three-point angles (Y-up in Houdini)
+    key_pos = list(key_position) if key_position else [5.0, 4.0, -5.0]  # front-right, above
+    fill_pos = list(fill_position) if fill_position else [-5.0, 2.0, -5.0]  # front-left, lower
+    rim_pos = list(rim_position) if rim_position else [0.0, 5.0, 8.0]  # behind, above
+
+    key_rot = [-30.0, -45.0, 0.0]
+    fill_rot = [-15.0, 45.0, 0.0]
+    rim_rot = [0.0, 180.0, 0.0]
+
+    try:
+        parent = get_node(hou, parent_path)
+        rig = parent.createNode("null", node_name=name)
+
+        key_result = _create_rig_light(
+            rig, "{}_key".format(name), light_type, key_intensity, key_col, key_pos, key_rot
+        )
+        fill_result = _create_rig_light(
+            rig, "{}_fill".format(name), light_type, fill_intensity, fill_col, fill_pos, fill_rot
+        )
+        rim_result = _create_rig_light(
+            rig, "{}_rim".format(name), light_type, rim_intensity, rim_col, rim_pos, rim_rot
+        )
+
+        return skill_success(
+            "Created three-point rig '{}' ({})".format(name, light_type),
+            rig_group=rig.path(),
+            rig_name=rig.name(),
+            key_light=key_result[1],
+            fill_light=fill_result[1],
+            rim_light=rim_result[1],
+            light_type=light_type,
+            prompt="Use aim_light_at_object to target lights, or set_light_rig_intensity to adjust overall brightness.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create three-point rig '{}'".format(name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_three_point_light_rig(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_three_point_light_rig.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_three_point_light_rig.py
@@ -16,13 +16,12 @@ from _light_rig_common import (  # noqa: E402
     LIGHT_TYPES,
     apply_transform,
     get_node,
-    node_summary,
     set_parm_if_exists,
 )
 
 
 def _create_rig_light(
-    parent: "hou.Node",
+    parent: "hou.Node",  # noqa: F821
     name: str,
     light_type: str,
     intensity: float,

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_three_point_light_rig.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/create_three_point_light_rig.py
@@ -119,15 +119,11 @@ def create_three_point_light_rig(
         parent = get_node(hou, parent_path)
         rig = parent.createNode("null", node_name=name)
 
-        key_result = _create_rig_light(
-            rig, "{}_key".format(name), light_type, key_intensity, key_col, key_pos, key_rot
-        )
+        key_result = _create_rig_light(rig, "{}_key".format(name), light_type, key_intensity, key_col, key_pos, key_rot)
         fill_result = _create_rig_light(
             rig, "{}_fill".format(name), light_type, fill_intensity, fill_col, fill_pos, fill_rot
         )
-        rim_result = _create_rig_light(
-            rig, "{}_rim".format(name), light_type, rim_intensity, rim_col, rim_pos, rim_rot
-        )
+        rim_result = _create_rig_light(rig, "{}_rim".format(name), light_type, rim_intensity, rim_col, rim_pos, rim_rot)
 
         return skill_success(
             "Created three-point rig '{}' ({})".format(name, light_type),

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Optional
-
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)
@@ -57,7 +55,7 @@ def get_lighting_summary(parent_path: str = "/obj") -> dict:
                     "path": child.path(),
                     "name": child.name(),
                     "light_count": len(rig_lights),
-                    "lights": [l["path"] for l in rig_lights],
+                    "lights": [lt["path"] for lt in rig_lights],
                 })
             elif is_light_node(child):
                 parms = get_light_parms(child)
@@ -65,8 +63,8 @@ def get_lighting_summary(parent_path: str = "/obj") -> dict:
                 lights.append(parms)
 
         # Collect standalone lights (not in a rig)
-        standalone = [l for l in lights if l.get("rig_parent") is None]
-        rigged = [l for l in lights if l.get("rig_parent") is not None]
+        standalone = [lt for lt in lights if lt.get("rig_parent") is None]
+        rigged = [lt for lt in lights if lt.get("rig_parent") is not None]
 
         totals = {
             "total_lights": len(lights),
@@ -77,9 +75,9 @@ def get_lighting_summary(parent_path: str = "/obj") -> dict:
 
         # Aggregate light types
         type_counts: dict = {}
-        for l in lights:
-            lt = l.get("type", "unknown")
-            type_counts[lt] = type_counts.get(lt, 0) + 1
+        for light in lights:
+            light_type = light.get("type", "unknown")
+            type_counts[light_type] = type_counts.get(light_type, 0) + 1
         totals["by_type"] = type_counts
 
         return skill_success(

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
@@ -52,12 +52,14 @@ def get_lighting_summary(parent_path: str = "/obj") -> dict:
                         parms["rig_parent"] = child.path()
                         rig_lights.append(parms)
                         lights.append(parms)
-                rigs.append({
-                    "path": child.path(),
-                    "name": child.name(),
-                    "light_count": len(rig_lights),
-                    "lights": [lt["path"] for lt in rig_lights],
-                })
+                rigs.append(
+                    {
+                        "path": child.path(),
+                        "name": child.name(),
+                        "light_count": len(rig_lights),
+                        "lights": [lt["path"] for lt in rig_lights],
+                    }
+                )
             elif is_light_node(child):
                 parms = get_light_parms(child)
                 parms["rig_parent"] = None

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/get_lighting_summary.py
@@ -1,0 +1,105 @@
+"""Scan a network for all hlight nodes and report their state as a lighting summary."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    get_light_parms,
+    get_node,
+    is_light_node,
+    is_rig_null,
+)
+
+
+def get_lighting_summary(parent_path: str = "/obj") -> dict:
+    """Scan *parent_path* for all hlight nodes and report lighting state.
+
+    Walks the network recursively and collects every ``hlight``/``hlight::2.0``
+    node.  For each light, reports type, intensity, color, exposure, position,
+    and rig membership (if parented under a null rig).  Also reports rig groups
+    and totals.
+
+    Args:
+        parent_path: Network path to scan. Default ``/obj``.
+
+    Returns:
+        ToolResult with ``lights`` list, ``rigs`` list, and ``totals`` dict.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+        lights = []
+        rigs = []
+
+        for child in parent.children():
+            if is_rig_null(child):
+                rig_lights = []
+                for light_child in child.children():
+                    if is_light_node(light_child):
+                        parms = get_light_parms(light_child)
+                        parms["rig_parent"] = child.path()
+                        rig_lights.append(parms)
+                        lights.append(parms)
+                rigs.append({
+                    "path": child.path(),
+                    "name": child.name(),
+                    "light_count": len(rig_lights),
+                    "lights": [l["path"] for l in rig_lights],
+                })
+            elif is_light_node(child):
+                parms = get_light_parms(child)
+                parms["rig_parent"] = None
+                lights.append(parms)
+
+        # Collect standalone lights (not in a rig)
+        standalone = [l for l in lights if l.get("rig_parent") is None]
+        rigged = [l for l in lights if l.get("rig_parent") is not None]
+
+        totals = {
+            "total_lights": len(lights),
+            "standalone_lights": len(standalone),
+            "rigged_lights": len(rigged),
+            "rig_groups": len(rigs),
+        }
+
+        # Aggregate light types
+        type_counts: dict = {}
+        for l in lights:
+            lt = l.get("type", "unknown")
+            type_counts[lt] = type_counts.get(lt, 0) + 1
+        totals["by_type"] = type_counts
+
+        return skill_success(
+            "Lighting summary: {} light(s), {} rig(s)".format(totals["total_lights"], totals["rig_groups"]),
+            scanned_path=parent.path(),
+            lights=lights,
+            rigs=rigs,
+            totals=totals,
+            prompt="Use list_light_rigs to focus on rig groups or group_lights to organize standalone lights.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get lighting summary")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_lighting_summary(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/group_lights.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/group_lights.py
@@ -1,0 +1,111 @@
+"""Group existing hlight nodes under a new null rig node for collective control."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    get_node,
+    is_light_node,
+    node_summary,
+)
+
+
+def group_lights(
+    rig_name: str,
+    light_paths: List[str],
+    parent_path: str = "/obj",
+) -> dict:
+    """Group one or more existing hlight nodes under a new null rig node.
+
+    Creates a null node at *parent_path* and re-parents the specified lights
+    underneath it.  The result is a rig group that tools like
+    ``set_light_rig_intensity`` and ``list_light_rigs`` can operate on.
+
+    Args:
+        rig_name: Name for the new rig null group node.
+        light_paths: Paths of ``hlight`` nodes to group under the rig.
+        parent_path: Parent network where the rig null is created.
+            Default ``/obj``.
+
+    Returns:
+        ToolResult with ``rig_path``, ``member_count``, and ``members``
+        list of grouped light paths.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if not light_paths:
+        return skill_error("No light paths provided", "light_paths must contain at least one path")
+
+    try:
+        parent = get_node(hou, parent_path)
+
+        # Create the rig null
+        rig = parent.createNode("null", node_name=rig_name)
+
+        grouped = []
+        skipped = []
+
+        for light_path in light_paths:
+            try:
+                light = get_node(hou, light_path)
+                if not is_light_node(light):
+                    skipped.append({
+                        "path": light_path,
+                        "reason": "Not an hlight node (type: {})".format(
+                            light.type().name()
+                        ),
+                    })
+                    continue
+                # Set parent to the rig null
+                light.setParent(rig)
+                grouped.append({
+                    "path": light.path(),
+                    "name": light.name(),
+                })
+            except Exception as exc:
+                skipped.append({
+                    "path": light_path,
+                    "reason": str(exc),
+                })
+
+        warnings = None
+        if skipped:
+            warnings = {
+                "skipped_count": len(skipped),
+                "skipped": skipped,
+            }
+
+        return skill_success(
+            "Grouped {} light(s) under rig '{}'".format(len(grouped), rig.name()),
+            rig_path=rig.path(),
+            rig_name=rig.name(),
+            member_count=len(grouped),
+            members=grouped,
+            warnings=warnings,
+            prompt="Use set_light_rig_intensity to adjust all lights in the rig, or list_light_rigs to review.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to group lights under rig '{}'".format(rig_name))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return group_lights(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/group_lights.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/group_lights.py
@@ -60,24 +60,28 @@ def group_lights(
             try:
                 light = get_node(hou, light_path)
                 if not is_light_node(light):
-                    skipped.append({
-                        "path": light_path,
-                        "reason": "Not an hlight node (type: {})".format(
-                            light.type().name()
-                        ),
-                    })
+                    skipped.append(
+                        {
+                            "path": light_path,
+                            "reason": "Not an hlight node (type: {})".format(light.type().name()),
+                        }
+                    )
                     continue
                 # Set parent to the rig null
                 light.setParent(rig)
-                grouped.append({
-                    "path": light.path(),
-                    "name": light.name(),
-                })
+                grouped.append(
+                    {
+                        "path": light.path(),
+                        "name": light.name(),
+                    }
+                )
             except Exception as exc:
-                skipped.append({
-                    "path": light_path,
-                    "reason": str(exc),
-                })
+                skipped.append(
+                    {
+                        "path": light_path,
+                        "reason": str(exc),
+                    }
+                )
 
         warnings = None
         if skipped:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/group_lights.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/group_lights.py
@@ -15,7 +15,6 @@ if _SCRIPT_DIR not in sys.path:
 from _light_rig_common import (  # noqa: E402
     get_node,
     is_light_node,
-    node_summary,
 )
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/list_light_rigs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/list_light_rigs.py
@@ -50,19 +50,23 @@ def list_light_rigs(parent_path: str = "/obj") -> dict:
                 # Read key parms via _light_rig_common
                 from _light_rig_common import eval_parm  # noqa: PLC0415
 
-                member_info.append({
-                    "path": light.path(),
-                    "name": light.name(),
-                    "intensity": eval_parm(light, "light_intensity"),
-                    "enabled": eval_parm(light, "light_enable"),
-                })
+                member_info.append(
+                    {
+                        "path": light.path(),
+                        "name": light.name(),
+                        "intensity": eval_parm(light, "light_intensity"),
+                        "enabled": eval_parm(light, "light_enable"),
+                    }
+                )
 
-            rigs.append({
-                "path": child.path(),
-                "name": child.name(),
-                "light_count": len(members),
-                "lights": member_info,
-            })
+            rigs.append(
+                {
+                    "path": child.path(),
+                    "name": child.name(),
+                    "light_count": len(members),
+                    "lights": member_info,
+                }
+            )
 
         return skill_success(
             "Listed {} light rig(s)".format(len(rigs)),

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/list_light_rigs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/list_light_rigs.py
@@ -1,0 +1,86 @@
+"""List all light rig groups (null nodes containing hlight children) in a network."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    get_node,
+    get_rig_members,
+    is_rig_null,
+)
+
+
+def list_light_rigs(parent_path: str = "/obj") -> dict:
+    """List light rig groups under *parent_path*.
+
+    A light rig is a null node whose children include at least one
+    ``hlight``/``hlight::2.0`` node.  Reports rig name, path, light count,
+    and member light paths with brief parameter summaries.
+
+    Args:
+        parent_path: Network path to search. Default ``/obj``.
+
+    Returns:
+        ToolResult with ``rigs`` list and ``count``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        parent = get_node(hou, parent_path)
+        rigs = []
+
+        for child in parent.children():
+            if not is_rig_null(child):
+                continue
+
+            members = get_rig_members(child)
+            member_info = []
+            for light in members:
+                # Read key parms via _light_rig_common
+                from _light_rig_common import eval_parm  # noqa: PLC0415
+
+                member_info.append({
+                    "path": light.path(),
+                    "name": light.name(),
+                    "intensity": eval_parm(light, "light_intensity"),
+                    "enabled": eval_parm(light, "light_enable"),
+                })
+
+            rigs.append({
+                "path": child.path(),
+                "name": child.name(),
+                "light_count": len(members),
+                "lights": member_info,
+            })
+
+        return skill_success(
+            "Listed {} light rig(s)".format(len(rigs)),
+            scanned_path=parent.path(),
+            count=len(rigs),
+            rigs=rigs,
+            prompt="Use set_light_rig_intensity to adjust a rig or get_lighting_summary for full lighting details.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list light rigs")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_light_rigs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_light_rig_intensity.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_light_rig_intensity.py
@@ -1,0 +1,102 @@
+"""Scale or set intensity of all lights parented under a rig null group."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _light_rig_common import (  # noqa: E402
+    eval_parm,
+    get_node,
+    get_rig_members,
+    set_parm_if_exists,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def set_light_rig_intensity(
+    rig_group: str,
+    intensity: float,
+    multiply: bool = False,
+) -> dict:
+    """Scale or set the intensity of every light under a rig null group.
+
+    Args:
+        rig_group: Path to the rig null group node.
+        intensity: New intensity value (absolute) or multiplier when
+            ``multiply=True``.
+        multiply: If True, multiply each light's current intensity by
+            *intensity* instead of setting an absolute value.
+            Default False.
+
+    Returns:
+        ToolResult with ``rig_group``, ``updated_lights`` list, and
+        ``light_count``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        rig = get_node(hou, rig_group)
+        members = get_rig_members(rig)
+
+        if not members:
+            return skill_error(
+                "No lights found under rig '{}'".format(rig_group),
+                "The rig group contains no hlight children.",
+                rig_group=rig_group,
+            )
+
+        updated = []
+        for light in members:
+            try:
+                if multiply:
+                    current = eval_parm(light, "light_intensity")
+                    if current is None:
+                        continue
+                    new_val = float(current) * float(intensity)
+                else:
+                    new_val = float(intensity)
+                if set_parm_if_exists(light, "light_intensity", new_val):
+                    updated.append({
+                        "path": light.path(),
+                        "name": light.name(),
+                        "intensity": new_val,
+                    })
+            except Exception as exc:
+                logger.warning("Could not set intensity on %s: %s", light.path(), exc)
+
+        mode = "multiplied" if multiply else "set"
+        return skill_success(
+            "{} intensity on {} light(s) in rig '{}'".format(
+                mode.capitalize(), len(updated), rig.name()
+            ),
+            rig_group=rig_group,
+            updated_lights=updated,
+            light_count=len(updated),
+            mode=mode,
+            prompt="Use list_light_rigs or get_lighting_summary to review updated intensities.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set intensity for rig '{}'".format(rig_group))
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_light_rig_intensity(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_light_rig_intensity.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_light_rig_intensity.py
@@ -68,19 +68,19 @@ def set_light_rig_intensity(
                 else:
                     new_val = float(intensity)
                 if set_parm_if_exists(light, "light_intensity", new_val):
-                    updated.append({
-                        "path": light.path(),
-                        "name": light.name(),
-                        "intensity": new_val,
-                    })
+                    updated.append(
+                        {
+                            "path": light.path(),
+                            "name": light.name(),
+                            "intensity": new_val,
+                        }
+                    )
             except Exception as exc:
                 logger.warning("Could not set intensity on %s: %s", light.path(), exc)
 
         mode = "multiplied" if multiply else "set"
         return skill_success(
-            "{} intensity on {} light(s) in rig '{}'".format(
-                mode.capitalize(), len(updated), rig.name()
-            ),
+            "{} intensity on {} light(s) in rig '{}'".format(mode.capitalize(), len(updated), rig.name()),
             rig_group=rig_group,
             updated_lights=updated,
             light_count=len(updated),

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_render_view_transform.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_render_view_transform.py
@@ -18,6 +18,7 @@ def _get_available_transforms() -> list:
     """Try to read available OCIO view transforms from the active config."""
     try:
         import PyOpenColorIO as OCIO  # noqa: PLC0415
+
         config = OCIO.GetCurrentConfig()
         return [str(vt.getName()) for vt in config.getViews()]
     except Exception:  # noqa: BLE001
@@ -28,6 +29,7 @@ def _get_available_displays() -> list:
     """Try to read available OCIO display devices."""
     try:
         import PyOpenColorIO as OCIO  # noqa: PLC0415
+
         config = OCIO.GetCurrentConfig()
         return [str(d.getName()) for d in config.getDisplays()]
     except Exception:  # noqa: BLE001
@@ -130,9 +132,7 @@ def set_render_view_transform(
         result = _apply_houdini_color_settings(view_transform, display_device, color_space)
 
         return skill_success(
-            "Set render view transform to '{}' ({})".format(
-                view_transform, result["applied"].get("method", "unknown")
-            ),
+            "Set render view transform to '{}' ({})".format(view_transform, result["applied"].get("method", "unknown")),
             applied=result["applied"],
             available_transforms=available_transforms,
             available_displays=available_displays,

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_render_view_transform.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/set_render_view_transform.py
@@ -1,0 +1,154 @@
+"""Configure the OCIO view transform for the Houdini session's render view."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+
+def _get_available_transforms() -> list:
+    """Try to read available OCIO view transforms from the active config."""
+    try:
+        import PyOpenColorIO as OCIO  # noqa: PLC0415
+        config = OCIO.GetCurrentConfig()
+        return [str(vt.getName()) for vt in config.getViews()]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _get_available_displays() -> list:
+    """Try to read available OCIO display devices."""
+    try:
+        import PyOpenColorIO as OCIO  # noqa: PLC0415
+        config = OCIO.GetCurrentConfig()
+        return [str(d.getName()) for d in config.getDisplays()]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _apply_houdini_color_settings(
+    view_transform: str,
+    display_device: str,
+    color_space: Optional[str] = None,
+) -> dict:
+    """Apply color settings via Houdini's hou.color API or OCIO env var."""
+    applied = {}
+    warnings = []
+
+    try:
+        import hou  # noqa: PLC0415
+
+        # Houdini 20+ has hou.color.setColorTransform
+        try:
+            if hasattr(hou, "color") and hasattr(hou.color, "setColorTransform"):
+                hou.color.setColorTransform(view_transform, display_device)
+                applied["method"] = "hou.color.setColorTransform"
+                applied["view_transform"] = view_transform
+                applied["display_device"] = display_device
+
+                if color_space:
+                    try:
+                        hou.color.setColorSpace(color_space)
+                        applied["color_space"] = color_space
+                    except Exception:  # noqa: BLE001
+                        warnings.append("Could not set color_space via hou.color.setColorSpace")
+                return {"applied": applied, "warnings": warnings}
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Fallback: set OCIO env var
+        _set_ocio_env(view_transform, display_device, color_space)
+        applied["method"] = "OCIO_env_var"
+        applied["view_transform"] = view_transform
+        applied["display_device"] = display_device
+        if color_space:
+            applied["color_space"] = color_space
+        return {"applied": applied, "warnings": warnings}
+
+    except ImportError:
+        # No hou at all — use env var only
+        _set_ocio_env(view_transform, display_device, color_space)
+        applied["method"] = "OCIO_env_var (no hou)"
+        applied["view_transform"] = view_transform
+        applied["display_device"] = display_device
+        if color_space:
+            applied["color_space"] = color_space
+        return {"applied": applied, "warnings": warnings}
+
+
+def _set_ocio_env(view_transform: str, display_device: str, color_space: Optional[str] = None) -> None:
+    """Set OCIO-related environment variables."""
+    os.environ["OCIO_VIEW_TRANSFORM"] = view_transform
+    os.environ["OCIO_DISPLAY"] = display_device
+    if color_space:
+        os.environ["OCIO_COLOR_SPACE"] = color_space
+
+
+def set_render_view_transform(
+    view_transform: str,
+    display_device: str = "sRGB",
+    color_space: Optional[str] = None,
+) -> dict:
+    """Configure the OCIO view transform for render view color management.
+
+    Attempts to set the view transform through Houdini's ``hou.color`` API
+    first (Houdini 20+), falling back to ``OCIO_*`` environment variables.
+    Reports the available transforms and displays for the active OCIO config.
+
+    Args:
+        view_transform: OCIO view transform name, e.g.
+            ``"ACES 1.0 SDR-video"``, ``"sRGB"``, ``"Raw"``,
+            ``"Un-tone-mapped"``.
+        display_device: OCIO display device name. Default ``"sRGB"``.
+        color_space: Optional OCIO color space for rendering
+            (e.g. ``"ACEScg"``, ``"scene_linear"``).
+
+    Returns:
+        ToolResult with ``applied`` configuration and ``available_transforms``.
+    """
+    try:
+        available_transforms = _get_available_transforms()
+        available_displays = _get_available_displays()
+
+        # Validate the view transform if we have a list
+        if available_transforms and view_transform not in available_transforms:
+            return skill_error(
+                "View transform '{}' not found in OCIO config".format(view_transform),
+                "Available transforms: {}".format(", ".join(available_transforms)),
+                requested_transform=view_transform,
+                available_transforms=available_transforms,
+            )
+
+        result = _apply_houdini_color_settings(view_transform, display_device, color_space)
+
+        return skill_success(
+            "Set render view transform to '{}' ({})".format(
+                view_transform, result["applied"].get("method", "unknown")
+            ),
+            applied=result["applied"],
+            available_transforms=available_transforms,
+            available_displays=available_displays,
+            warnings=result.get("warnings"),
+            prompt="Use get_lighting_summary to review the scene's lighting, then capture_viewport (houdini-render) to verify the render look.",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set render view transform")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_render_view_transform(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/tools.yaml
@@ -1,0 +1,395 @@
+tools:
+  - name: create_three_point_light_rig
+    description: >-
+      Create a standard three-point (key/fill/rim) lighting rig under a null
+      group at /obj.  Each light is an hlight::2.0 node positioned at classic
+      three-point angles.  Returns the rig group, individual light paths, and
+      applied parameters.
+    source_file: scripts/create_three_point_light_rig.py
+    execution: sync
+    affinity: main
+    group: light-rig-create
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      properties:
+        name:
+          type: string
+          default: threePoint_rig
+          description: Base name for the rig null group and lights.
+        parent_path:
+          type: string
+          default: /obj
+          description: Parent network for the rig null node.
+        key_intensity:
+          type: number
+          default: 1.0
+          description: Key light intensity.
+        fill_intensity:
+          type: number
+          default: 0.5
+          description: Fill light intensity.
+        rim_intensity:
+          type: number
+          default: 0.75
+          description: Rim (back/hair) light intensity.
+        light_type:
+          type: string
+          enum: [point, distant, spot, sphere, grid, disk]
+          default: distant
+          description: hlight light_type for all three lights.
+        key_color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: RGB color for the key light. Defaults to warm white [1.0, 0.95, 0.85].
+        fill_color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: RGB color for the fill light. Defaults to cool white [0.85, 0.90, 1.0].
+        rim_color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: RGB color for the rim light. Defaults to neutral white [1.0, 1.0, 1.0].
+        key_position:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: World-space position override for the key light.
+        fill_position:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: World-space position override for the fill light.
+        rim_position:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: World-space position override for the rim light.
+    next-tools:
+      on-success:
+        - houdini_light_rig__aim_light_at_object
+        - houdini_light_rig__set_light_rig_intensity
+        - houdini_light_rig__get_lighting_summary
+
+  - name: aim_light_at_object
+    description: >-
+      Point a light at a target object using Houdini's lookatpath parameter.
+      Optionally set a look-at up-vector for finer control.  Returns the
+      light's updated configuration.
+    source_file: scripts/aim_light_at_object.py
+    execution: sync
+    affinity: main
+    group: light-rig-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [light_path, target_path]
+      properties:
+        light_path:
+          type: string
+          description: Path to the hlight node to aim.
+        target_path:
+          type: string
+          description: Path to the target node the light should point at.
+        up_vector:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          default: [0, 1, 0]
+          description: Up vector for the look-at constraint. Default [0,1,0].
+
+  - name: create_hdri_world
+    description: >-
+      Create an environment light (hlight::2.0, type=environment) with an
+      HDRI texture map for image-based lighting.  Configures intensity,
+      rotation, diffuse/specular contribution, and the environment map path.
+    source_file: scripts/create_hdri_world.py
+    execution: sync
+    affinity: main
+    group: light-rig-create
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [hdri_path]
+      properties:
+        hdri_path:
+          type: string
+          description: Absolute path to the .hdr or .exr environment map file.
+        name:
+          type: string
+          default: hdri_world
+          description: Name for the environment light node.
+        parent_path:
+          type: string
+          default: /obj
+          description: Parent network for the light node.
+        intensity:
+          type: number
+          default: 1.0
+          description: Light intensity multiplier.
+        rotation:
+          type: number
+          default: 0.0
+          description: Y-axis rotation in degrees for the HDRI orientation.
+        visible_in_diffuse:
+          type: boolean
+          default: true
+          description: Enable diffuse contribution from the environment light.
+        visible_in_specular:
+          type: boolean
+          default: true
+          description: Enable specular contribution from the environment light.
+    next-tools:
+      on-success:
+        - houdini_light_rig__set_light_rig_intensity
+        - houdini_light_rig__get_lighting_summary
+
+  - name: get_lighting_summary
+    description: >-
+      Scan the /obj network (or a specified parent) for all hlight nodes and
+      report their type, intensity, color, exposure, position, and rig
+      membership.  Read-only — no scene modification.
+    source_file: scripts/get_lighting_summary.py
+    execution: sync
+    affinity: main
+    group: light-rig-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+          description: Network path to scan for light nodes.
+
+  - name: group_lights
+    description: >-
+      Group one or more existing hlight nodes under a new null rig node.
+      The null is created at the specified parent_path and the lights are
+      re-parented underneath.  Returns the rig group path and its light
+      members.
+    source_file: scripts/group_lights.py
+    execution: sync
+    affinity: main
+    group: light-rig-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [rig_name, light_paths]
+      properties:
+        rig_name:
+          type: string
+          description: Name for the rig null group node.
+        light_paths:
+          type: array
+          items: {type: string}
+          minItems: 1
+          description: Paths of hlight nodes to group under the rig.
+        parent_path:
+          type: string
+          default: /obj
+          description: Parent network where the rig null is created.
+
+  - name: list_light_rigs
+    description: >-
+      List all light rig groups (null nodes containing hlight children)
+      under /obj or a specified parent.  Reports rig name, path, light
+      count, and member light paths.  Read-only.
+    source_file: scripts/list_light_rigs.py
+    execution: sync
+    affinity: main
+    group: light-rig-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+          description: Parent network to search for rig null groups.
+    next-tools:
+      on-success:
+        - houdini_light_rig__set_light_rig_intensity
+        - houdini_light_rig__get_lighting_summary
+
+  - name: set_light_rig_intensity
+    description: >-
+      Scale or set the intensity of all hlight nodes parented under a rig
+      null group.  Supports absolute set or multiplicative scale mode.
+      Reports the rig group, updated light count, and per-light intensity
+      values.
+    source_file: scripts/set_light_rig_intensity.py
+    execution: sync
+    affinity: main
+    group: light-rig-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [rig_group, intensity]
+      properties:
+        rig_group:
+          type: string
+          description: Path to the rig null group node.
+        intensity:
+          type: number
+          description: New intensity value (absolute) or multiplier when multiply=True.
+        multiply:
+          type: boolean
+          default: false
+          description: If true, multiply each light's current intensity by the given value.
+
+  - name: set_render_view_transform
+    description: >-
+      Configure the OCIO view transform for the Houdini session's render
+      view.  Applies to the viewport and/or render output color management.
+      Detects the active OCIO config and validates the transform name.
+    source_file: scripts/set_render_view_transform.py
+    execution: sync
+    affinity: main
+    group: light-rig-edit
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [view_transform]
+      properties:
+        view_transform:
+          type: string
+          description: >-
+            OCIO view transform name, e.g. "ACES 1.0 SDR-video",
+            "sRGB", "Raw", "Un-tone-mapped".
+        display_device:
+          type: string
+          default: sRGB
+          description: OCIO display device name. Default "sRGB".
+        color_space:
+          type: string
+          description: >-
+            Optional OCIO color space to set for rendering
+            (e.g. "ACEScg", "scene_linear").
+
+  - name: create_area_softbox
+    description: >-
+      Create a grid or disk area light configured as a softbox with large
+      area size, soft quality, and controlled diffuse/specular contribution.
+      Suitable for studio-style soft lighting.
+    source_file: scripts/create_area_softbox.py
+    execution: sync
+    affinity: main
+    group: light-rig-create
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      properties:
+        name:
+          type: string
+          default: softbox
+          description: Name for the area light node.
+        parent_path:
+          type: string
+          default: /obj
+          description: Parent network for the light.
+        shape:
+          type: string
+          enum: [grid, disk, sphere, tube]
+          default: grid
+          description: Shape of the area light.
+        size:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+          default: [5, 5]
+          description: Area size [width, height] for grid or [radius, radius] for disk/sphere.
+        intensity:
+          type: number
+          default: 2.0
+          description: Light intensity.
+        color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: RGB light color. Defaults to neutral white [1.0, 1.0, 1.0].
+        translate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: World-space position.
+        rotate:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          description: World-space rotation in degrees.
+        exposure:
+          type: number
+          description: Exposure compensation.
+    next-tools:
+      on-success:
+        - houdini_light_rig__aim_light_at_object
+        - houdini_light_rig__get_lighting_summary


### PR DESCRIPTION
## Summary

Adds `houdini-light-rig` authoring skill providing advanced lighting automation for Houdini.

### New tools (9 total)

| Tool | Description |
|------|-------------|
| `create_three_point_light_rig` | Key/fill/rim three-point studio rig |
| `aim_light_at_object` | Aim a light at a target object |
| `create_hdri_world` | HDRI environment dome light |
| `get_lighting_summary` | Scan and report all scene lighting |
| `group_lights` | Organize lights into rig groups |
| `list_light_rigs` | Enumerate light rigs in scene |
| `set_light_rig_intensity` | Batch intensity adjustment for rigs |
| `set_render_view_transform` | OCIO color transform configuration |
| `create_area_softbox` | Area light with softbox shaping |

### Implementation notes

- Uses `hlight::2.0` nodes at `/obj` level (consistent with `houdini-camera-light`)
- Light rigs use null nodes as parent groups (Maya-compatible pattern)
- HDRI uses `light_type=environment` with `envmap` parameter
- Aim priority: Houdini `lookatpath` → world-space vector fallback
- View transform via `hou.color` API or `OCIO_*` environment variables
- All scripts follow lazy `hou` import convention

### Validation

```
dcc-mcp-cli 0.18.2: checked=23 errors=0 warnings=0
All 10 Python scripts pass compilation check
SKILL.md structure validated
```

### Skills index updated

- Added `houdini-light-rig` to authoring stage
- Added 3 new tracer-bullet flow chains (three-point, HDRI, rig management)

Ref: PIP-564