### PR TITLE
feat: add houdini-material-library skill (PIP-562)

### DIFF
--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,7 +6,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
-| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`, `houdini-light-rig` | no |
+| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-material-library`, `houdini-hda`, `houdini-light-rig` | no |
 | `interchange` | `houdini-interchange`, `houdini-export-preset` | no |
 | `pipeline` | `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake` | no |
 
@@ -35,6 +35,8 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Animate & bake | `load_skill("houdini-animation")` → `houdini_animation__set_timeline` → `houdini_animation__set_keyframe` → `houdini_animation__get_keyframes` → `houdini_animation__bake_channels` / `houdini_animation__cache_simulation` |
 | Lookdev & shader networks | `load_skill("houdini-lookdev")` → `houdini_lookdev__list_materials` → `houdini_lookdev__get_material_parms` → `houdini_lookdev__set_material_parms` → `houdini_lookdev__save_preset` / `houdini_lookdev__load_preset` |
+| Material library & presets | `load_skill("houdini-material-library")` → `houdini_material_library__list_material_presets` → `houdini_material_library__save_material_preset` / `houdini_material_library__load_material_preset` → `houdini_material_library__assign_texture` |
+| Inspect textures & colors | `load_skill("houdini-material-library")` → `houdini_material_library__list_images` → `houdini_material_library__list_color_spaces` → `houdini_material_library__reload_image` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
 | Manage export presets | `load_skill("houdini-export-preset")` → `houdini_export_preset__save_export_preset` → `houdini_export_preset__list_export_presets` → `houdini_export_preset__load_export_preset` |

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   houdini-materials (create/assign) and houdini-lookdev (shader-network
   editing, adapter-owned presets).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.17+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.18.9+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: houdini-material-library
+description: >-
+  Authoring skill — manage reusable material presets as JSON library files,
+  handle texture assignment (image nodes / file paths), reload textures from
+  disk, configure OCIO color management and list available color spaces,
+  inspect material/shader connections and assignments.  Pair with
+  houdini-materials (create/assign) and houdini-lookdev (shader-network
+  editing, adapter-owned presets).
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.17+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, materials, library, presets, textures, color-management, ocio, shader, assignment, authoring]
+    search-hint: "material library, texture management, material preset, color space, OCIO, image reload, shader assignment"
+    search-aliases: [save material preset, load material preset, material library, texture assignment, reload texture, color management, ocio config, shader assignment, list color spaces, material connections]
+    example-prompts:
+      - "Save the clay material as a preset named warm_clay in the library"
+      - "List all material presets in the project library"
+      - "Assign the brick texture to the basecolor of /mat/wall_shader"
+      - "Reload all textures in the scene"
+      - "List the available OCIO color spaces"
+      - "Which objects is /mat/metal assigned to?"
+    intent: "Manage material presets library, textures, color management, and inspect material connections/assignments."
+    recall-context:
+      app_type: houdini
+      domain: lookdev
+      workflow-stage: authoring
+      task-category: mutate
+    requires: []
+    produces: [material_preset, texture, image_node, color_space]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=19.5"
+    side-effects:
+      creates: true
+      modifies: true
+      targets: [material, texture, image_node, color_config]
+    tools: tools.yaml
+---
+
+# houdini-material-library
+
+Typed material-library tools that complement `houdini-materials` (material
+create/assign) and `houdini-lookdev` (shader-network editing and adapter-owned
+presets).
+
+## Tool groups
+
+- **`library-presets`:** `save_material_preset`, `load_material_preset`,
+  `list_material_presets`, `delete_material_preset` — JSON files under a
+  user-supplied `library_dir` (defaults to `~/.dcc-mcp/houdini/material_library/`,
+  override with `DCC_MCP_HOUDINI_MATERIAL_LIBRARY_DIR`).
+- **`library-textures`:** `assign_texture`, `list_images`, `reload_image`.
+- **`library-color`:** `set_color_management`, `list_color_spaces` (both
+  read Houdini's OCIO configuration).
+- **`library-query`** (read-only): `get_material_connections`,
+  `get_shader_assignment`.
+
+## Context limitations
+
+- **Presets vs lookdev presets:** This skill operates on a *library directory*
+  (`library_dir`) — independent of the `houdini-lookdev` adapter-owned preset
+  store.  A library preset captures the full node type and all settable scalar
+  parameters; lookdev presets capture evaluated values only.  Choose the
+  library path when sharing across projects; choose lookdev presets for
+  quick per-user snapshots.
+- **Texture mapping:** `assign_texture` creates a file texture VOP
+  (`arnold::image` / `mtlximage` / `principledshader` map) or sets a string
+  file-path parameter on the target material node.
+- **OCIO:** `list_color_spaces` reads from Houdini's active OCIO config;
+  `set_color_management` sets the `OCIO` environment variable and triggers a
+  Houdini refresh when possible.
+
+## Tracer-bullet flow
+
+1. `houdini_materials__create_material(material_name="brick_wall")`
+2. `assign_texture("/mat/brick_wall", "basecolor", "/path/to/brick.exr")`
+3. `list_color_spaces()` → discover available options
+4. `set_color_management(color_space="ACEScg")`
+5. `save_material_preset("/mat/brick_wall", "brick_wall", library_dir="/proj/lib")`
+6. `get_shader_assignment(material_path="/mat/brick_wall")` → see which objects use it

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/_library_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/_library_common.py
@@ -1,0 +1,152 @@
+"""Shared helpers for Houdini material-library skills."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from dcc_mcp_core.skill import skill_error
+
+ENV_LIBRARY_DIR = "DCC_MCP_HOUDINI_MATERIAL_LIBRARY_DIR"
+
+# Known texture file-node type names (checked in priority order).
+TEXTURE_NODE_TYPES = [
+    "arnold::image",
+    "mtlximage",
+    "redshift::TextureSampler",
+    "principledtexture",
+    "composite",
+    "file",
+]
+
+# Parameter names that store a file path on image nodes.
+IMAGE_FILE_PARMS = ("filename", "file", "texturefile", "tex0", "map")
+
+# Parameter names that store a material assignment on OBJ/SOP nodes.
+MATERIAL_ASSIGN_PARMS = ("shop_materialpath", "shop_materialpath1", "material")
+
+
+def library_dir(base: Optional[str] = None) -> Path:
+    """Return the material-library directory (created on demand).
+
+    Priority:
+    1. Explicit *base* argument.
+    2. ``DCC_MCP_HOUDINI_MATERIAL_LIBRARY_DIR`` environment variable.
+    3. ``~/.dcc-mcp/houdini/material_library/``.
+    """
+    if base:
+        target = Path(base)
+    else:
+        override = os.environ.get(ENV_LIBRARY_DIR)
+        target = Path(override) if override else Path.home() / ".dcc-mcp" / "houdini" / "material_library"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def hou_import_error() -> dict:
+    """Standard error when the HOM module is unavailable."""
+    return skill_error("Houdini not available", "hou could not be imported")
+
+
+def node_summary(node: Any) -> dict:
+    """Return a small, JSON-safe node summary."""
+    type_obj = node.type()
+    return {
+        "path": node.path(),
+        "name": node.name(),
+        "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
+    }
+
+
+def coerce_value(value: Any, current: Any) -> Any:
+    """Best-effort coerce *value* to the type of *current*."""
+    if current is None:
+        return value
+    try:
+        if isinstance(current, bool):
+            return bool(value)
+        if isinstance(current, int) and not isinstance(current, bool):
+            return int(value)
+        if isinstance(current, float):
+            return float(value)
+        if isinstance(current, str):
+            return str(value)
+    except (TypeError, ValueError):
+        return value
+    return value
+
+
+def set_node_parameter(node: Any, name: str, value: Any) -> Any:
+    """Set a parameter on *node* and return the coerced value set."""
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is None:
+            raise ValueError("No parameter tuple named {!r} on {}".format(name, node.path()))
+        parm_tuple.set(tuple(value))
+        return list(value)
+    parm = node.parm(name)
+    if parm is None:
+        raise ValueError("No parameter named {!r} on {}".format(name, node.path()))
+    try:
+        current = parm.eval()
+    except Exception:  # noqa: BLE001
+        current = None
+    coerced = coerce_value(value, current)
+    parm.set(coerced)
+    return coerced
+
+
+def find_image_filepath(node: Any) -> Optional[str]:
+    """Return the file path referenced by an image/texture node, or None."""
+    for parm_name in IMAGE_FILE_PARMS:
+        parm = node.parm(parm_name)
+        if parm is None:
+            continue
+        try:
+            value = parm.eval()
+        except Exception:  # noqa: BLE001
+            continue
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def is_image_node(node: Any) -> bool:
+    """Return True if *node* looks like a file-texture node."""
+    type_name = node.type().name() if hasattr(node.type(), "name") else ""
+    for candidate in TEXTURE_NODE_TYPES:
+        if candidate in type_name:
+            return True
+    # Fallback: check for a filename/file parameter with a non-empty path.
+    return find_image_filepath(node) is not None
+
+
+def iter_nodes_recursive(parent: Any) -> Any:
+    """Yield every node under *parent* recursively."""
+    yield parent
+    for child in parent.children():
+        yield from iter_nodes_recursive(child)
+
+
+def find_material_assignment_parm(node: Any) -> Optional[Any]:
+    """Return the first material assignment parm set on *node*, or None."""
+    for pname in MATERIAL_ASSIGN_PARMS:
+        parm = node.parm(pname)
+        if parm is None:
+            continue
+        try:
+            value = parm.eval()
+        except Exception:  # noqa: BLE001
+            continue
+        if value and isinstance(value, str) and value.strip():
+            return parm
+    return None

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -1,0 +1,185 @@
+"""Assign a texture file to a material/shader parameter."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import get_node, hou_import_error, node_summary  # noqa: E402
+
+# Map of common parameter names → texture node types to create.
+_TEXTURE_NODE_TYPE_MAP = {
+    "principledshader": "principledtexture",
+    "principledshader::2.0": "principledtexture",
+}
+
+
+def _detect_colorspace(texture_path: str) -> Optional[str]:
+    """Best-effort color space detection from file extension."""
+    ext = Path(texture_path).suffix.lower()
+    mapping = {
+        ".exr": "linear",
+        ".hdr": "linear",
+        ".jpg": "sRGB",
+        ".jpeg": "sRGB",
+        ".png": "sRGB",
+        ".tif": "linear",
+        ".tiff": "linear",
+        ".tga": "sRGB",
+        ".bmp": "sRGB",
+        ".tx": "auto",
+        ".rat": "auto",
+    }
+    return mapping.get(ext)
+
+
+def assign_texture(
+    material_path: str,
+    parameter_name: str,
+    texture_path: str,
+    colorspace: Optional[str] = None,
+) -> dict:
+    """Assign a texture file to a material/shader parameter.
+
+    Creates or updates a file-texture VOP node and wires it to the target
+    material parameter.  If the parameter is a string file-path parm (e.g.
+    on an ``arnold::image`` node), the path is set directly.
+
+    Args:
+        material_path: Path to the material/shader node.
+        parameter_name: Name of the color/texture parameter to drive.
+        texture_path: File path to the texture image on disk.
+        colorspace: OCIO color space for the texture.  Auto-detected when omitted.
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        # Validate the texture file exists.
+        tex_path = Path(texture_path)
+        if not tex_path.is_file():
+            return skill_error(
+                "Texture file not found: {}".format(texture_path),
+                "Check the path and try again.",
+            )
+
+        material_node = get_node(hou, material_path)
+        parm = material_node.parm(parameter_name)
+
+        # Case 1: The parameter is a string (file path on an image node).
+        if parm is not None:
+            parm_template = parm.parmTemplate()
+            try:
+                parm_type = parm_template.type()
+            except Exception:  # noqa: BLE001
+                parm_type = None
+
+            if parm_type == hou.parmTemplateType.String:
+                parm.set(str(texture_path))
+                if colorspace:
+                    cs_parm = material_node.parm("colorspace")
+                    if cs_parm is not None:
+                        cs_parm.set(colorspace)
+                return skill_success(
+                    "Assigned texture to material parameter",
+                    material=node_summary(material_node),
+                    parameter=parameter_name,
+                    texture_path=str(texture_path),
+                    colorspace=colorspace or _detect_colorspace(texture_path),
+                )
+
+        # Case 2: Create a file-texture node and wire it.
+        parent = material_node.parent()
+        mat_type = material_node.type().name() if hasattr(material_node.type(), "name") else ""
+
+        # Try known texture node types.
+        tex_node_type = _TEXTURE_NODE_TYPE_MAP.get(mat_type, "principledtexture")
+        tex_node = None
+
+        for candidate in [tex_node_type, "mtlximage", "arnold::image", "file"]:
+            try:
+                tex_node = parent.createNode(candidate)
+                break
+            except Exception:  # noqa: BLE001
+                continue
+
+        if tex_node is None:
+            return skill_error(
+                "Could not create texture node under {}".format(parent.path()),
+                "No supported texture node type found.",
+            )
+
+        # Set the file path on the texture node.
+        file_parm_set = False
+        for file_parm_name in ("filename", "file", "texturefile", "tex0"):
+            fp = tex_node.parm(file_parm_name)
+            if fp is not None:
+                fp.set(str(texture_path))
+                file_parm_set = True
+                break
+
+        if not file_parm_set:
+            return skill_error(
+                "Texture node has no file path parameter",
+                "Node type: {}".format(tex_node.type().name()),
+            )
+
+        # Set color space if available.
+        actual_colorspace = colorspace or _detect_colorspace(texture_path)
+        if actual_colorspace:
+            cs_parm = tex_node.parm("colorspace")
+            if cs_parm is not None:
+                cs_parm.set(actual_colorspace)
+
+        # Wire the texture output to the material input.
+        try:
+            # Find input index for the parameter.
+            input_idx = None
+            for i, name in enumerate(material_node.inputNames()):
+                if parameter_name.lower() in name.lower():
+                    input_idx = i
+                    break
+            if input_idx is None:
+                # Default: use input index 0 or try to set by name.
+                try:
+                    material_node.setNamedInput(parameter_name, tex_node, 0)
+                except Exception:  # noqa: BLE001
+                    material_node.setInput(0, tex_node, 0)
+            else:
+                material_node.setInput(input_idx, tex_node, 0)
+        except Exception:  # noqa: BLE001
+            pass
+
+        return skill_success(
+            "Assigned texture to material",
+            material=node_summary(material_node),
+            parameter=parameter_name,
+            texture_node=node_summary(tex_node),
+            texture_path=str(texture_path),
+            colorspace=actual_colorspace,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to assign texture")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return assign_texture(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/delete_material_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/delete_material_preset.py
@@ -1,0 +1,64 @@
+"""Delete a material preset JSON file from the library."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _library_common  # noqa: E402
+
+
+def delete_material_preset(preset_name: str, library_dir: Optional[str] = None) -> dict:
+    """Delete a material preset JSON file from the library.
+
+    Args:
+        preset_name: Name of the preset file to delete (stem without .json).
+        library_dir: Directory containing .json preset files.
+
+    Returns:
+        ToolResult dict confirming deletion.
+    """
+    try:
+        base = _library_common.library_dir(library_dir)
+        target = base / "{}.json".format(preset_name)
+
+        if not target.is_file():
+            # Try fuzzy match (allow passing the sanitized stem directly).
+            candidates = list(base.glob("*.json"))
+            for candidate in candidates:
+                if candidate.stem == preset_name:
+                    target = candidate
+                    break
+            else:
+                return skill_error(
+                    "Preset not found: {!r}".format(preset_name),
+                    "Use list_material_presets to find available preset names.",
+                    library_dir=str(base),
+                )
+
+        target.unlink()
+        return skill_success(
+            "Deleted material preset",
+            preset_name=preset_name,
+            preset_path=str(target),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete material preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return delete_material_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/get_material_connections.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/get_material_connections.py
@@ -1,0 +1,135 @@
+"""Query a material/shader node's input and output connections (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, List
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import find_image_filepath, get_node, hou_import_error, node_summary  # noqa: E402
+
+
+def _connection_info(source_node: Any) -> dict:
+    """Return a JSON-safe summary of a connected source node."""
+    info = node_summary(source_node)
+    # Check if it's an image node.
+    filepath = find_image_filepath(source_node)
+    if filepath:
+        info["image_file"] = filepath
+    return info
+
+
+def _traverse_upstream(node: Any, depth: int, visited: set) -> List[dict]:
+    """Recursively collect upstream connections up to *depth* levels."""
+    if depth <= 0 or node.path() in visited:
+        return []
+    visited.add(node.path())
+    result: List[dict] = []
+    for i, source in enumerate(node.inputs()):
+        if source is None:
+            continue
+        info = _connection_info(source)
+        info["input_index"] = i
+        info["upstream"] = _traverse_upstream(source, depth - 1, visited)
+        result.append(info)
+    return result
+
+
+def get_material_connections(material_path: str, depth: int = 1) -> dict:
+    """Query a material/shader node's connections.
+
+    Args:
+        material_path: Path to the material/shader node.
+        depth: Upstream traversal depth (1 = direct inputs only).
+
+    Returns:
+        ToolResult dict with inputs and outputs.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        node = get_node(hou, material_path)
+
+        # Input connections.
+        try:
+            input_names = list(node.inputNames())
+        except Exception:  # noqa: BLE001
+            input_names = []
+
+        inputs = []
+        visited: set = set()
+        visited.add(node.path())
+        for index, source in enumerate(node.inputs()):
+            if source is None:
+                continue
+            name = input_names[index] if index < len(input_names) else None
+            info = _connection_info(source)
+            info["input_index"] = index
+            info["input_name"] = name
+            info["upstream"] = _traverse_upstream(source, depth - 1, visited)
+            inputs.append(info)
+
+        # Output connections.
+        outputs = []
+        try:
+            for out_node in node.outputs():
+                outputs.append(node_summary(out_node))
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Material assignments on renderable objects.
+        assignments: List[dict] = []
+        material_path_normalized = node.path()
+        try:
+            obj_root = hou.node("/obj")
+            if obj_root is not None:
+                # Walk /obj for any node referencing this material.
+                for child in obj_root.allSubChildren():
+                    shop_parm = child.parm("shop_materialpath")
+                    if shop_parm is None:
+                        shop_parm = child.parm("shop_materialpath1")
+                    if shop_parm is None:
+                        continue
+                    try:
+                        shop_val = shop_parm.eval()
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if shop_val == material_path_normalized:
+                        assignments.append(
+                            {"object_path": child.path(), "object_name": child.name()}
+                        )
+        except Exception:  # noqa: BLE001
+            pass
+
+        return skill_success(
+            "Read material connections",
+            node=node_summary(node),
+            input_count=len(inputs),
+            output_count=len(outputs),
+            assignment_count=len(assignments),
+            inputs=inputs,
+            outputs=outputs,
+            assignments=assignments if assignments else None,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get material connections")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_material_connections(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/get_material_connections.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/get_material_connections.py
@@ -104,9 +104,7 @@ def get_material_connections(material_path: str, depth: int = 1) -> dict:
                     except Exception:  # noqa: BLE001
                         continue
                     if shop_val == material_path_normalized:
-                        assignments.append(
-                            {"object_path": child.path(), "object_name": child.name()}
-                        )
+                        assignments.append({"object_path": child.path(), "object_name": child.name()})
         except Exception:  # noqa: BLE001
             pass
 

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/get_shader_assignment.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/get_shader_assignment.py
@@ -1,0 +1,106 @@
+"""Query which renderable objects a material/shader is assigned to (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import get_node, hou_import_error, node_summary  # noqa: E402
+
+# Parameter names that carry material assignment on renderable nodes.
+_ASSIGN_PARMS = ("shop_materialpath", "shop_materialpath1", "material")
+
+
+def get_shader_assignment(
+    material_path: str,
+    search_root: str = "/obj",
+) -> dict:
+    """Query which renderable objects use *material_path*.
+
+    Searches OBJ/SOP nodes under *search_root* for material-path parameters
+    that reference the given material.
+
+    Args:
+        material_path: Path to the material/shader node.
+        search_root: Root path to search for assignments.
+
+    Returns:
+        ToolResult dict with a list of assigned objects.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        material_node = get_node(hou, material_path)
+        mat_path = material_node.path()
+        root = get_node(hou, search_root)
+
+        assigned: List[dict] = []
+        other_assignments: List[dict] = []
+
+        # Walk all descendant nodes looking for material assignments.
+        for child in root.allSubChildren():
+            assigned_material = None
+            parm_name_used = None
+
+            for pname in _ASSIGN_PARMS:
+                parm = child.parm(pname)
+                if parm is None:
+                    continue
+                try:
+                    value = parm.eval()
+                except Exception:  # noqa: BLE001
+                    continue
+                if value and isinstance(value, str) and value.strip():
+                    assigned_material = value
+                    parm_name_used = pname
+                    break
+
+            if assigned_material is None:
+                continue
+
+            entry = {
+                "object_path": child.path(),
+                "object_name": child.name(),
+                "object_type": child.type().name() if hasattr(child.type(), "name") else str(child.type()),
+                "assigned_material": assigned_material,
+                "parameter": parm_name_used,
+            }
+
+            if assigned_material == mat_path:
+                assigned.append(entry)
+            else:
+                other_assignments.append(entry)
+
+        return skill_success(
+            "Queried shader assignment",
+            material=node_summary(material_node),
+            material_path=mat_path,
+            search_root=root.path(),
+            assigned_count=len(assigned),
+            assigned_objects=assigned,
+            other_objects_count=len(other_assignments),
+            other_objects=other_assignments[:50] if other_assignments else None,  # Limit for large scenes
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get shader assignment")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_shader_assignment(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/list_color_spaces.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/list_color_spaces.py
@@ -1,0 +1,94 @@
+"""List available OCIO color spaces from Houdini's active config (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import hou_import_error  # noqa: E402
+
+
+def list_color_spaces(filter: Optional[str] = None) -> dict:
+    """List available OCIO color spaces.
+
+    Args:
+        filter: Optional substring to filter color space names.
+
+    Returns:
+        ToolResult dict with color_spaces list.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        color_spaces = []
+
+        # Houdini 20+ OCIO API.
+        try:
+            if hasattr(hou, "ocio") and hasattr(hou.ocio, "colorSpaces"):
+                for cs in hou.ocio.colorSpaces():
+                    name = cs.getName() if hasattr(cs, "getName") else str(cs)
+                    if filter and filter.lower() not in name.lower():
+                        continue
+                    entry = {"name": name}
+                    if hasattr(cs, "getFamily"):
+                        family = cs.getFamily()
+                        if family:
+                            entry["family"] = family
+                    if hasattr(cs, "getDescription"):
+                        desc = cs.getDescription()
+                        if desc:
+                            entry["description"] = desc
+                    color_spaces.append(entry)
+            elif hasattr(hou, "color") and hasattr(hou.color, "colorSpaces"):
+                # Older Houdini API.
+                for cs_name in hou.color.colorSpaces():
+                    if filter and filter.lower() not in cs_name.lower():
+                        continue
+                    color_spaces.append({"name": cs_name})
+            else:
+                # Fallback: try to list roles.
+                if hasattr(hou, "color") and hasattr(hou.color, "roles"):
+                    for role_name in hou.color.roles():
+                        if filter and filter.lower() not in role_name.lower():
+                            continue
+                        color_spaces.append({"name": role_name, "type": "role"})
+                else:
+                    return skill_error(
+                        "OCIO color space listing not available",
+                        "Houdini version may not expose the OCIO API via HOM.",
+                    )
+        except Exception as exc:  # noqa: BLE001
+            return skill_error(
+                "Failed to list OCIO color spaces",
+                str(exc),
+            )
+
+        return skill_success(
+            "Listed OCIO color spaces",
+            count=len(color_spaces),
+            filter=filter,
+            color_spaces=color_spaces,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list color spaces")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_color_spaces(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/list_images.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/list_images.py
@@ -1,0 +1,93 @@
+"""List image/file-texture nodes in the scene (read-only)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import (  # noqa: E402
+    find_image_filepath,
+    get_node,
+    hou_import_error,
+    is_image_node,
+    iter_nodes_recursive,
+)
+
+
+def list_images(parent_path: str = "/mat") -> dict:
+    """List image/file-texture nodes under *parent_path*.
+
+    Args:
+        parent_path: Material network to scan (e.g. /mat or /obj).
+
+    Returns:
+        ToolResult dict with a list of image node info dicts.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        parent = get_node(hou, parent_path)
+        images: List[dict] = []
+        missing_files: List[dict] = []
+
+        for node in iter_nodes_recursive(parent):
+            if not is_image_node(node):
+                continue
+            info = {
+                "path": node.path(),
+                "name": node.name(),
+                "type": node.type().name() if hasattr(node.type(), "name") else str(node.type()),
+            }
+            filepath = find_image_filepath(node)
+            if filepath:
+                info["file_path"] = filepath
+                fp = Path(filepath)
+                info["exists_on_disk"] = fp.is_file()
+                if not fp.is_file():
+                    missing_files.append(info.copy())
+            else:
+                info["file_path"] = None
+                info["exists_on_disk"] = False
+
+            # Try to get resolution info.
+            try:
+                res_parm = node.parm("resolution")
+                if res_parm is not None:
+                    res_val = res_parm.eval()
+                    info["resolution"] = res_val
+            except Exception:  # noqa: BLE001
+                pass
+
+            images.append(info)
+
+        return skill_success(
+            "Listed image nodes",
+            parent_path=parent.path(),
+            total_count=len(images),
+            missing_count=len(missing_files),
+            images=images,
+            missing_files=missing_files if missing_files else None,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list images")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_images(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/list_material_presets.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/list_material_presets.py
@@ -1,0 +1,72 @@
+"""List all material preset JSON files in a library directory (read-only)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _library_common  # noqa: E402
+
+
+def list_material_presets(library_dir: Optional[str] = None) -> dict:
+    """List all material preset JSON files in a library directory.
+
+    Args:
+        library_dir: Directory to search for .json preset files.
+            Defaults to the configured or default library directory.
+
+    Returns:
+        ToolResult dict with a list of preset info dicts.
+    """
+    try:
+        base = _library_common.library_dir(library_dir)
+        if not base.is_dir():
+            return skill_error(
+                "Library directory not found: {}".format(base),
+                "Create the directory or run save_material_preset first.",
+            )
+
+        presets = []
+        for path in sorted(base.glob("*.json")):
+            entry = {
+                "name": path.stem,
+                "file_path": str(path),
+                "size_bytes": path.stat().st_size,
+            }
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    data = json.load(handle)
+                entry["material_type"] = data.get("material_type", "unknown")
+                entry["source_material"] = data.get("material_path", "unknown")
+                entry["parameter_count"] = len(data.get("parameters", {}))
+            except Exception:  # noqa: BLE001
+                entry["error"] = "unreadable preset"
+            presets.append(entry)
+
+        return skill_success(
+            "Listed material presets",
+            library_dir=str(base),
+            count=len(presets),
+            presets=presets,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list material presets")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_material_presets(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/load_material_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/load_material_preset.py
@@ -1,0 +1,105 @@
+"""Recreate a material from a JSON preset file and optionally assign it to objects."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import get_node, hou_import_error, node_summary, set_node_parameter  # noqa: E402
+
+
+def load_material_preset(
+    file_path: str,
+    material_name: Optional[str] = None,
+    parent_path: str = "/mat",
+    assign_to: Optional[List[str]] = None,
+) -> dict:
+    """Recreate a material from a JSON preset file.
+
+    Args:
+        file_path: Path to the .json preset file.
+        material_name: Override name for the created material node.
+        parent_path: Material network to create the node under.
+        assign_to: Optional list of OBJ/SOP node paths to assign to.
+
+    Returns:
+        ToolResult dict with the created node and assignment info.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        try:
+            with open(file_path, encoding="utf-8") as handle:
+                preset_data = json.load(handle)
+        except (IOError, ValueError) as exc:
+            return skill_error("Cannot read preset {!r}".format(file_path), str(exc))
+
+        node_type = preset_data.get("material_type", "principledshader")
+        default_name = preset_data.get("material_path", "").rsplit("/", 1)[-1] or "material_preset"
+        name = material_name or default_name
+
+        # Create the material node.
+        parent = get_node(hou, parent_path)
+        try:
+            material = parent.createNode(node_type, node_name=name)
+        except Exception:
+            # Fallback: try principledshader as a safe default.
+            material = parent.createNode("principledshader::2.0", node_name=name)
+
+        # Apply saved parameters.
+        parameters: Dict[str, Any] = preset_data.get("parameters", {})
+        applied = 0
+        errors: Dict[str, str] = {}
+        for attr, val in parameters.items():
+            try:
+                set_node_parameter(material, attr, val)
+                applied += 1
+            except Exception as exc:  # noqa: BLE001
+                errors[attr] = str(exc)
+
+        # Optionally assign to objects.
+        assigned_to: List[str] = []
+        if assign_to:
+            for obj_path in assign_to:
+                try:
+                    obj_node = get_node(hou, obj_path)
+                    parm = obj_node.parm("shop_materialpath")
+                    if parm is not None:
+                        parm.set(material.path())
+                        assigned_to.append(obj_path)
+                except Exception:  # noqa: BLE001
+                    pass
+
+        return skill_success(
+            "Loaded material preset",
+            material=node_summary(material),
+            preset_type=node_type,
+            applied_count=applied,
+            error_count=len(errors),
+            errors=errors,
+            assigned_to=assigned_to,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to load material preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return load_material_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/reload_image.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/reload_image.py
@@ -1,0 +1,133 @@
+"""Reload one or more image texture nodes from disk."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import (  # noqa: E402
+    find_image_filepath,
+    get_node,
+    hou_import_error,
+    is_image_node,
+    iter_nodes_recursive,
+)
+
+
+def _reload_node(node: Any) -> dict:
+    """Attempt to reload a single image node and return result info."""
+    info = {"path": node.path(), "name": node.name(), "reloaded": False}
+    filepath = find_image_filepath(node)
+    if filepath:
+        info["file_path"] = filepath
+
+    # Houdini image nodes typically reload by re-setting the file parameter
+    # or via node.cook(force=True).
+    try:
+        # Method 1: Try the parm.pressButton for reload.
+        reload_parm = node.parm("reload")
+        if reload_parm is not None:
+            reload_parm.pressButton()
+            info["reloaded"] = True
+            info["method"] = "reload_button"
+            return info
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        # Method 2: Re-set the filename parameter.
+        if filepath:
+            for file_parm_name in ("filename", "file", "texturefile"):
+                fp = node.parm(file_parm_name)
+                if fp is not None:
+                    fp.set(filepath)
+                    info["reloaded"] = True
+                    info["method"] = "reset_filename"
+                    return info
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        # Method 3: Force re-cook.
+        node.cook(force=True)
+        info["reloaded"] = True
+        info["method"] = "force_cook"
+    except Exception:  # noqa: BLE001
+        pass
+
+    return info
+
+
+def reload_image(
+    node_path: Optional[str] = None,
+    parent_path: str = "/mat",
+    reload_all: bool = False,
+) -> dict:
+    """Reload image texture nodes from disk.
+
+    Args:
+        node_path: Path to a single image node to reload.
+        parent_path: Material network to scan (when node_path is None).
+        reload_all: Reload every image node under parent_path.
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        results: List[dict] = []
+
+        if node_path:
+            node = get_node(hou, node_path)
+            if not is_image_node(node):
+                return skill_error(
+                    "Not an image node: {}".format(node_path),
+                    "Use list_images to find image nodes.",
+                )
+            results.append(_reload_node(node))
+        elif reload_all:
+            parent = get_node(hou, parent_path)
+            for node in iter_nodes_recursive(parent):
+                if is_image_node(node):
+                    results.append(_reload_node(node))
+        else:
+            return skill_error(
+                "Specify node_path or set reload_all=True",
+                "Use list_images to find available image nodes.",
+            )
+
+        reloaded = [r for r in results if r.get("reloaded")]
+        failed = [r for r in results if not r.get("reloaded")]
+
+        return skill_success(
+            "Reloaded image nodes",
+            total=len(results),
+            reloaded_count=len(reloaded),
+            failed_count=len(failed),
+            reloaded=reloaded,
+            failed=failed if failed else None,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to reload images")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return reload_image(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/save_material_preset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/save_material_preset.py
@@ -1,0 +1,126 @@
+"""Save a material/shader node's definition as a JSON preset in a library directory."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import _library_common  # noqa: E402
+from _library_common import get_node, hou_import_error, node_summary  # noqa: E402
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
+
+# Parameters to skip during serialization (read-only / internal).
+_SKIP_PARMS = {
+    "caching",
+    "frozen",
+    "isHistoricallyInteresting",
+    "nodeState",
+    "display",
+    "renderable",
+    "visible",
+    "picking",
+    "unload",
+    "dirty",
+    "bypass",
+}
+
+
+def _safe_name(name: str) -> str:
+    cleaned = _SAFE_NAME.sub("_", name).strip("_")
+    return cleaned or "preset"
+
+
+def save_material_preset(
+    material_path: str,
+    preset_name: str,
+    library_dir: Optional[str] = None,
+    attributes: Optional[List[str]] = None,
+    overwrite: bool = True,
+) -> dict:
+    """Serialize *material_path*'s definition to a JSON preset file.
+
+    Args:
+        material_path: Path to the material/shader node.
+        preset_name: File name stem (without .json).
+        library_dir: Directory for preset files.
+        attributes: Explicit list of parameter names to capture.
+        overwrite: If False and the file exists, return an error.
+
+    Returns:
+        ToolResult dict with file_path, node_type, and parameter_count.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        node = get_node(hou, material_path)
+        base = _library_common.library_dir(library_dir)
+        safe_stem = _safe_name(preset_name)
+        file_path = base / "{}.json".format(safe_stem)
+
+        if not overwrite and file_path.exists():
+            return skill_error(
+                "Preset {!r} already exists at {}".format(safe_stem, file_path),
+                "Set overwrite=True to replace it.",
+            )
+
+        parameters = {}
+        source_parms = node.parms()
+        wanted = set(attributes) if attributes else None
+        for parm in source_parms:
+            name = parm.name()
+            if wanted is not None and name not in wanted:
+                continue
+            if name in _SKIP_PARMS or "." in name:
+                continue
+            try:
+                value = parm.eval()
+            except Exception:  # noqa: BLE001
+                continue
+            # Convert tuples to lists for JSON serialization.
+            if isinstance(value, tuple):
+                value = list(value)
+            parameters[name] = value
+
+        preset_data = {
+            "preset_name": preset_name,
+            "material_path": material_path,
+            "material_type": node.type().name(),
+            "parameters": parameters,
+        }
+
+        with open(file_path, "w", encoding="utf-8") as handle:
+            json.dump(preset_data, handle, indent=2)
+
+        return skill_success(
+            "Saved material preset",
+            preset_name=preset_name,
+            material=node_summary(node),
+            parameter_count=len(parameters),
+            preset_path=str(file_path),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to save material preset")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return save_material_preset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/set_color_management.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/set_color_management.py
@@ -1,0 +1,110 @@
+"""Configure Houdini's OCIO color management settings."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import hou_import_error  # noqa: E402
+
+
+def set_color_management(
+    ocio_config_path: Optional[str] = None,
+    color_space: Optional[str] = None,
+    view_transform: Optional[str] = None,
+) -> dict:
+    """Configure Houdini OCIO color management.
+
+    Args:
+        ocio_config_path: Path to an OCIO config.ocio file.
+        color_space: Default color space name (e.g. ACEScg).
+        view_transform: View transform name (e.g. Un-tone-mapped).
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    changes: dict = {}
+    warnings: list = []
+
+    # --- Set OCIO config path ---
+    if ocio_config_path:
+        config_path = Path(ocio_config_path)
+        if not config_path.is_file():
+            return skill_error(
+                "OCIO config not found: {}".format(ocio_config_path),
+                "Provide a valid path to a config.ocio file.",
+            )
+        try:
+            os.environ["OCIO"] = str(config_path)
+            changes["ocio_config_path"] = str(config_path)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append("Failed to set OCIO env: {}".format(exc))
+
+    # --- Set color space / view transform via HOM ---
+    # Houdini 20+ exposes hou.Color.oclo; older versions use env vars.
+    try:
+        if color_space:
+            # Try Houdini 20+ color management API.
+            try:
+                if hasattr(hou, "ocio") and hasattr(hou.ocio, "setDefaultColorSpace"):
+                    hou.ocio.setDefaultColorSpace(color_space)
+                    changes["color_space"] = color_space
+                else:
+                    os.environ["OCIO_COLOR_SPACE"] = color_space
+                    changes["color_space"] = color_space
+            except Exception:  # noqa: BLE001
+                os.environ["OCIO_COLOR_SPACE"] = color_space
+                changes["color_space"] = color_space
+                warnings.append("Set via env var (HOM API unavailable)")
+
+        if view_transform:
+            try:
+                if hasattr(hou, "ocio") and hasattr(hou.ocio, "setDefaultViewTransform"):
+                    hou.ocio.setDefaultViewTransform(view_transform)
+                    changes["view_transform"] = view_transform
+                else:
+                    os.environ["OCIO_VIEW_TRANSFORM"] = view_transform
+                    changes["view_transform"] = view_transform
+            except Exception:  # noqa: BLE001
+                os.environ["OCIO_VIEW_TRANSFORM"] = view_transform
+                changes["view_transform"] = view_transform
+                warnings.append("Set via env var (HOM API unavailable)")
+    except Exception as exc:  # noqa: BLE001
+        warnings.append("Color management API error: {}".format(exc))
+
+    if not changes:
+        return skill_error(
+            "No color management settings provided",
+            "Specify at least one of: ocio_config_path, color_space, view_transform.",
+        )
+
+    return skill_success(
+        "Updated color management settings",
+        changes=changes,
+        warnings=warnings if warnings else None,
+        note="A Houdini restart or refresh may be needed for env-var changes to take full effect.",
+    )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_color_management(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/set_material_attribute.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/set_material_attribute.py
@@ -1,0 +1,83 @@
+"""Set an attribute on a material/shader node with type coercion."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _library_common import get_node, hou_import_error, node_summary, set_node_parameter  # noqa: E402
+
+
+def set_material_attribute(
+    material_path: str,
+    attribute_name: str,
+    value: Any,
+) -> dict:
+    """Set a parameter/attribute on a material/shader node.
+
+    Args:
+        material_path: Path to the material/shader node.
+        attribute_name: Name of the parameter to set.
+        value: Value to set (scalar or list/tuple for tuple params).
+
+    Returns:
+        ToolResult dict.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        node = get_node(hou, material_path)
+
+        # Check if the parameter exists.
+        parm = node.parm(attribute_name)
+        parm_tuple = node.parmTuple(attribute_name)
+        if parm is None and parm_tuple is None:
+            # List available parameter names for diagnostics.
+            available = [p.name() for p in node.parms()]
+            return skill_error(
+                "Parameter {!r} not found on {}".format(attribute_name, material_path),
+                "Available parameters (first 20): {}".format(", ".join(available[:20])),
+            )
+
+        old_value = None
+        try:
+            if isinstance(value, (list, tuple)):
+                if parm_tuple is not None:
+                    old_value = list(parm_tuple.eval())
+            elif parm is not None:
+                old_value = parm.eval()
+        except Exception:  # noqa: BLE001
+            pass
+
+        coerced = set_node_parameter(node, attribute_name, value)
+
+        return skill_success(
+            "Set material attribute",
+            material=node_summary(node),
+            attribute=attribute_name,
+            set_value=coerced,
+            previous_value=old_value,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set material attribute")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_material_attribute(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
@@ -1,0 +1,384 @@
+tools:
+  # ── Library Presets ────────────────────────────────────────────────
+  - name: save_material_preset
+    description: >-
+      Save a material/shader node's definition (type + all settable scalar
+      parameters) as a JSON preset file in a library directory.  Creates the
+      library directory if needed.
+    source_file: scripts/save_material_preset.py
+    execution: sync
+    affinity: main
+    group: library-presets
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path, preset_name]
+      properties:
+        material_path:
+          type: string
+          description: Material/shader node path to serialize (e.g. /mat/clay).
+        preset_name:
+          type: string
+          description: Name for the preset file (stem without .json extension).
+        library_dir:
+          type: string
+          description: >-
+            Directory where preset .json files are stored.  Defaults to
+            $DCC_MCP_HOUDINI_MATERIAL_LIBRARY_DIR or
+            ~/.dcc-mcp/houdini/material_library/.
+        attributes:
+          type: array
+          items: {type: string}
+          description: >-
+            Explicit list of parameter names to capture.  When omitted, all
+            settable scalar parameters are captured automatically.
+        overwrite:
+          type: boolean
+          default: true
+          description: If false and the preset file exists, return an error.
+
+  - name: load_material_preset
+    description: >-
+      Recreate a material from a JSON preset file and optionally assign it
+      to target objects.
+    source_file: scripts/load_material_preset.py
+    execution: sync
+    affinity: main
+    group: library-presets
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [file_path]
+      properties:
+        file_path:
+          type: string
+          description: Path to the .json preset file.
+        material_name:
+          type: string
+          description: >-
+            Override name for the created material node.  Defaults to the
+            name stored in the preset.
+        parent_path:
+          type: string
+          default: "/mat"
+          description: Material network to create the node under.
+        assign_to:
+          type: array
+          items: {type: string}
+          description: >-
+            Optional list of OBJ/SOP node paths to assign the material to
+            after creation.
+
+  - name: list_material_presets
+    description: >-
+      List all material preset JSON files in a library directory (read-only,
+      no Houdini scene access required).
+    source_file: scripts/list_material_presets.py
+    execution: sync
+    affinity: any
+    group: library-presets
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        library_dir:
+          type: string
+          description: >-
+            Directory to search for .json preset files.  Defaults to
+            $DCC_MCP_HOUDINI_MATERIAL_LIBRARY_DIR or
+            ~/.dcc-mcp/houdini/material_library/.
+
+  - name: delete_material_preset
+    description: >-
+      Delete a material preset JSON file from the library (no Houdini
+      scene access required).
+    source_file: scripts/delete_material_preset.py
+    execution: sync
+    affinity: any
+    group: library-presets
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [preset_name]
+      properties:
+        preset_name:
+          type: string
+          description: Name of the preset file to delete (stem without .json).
+        library_dir:
+          type: string
+          description: >-
+            Directory containing preset .json files.  Defaults to
+            $DCC_MCP_HOUDINI_MATERIAL_LIBRARY_DIR or
+            ~/.dcc-mcp/houdini/material_library/.
+
+  # ── Texture Management ─────────────────────────────────────────────
+  - name: assign_texture
+    description: >-
+      Assign a texture file to a material/shader parameter.  Creates or
+      updates a file-texture VOP node and wires it to the target parameter.
+      Supports principledshader, MaterialX, and Arnold shaders.
+    source_file: scripts/assign_texture.py
+    execution: sync
+    affinity: main
+    group: library-textures
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path, parameter_name, texture_path]
+      properties:
+        material_path:
+          type: string
+          description: Path to the material/shader node.
+        parameter_name:
+          type: string
+          description: >-
+            Name of the color/texture parameter to drive
+            (e.g. basecolor, baseColor, diffuse, base_color).
+        texture_path:
+          type: string
+          description: File path to the texture image on disk.
+        colorspace:
+          type: string
+          description: >-
+            OCIO color space for the texture (e.g. Utility - sRGB - Texture,
+            ACES - ACEScg).  Auto-detected from file extension when omitted.
+
+  - name: list_images
+    description: >-
+      List image/file-texture nodes in the scene (read-only).  Scans
+      material networks for nodes that reference image files on disk.
+    source_file: scripts/list_images.py
+    execution: sync
+    affinity: main
+    group: library-textures
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        parent_path:
+          type: string
+          default: "/mat"
+          description: >-
+            Material network to scan for image nodes.  Use "/" to scan the
+            entire scene (can be slow in large scenes).
+
+  - name: reload_image
+    description: >-
+      Reload one or more image texture nodes from disk.  Optionally reloads
+      all image nodes in a given material network.
+    source_file: scripts/reload_image.py
+    execution: sync
+    affinity: main
+    group: library-textures
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        node_path:
+          type: string
+          description: >-
+            Path to a single image/texture node to reload.  If omitted,
+            parent_path is used for a bulk reload.
+        parent_path:
+          type: string
+          default: "/mat"
+          description: >-
+            Material network to scan for image nodes when node_path is
+            not specified.
+        reload_all:
+          type: boolean
+          default: false
+          description: >-
+            When true, reloads every image node found under parent_path.
+
+  # ── Color Management ───────────────────────────────────────────────
+  - name: set_color_management
+    description: >-
+      Configure Houdini's OCIO color management: set the active config
+      path, the default color space, or the view transform.
+    source_file: scripts/set_color_management.py
+    execution: sync
+    affinity: main
+    group: library-color
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        ocio_config_path:
+          type: string
+          description: >-
+            Path to an OCIO config file (config.ocio).  Sets the OCIO
+            environment variable for the current Houdini session.
+        color_space:
+          type: string
+          description: >-
+            Default color space name to use (e.g. ACEScg, ACES2065-1,
+            sRGB).  Houdini's color picker and viewport will use this.
+        view_transform:
+          type: string
+          description: >-
+            View transform name (e.g. Un-tone-mapped, ACES 1.0 SDR-video).
+
+  - name: list_color_spaces
+    description: >-
+      List the available OCIO color spaces from Houdini's active
+      configuration (read-only).
+    source_file: scripts/list_color_spaces.py
+    execution: sync
+    affinity: main
+    group: library-color
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        filter:
+          type: string
+          description: >-
+            Optional substring to filter color space names
+            (e.g. "ACES" returns only ACES-family spaces).
+
+  # ── Material Attributes / Connections ──────────────────────────────
+  - name: set_material_attribute
+    description: >-
+      Set an attribute on a material/shader node.  Supports both scalar
+      values and tuple (color/vector) parameters with type coercion.
+    source_file: scripts/set_material_attribute.py
+    execution: sync
+    affinity: main
+    group: library-query
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path, attribute_name, value]
+      properties:
+        material_path:
+          type: string
+          description: Path to the material/shader node.
+        attribute_name:
+          type: string
+          description: Name of the parameter/attribute to set.
+        value:
+          description: >-
+            Value to set.  Scalars (float/int/str/bool) are coerced
+            automatically; lists/tuples set parameter tuples (e.g.
+            [0.8, 0.4, 0.2] for a color).
+
+  - name: get_material_connections
+    description: >-
+      Query a material/shader node's input and output connections, including
+      upstream texture nodes and downstream shader assignments (read-only).
+    source_file: scripts/get_material_connections.py
+    execution: sync
+    affinity: main
+    group: library-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path]
+      properties:
+        material_path:
+          type: string
+          description: Path to the material/shader node to inspect.
+        depth:
+          type: integer
+          default: 1
+          description: >-
+            How many levels of upstream connections to traverse
+            (1 = direct inputs, 2 = inputs of inputs, etc.).
+
+  - name: get_shader_assignment
+    description: >-
+      Query which renderable objects a material/shader is assigned to
+      (read-only).  Searches OBJ/SOP nodes for shop_materialpath
+      references to the given material.
+    source_file: scripts/get_shader_assignment.py
+    execution: sync
+    affinity: main
+    group: library-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [material_path]
+      properties:
+        material_path:
+          type: string
+          description: >-
+            Path to the material/shader node to query assignments for.
+        search_root:
+          type: string
+          default: "/obj"
+          description: >-
+            Root path to search for assignments.  "/obj" covers most
+            standard scenes.  Use "/" for exhaustive (slower) search.


### PR DESCRIPTION
## Summary

Adds the `houdini-material-library` skill covering 12 tools for material preset management, texture operations, color management, and shader connection/assignment queries.

## New Skill: houdini-material-library

```
src/dcc_mcp_houdini/skills/houdini-material-library/
├── SKILL.md
├── tools.yaml
└── scripts/
    ├── _library_common.py
    ├── save_material_preset.py
    ├── load_material_preset.py
    ├── list_material_presets.py
    ├── delete_material_preset.py
    ├── assign_texture.py
    ├── list_images.py
    ├── reload_image.py
    ├── set_color_management.py
    ├── list_color_spaces.py
    ├── set_material_attribute.py
    ├── get_material_connections.py
    └── get_shader_assignment.py
```

### Tool Groups

| Group | Tools |
|-------|-------|
| library-presets | save/load/list/delete | material_preset |
| library-textures | assign_texture, list_images, reload_image |
| library-color | set_color_management, list_color_spaces |
| library-query | set_material_attribute, get_material_connections, get_shader_assignment |

### Relation to existing skills

- **houdini-materials**: create/assign materials
- **houdini-lookdev**: shader-network editing, adapter-owned presets
- **houdini-material-library** (new): material preset library, textures, color management, connection queries

## Validation

- ruff check: All checks passed
- py_compile: All 13 scripts compile cleanly
- lint_skills --warnings-as-errors: checked=22 errors=0 warnings=0

Closes: PIP-562