### PR TITLE
fix(ci): fallback through recent releases when latest lacks CLI binary

### DIFF
--- a/tests/test_agent_instruction_files.py
+++ b/tests/test_agent_instruction_files.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
-
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 AGENT_ENTRYPOINTS = (
@@ -53,9 +52,6 @@ def test_multica_runtime_artifacts_are_not_tracked() -> None:
     offenders = [
         path
         for path in tracked
-        if any(
-            path == prefix.rstrip("/") or path.startswith(prefix)
-            for prefix in FORBIDDEN_TRACKED_PREFIXES
-        )
+        if any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in FORBIDDEN_TRACKED_PREFIXES)
     ]
     assert offenders == []

--- a/tools/install_dcc_mcp_cli.py
+++ b/tools/install_dcc_mcp_cli.py
@@ -63,22 +63,76 @@ def _release_api_url(tag: Optional[str]) -> str:
     return f"https://api.github.com/repos/{REPO}/releases/latest"
 
 
-def _resolve_download_url(tag: Optional[str], asset_name: str) -> str:
-    api_url = _release_api_url(tag)
-    try:
-        with urllib.request.urlopen(_request(api_url), timeout=60) as resp:
-            payload = json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
-        raise SystemExit(f"failed to query {api_url}: HTTP {exc.code} {exc.reason}") from exc
-    except urllib.error.URLError as exc:  # pragma: no cover - network failure path
-        raise SystemExit(f"failed to query {api_url}: {exc.reason}") from exc
-
+def _find_asset_in_payload(payload: dict, asset_name: str) -> Optional[str]:
+    """Return the browser_download_url if *asset_name* is present in *payload*."""
     for asset in payload.get("assets", []):
         if asset.get("name") == asset_name:
             return asset["browser_download_url"]
+    return None
 
-    available = ", ".join(sorted(a.get("name", "?") for a in payload.get("assets", [])))
-    raise SystemExit(f"asset {asset_name!r} not found in release {payload.get('tag_name')!r}. available: {available}")
+
+def _resolve_download_url(tag: Optional[str], asset_name: str) -> str:
+    """Resolve the download URL, walking recent releases as fallback.
+
+    When *tag* is ``None`` (latest release), the latest release may have been
+    published but its binary assets are still building.  Fall back through
+    the most recent 10 releases so CI doesn't fail on a transient race.
+    """
+    # ── pinned tag: try exactly one release ──
+    if tag is not None:
+        api_url = _release_api_url(tag)
+        try:
+            with urllib.request.urlopen(_request(api_url), timeout=60) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
+            raise SystemExit(f"failed to query {api_url}: HTTP {exc.code} {exc.reason}") from exc
+        except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+            raise SystemExit(f"failed to query {api_url}: {exc.reason}") from exc
+
+        url = _find_asset_in_payload(payload, asset_name)
+        if url is not None:
+            return url
+
+        available = ", ".join(sorted(a.get("name", "?") for a in payload.get("assets", [])))
+        raise SystemExit(
+            f"asset {asset_name!r} not found in release {payload.get('tag_name')!r}. available: {available}"
+        )
+
+    # ── latest release with fallback walk ──
+    releases_url = f"https://api.github.com/repos/{REPO}/releases?per_page=10"
+    try:
+        with urllib.request.urlopen(_request(releases_url), timeout=60) as resp:
+            releases = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
+        raise SystemExit(
+            f"failed to query {releases_url}: HTTP {exc.code} {exc.reason}"
+        ) from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure path
+        raise SystemExit(f"failed to query {releases_url}: {exc.reason}") from exc
+
+    if not releases:
+        raise SystemExit(f"no releases found for {REPO}")
+
+    for release in releases:
+        tag_name = release.get("tag_name", "?")
+        url = _find_asset_in_payload(release, asset_name)
+        if url is not None:
+            if tag_name != releases[0].get("tag_name", "?"):
+                print(
+                    f"latest release {releases[0].get('tag_name', '?')!r} missing {asset_name}; "
+                    f"falling back to {tag_name!r}"
+                )
+            return url
+
+    available_summary = "\n".join(
+        f"  {r.get('tag_name', '?')!r}: "
+        f"{', '.join(sorted(a.get('name', '?') for a in r.get('assets', [])))}"
+        for r in releases
+    )
+    raise SystemExit(
+        f"asset {asset_name!r} not found in any of the {len(releases)} most recent releases.\n"
+        f"{available_summary}"
+    )
 
 
 def _download(url: str, dest: pathlib.Path) -> None:

--- a/tools/install_dcc_mcp_cli.py
+++ b/tools/install_dcc_mcp_cli.py
@@ -104,9 +104,7 @@ def _resolve_download_url(tag: Optional[str], asset_name: str) -> str:
         with urllib.request.urlopen(_request(releases_url), timeout=60) as resp:
             releases = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
-        raise SystemExit(
-            f"failed to query {releases_url}: HTTP {exc.code} {exc.reason}"
-        ) from exc
+        raise SystemExit(f"failed to query {releases_url}: HTTP {exc.code} {exc.reason}") from exc
     except urllib.error.URLError as exc:  # pragma: no cover - network failure path
         raise SystemExit(f"failed to query {releases_url}: {exc.reason}") from exc
 
@@ -125,13 +123,11 @@ def _resolve_download_url(tag: Optional[str], asset_name: str) -> str:
             return url
 
     available_summary = "\n".join(
-        f"  {r.get('tag_name', '?')!r}: "
-        f"{', '.join(sorted(a.get('name', '?') for a in r.get('assets', [])))}"
+        f"  {r.get('tag_name', '?')!r}: {', '.join(sorted(a.get('name', '?') for a in r.get('assets', [])))}"
         for r in releases
     )
     raise SystemExit(
-        f"asset {asset_name!r} not found in any of the {len(releases)} most recent releases.\n"
-        f"{available_summary}"
+        f"asset {asset_name!r} not found in any of the {len(releases)} most recent releases.\n{available_summary}"
     )
 
 


### PR DESCRIPTION
## Problem

The CI `Lint and Skill Metadata` workflow fails at `Install dcc-mcp-cli` step when the latest dcc-mcp-core release has been published but its standalone binaries haven't finished uploading yet.

**Root cause:** The dcc-mcp-core release pipeline (release-please) creates the GitHub Release tag immediately, but the `build-binaries` matrix jobs upload `dcc-mcp-cli-*` assets asynchronously — sometimes taking 30-60 minutes after the tag is created. If dcc-mcp-houdini CI runs during this window it fails with:

```
asset 'dcc-mcp-cli-linux-x86_64' not found in release 'v0.18.7'. available:
```

This happened for both v0.18.7 and v0.18.10.

## Fix

Modified `tools/install_dcc_mcp_cli.py` `_resolve_download_url()` to fall back through the 10 most recent releases when `--tag` is not specified and the latest release doesn't have the requested CLI binary asset.

- When `--tag` is specified: behavior unchanged (tries only that tag)
- When no `--tag` (default/latest): tries the latest release first, walks recent releases in order if the binary isn't found, prints a fallback notice

## Test

```
python -m py_compile tools/install_dcc_mcp_cli.py  # passes
```

The CI itself serves as the integration test — the next push to main will trigger the lint job which exercises this path.