### PR TITLE
fix: sync STAGE_SKILLS with 4 newly added skills

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -33,8 +33,13 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
         "houdini-materials",
         "houdini-lookdev",
         "houdini-hda",
+        "houdini-material-library",
+        "houdini-light-rig",
     ),
-    "interchange": ("houdini-interchange",),
+    "interchange": (
+        "houdini-interchange",
+        "houdini-export-preset",
+    ),
     "pipeline": (
         "houdini-render",
         "houdini-animation",
@@ -42,6 +47,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
         "houdini-pipeline",
         "houdini-dev",
         "houdini-automation",
+        "houdini-texture-bake",
     ),
 }
 


### PR DESCRIPTION
## Summary

Adds 4 newly added skills to the `STAGE_SKILLS` dictionary in `_skill_loader.py` to align with `SKILLS_INDEX.md`.

## Changes

| Skill | Stage |
|---|---|
| `houdini-material-library` | `authoring` |
| `houdini-light-rig` | `authoring` |
| `houdini-export-preset` | `interchange` |
| `houdini-texture-bake` | `pipeline` |

Also reformats `interchange` from single-line tuple to multi-line for consistency.

## Verification

- Total skills: 24 across all stages
- `tools/lint_skills.py --no-cli` passes
- All acceptance criteria verified