### PR TITLE
chore(deps): bump dcc-mcp-core to >=0.18.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.18.7`
+- `dcc-mcp-core >= 0.18.9`
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -34,7 +34,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.18.7"
+MIN_CORE_VERSION = "0.18.9"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,9 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.18.2+: Release Train anchor — import-light public facade,
-    # DccServerOptions composition root, HostExecutionBridge, and
-    # adapter-ready diagnostics/readiness surfaces.
-    "dcc-mcp-core>=0.18.7,<1.0.0",
+    # 0.18.9: Release Train anchor — marketplace shared crate,
+    # gateway election disabled for probe server, ADR-010 docs.
+    "dcc-mcp-core>=0.18.9,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   channels and expressions; export/import channel JSON; bake channels and
   trigger bounded simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   with typed parameters. Use when loading .hda/.otl assets or executing an HDA
   node as part of automation. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   nodes through typed HOM operations. Use when building lookdev/material
   workflows. Not for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   written_files, elapsed time, and warnings without hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.7+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:


### PR DESCRIPTION
## Summary
- Bump `dcc-mcp-core` dependency from `>=0.18.7,<1.0.0` to `>=0.18.9,<1.0.0`
- Release Train v0.18.0..v0.18.9: marketplace shared crate, gateway election disabled for probe server, ADR-010 dual-protocol migration docs

## Related
- Core release: https://github.com/dcc-mcp/dcc-mcp-core/releases/tag/v0.18.9