### PR TITLE
feat: add houdini-chops, houdini-constraints, and houdini-kinefx skills

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -43,6 +43,9 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "pipeline": (
         "houdini-render",
         "houdini-animation",
+        "houdini-chops",
+        "houdini-constraints",
+        "houdini-kinefx",
         "houdini-hda-automation",
         "houdini-pipeline",
         "houdini-dev",

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -8,7 +8,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
 | `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-material-library`, `houdini-hda`, `houdini-light-rig` | no |
 | `interchange` | `houdini-interchange`, `houdini-export-preset` | no |
-| `pipeline` | `houdini-render`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake` | no |
+| `pipeline` | `houdini-render`, `houdini-animation`, `houdini-chops`, `houdini-constraints`, `houdini-kinefx`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake` | no |
 
 ## Common chains
 
@@ -44,4 +44,8 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Project + shot packaging | `load_skill("houdini-pipeline")` → `houdini_pipeline__set_project` → `houdini_pipeline__validate_scene` → `houdini_pipeline__collect_dependencies` → `houdini_pipeline__export_shot_package` |
 | Develop & debug tools | `load_skill("houdini-dev")` → `houdini_dev__attach_project` → `houdini_dev__reload_modules` → `houdini_dev__run_entrypoint` → `houdini_dev__introspect_hom` / `houdini_dev__start_debugpy` |
 | File-based automation | `load_skill("houdini-automation")` → `houdini_automation__run_python_file` |
+| Motion FX & CHOPs | `load_skill("houdini-chops")` → `houdini_chops__create_chop_network` → `houdini_chops__create_motionclip` → `houdini_chops__apply_filter` → `houdini_chops__get_channel_info` → `houdini_chops__export_to_keyframes` |
+| Audio-driven animation | `load_skill("houdini-chops")` → `houdini_chops__create_chop_network` → `houdini_chops__create_audio_driven` |
+| Constrain transforms | `load_skill("houdini-constraints")` → `houdini_constraints__create_parent_constraint` / `create_blend_constraint` / `create_position_constraint` / `create_orient_constraint` → `houdini_constraints__list_constraints` → `houdini_constraints__delete_constraint` |
+| KineFX character rig | `load_skill("houdini-kinefx")` → `houdini_kinefx__create_rig` → `houdini_kinefx__set_rig_pose` → `houdini_kinefx__capture_joints` → `houdini_kinefx__apply_mocap` |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |

--- a/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: houdini-chops
+description: >-
+  Pipeline skill — typed CHOP (Channel Operator) tools for motion FX,
+  audio-driven animation, procedural filtering, and CHOP-to-keyframe
+  export. Create and manage CHOP networks, motion clips, audio-driven
+  channels, and filter effects.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.14+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: pipeline
+    version: "1.0.0"
+    tags: [houdini, chops, motion-fx, audio, filter, envelope, keyframe, channel, pipeline]
+    search-hint: "chop channel motion clip audio filter lag spring noise envelope keyframe export"
+    tools: tools.yaml
+---
+
+# houdini-chops
+
+Typed CHOP tools for agents. All tools are `affinity: main`.
+
+## Tool groups
+
+- **`network`:** `create_chop_network` — create and manage CHOP container networks.
+- **`motion`:** `create_motionclip` — import or create motion clip CHOPs for
+  animation data.
+- **`audio`:** `create_audio_driven` — set up audio-driven animation channels
+  using Audio/Envelope CHOPs.
+- **`filter`:** `apply_filter` — apply procedural CHOP filters (lag, spring,
+  noise, smooth).
+- **`export`:** `export_to_keyframes` — bake CHOP channel data to object
+  keyframes.
+- **`inspect`:** `get_channel_info` — inspect CHOP node channels (names, sample
+  rate, length, value range).
+
+## Tracer-bullet flow
+
+1. `create_chop_network(network_path="/ch/motion_fx")`
+2. `create_motionclip(network_path="/ch/motion_fx", node_name="walk_cycle", clip_file="/tmp/walk.bclip")`
+3. `apply_filter(network_path="/ch/motion_fx", source_node="walk_cycle", filter_type="lag", amount=0.5)`
+4. `get_channel_info(node_path="/ch/motion_fx/lag1")`
+5. `export_to_keyframes(node_path="/ch/motion_fx/lag1", target_path="/obj/geo1", parm_names=["tx", "ty"])`
+
+`create_audio_driven` can point at a `.wav` file or use an existing audio node.
+The envelope follower produces amplitude-driven channels that can be wired to
+any object parameter.

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/_chops_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/_chops_common.py
@@ -1,0 +1,76 @@
+"""Shared helpers for Houdini CHOP skills."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def get_or_create_network(hou: Any, network_path: str) -> Any:
+    """Return the CHOP network at *network_path*, creating it if missing."""
+    node = hou.node(network_path)
+    if node is not None:
+        return node
+    # Walk up to find the closest existing parent, then create downwards.
+    parts = network_path.strip("/").split("/")
+    for i in range(len(parts) - 1, -1, -1):
+        parent_path = "/" + "/".join(parts[: i + 1])
+        parent = hou.node(parent_path)
+        if parent is not None:
+            # Create remaining levels as CHOP networks.
+            for name in parts[i + 1 :]:
+                parent = parent.createNode("chopnet", node_name=name)
+            return parent
+    raise ValueError("Cannot resolve CHOP network path: {}".format(network_path))
+
+
+def ensure_chop_network(hou: Any, parent_path: str, network_name: str) -> Any:
+    """Create a CHOP network container under *parent_path*."""
+    parent = hou.node(parent_path)
+    if parent is None:
+        raise ValueError("Parent node not found: {}".format(parent_path))
+    existing = hou.node("{}/{}".format(parent.path(), network_name))
+    if existing is not None:
+        return existing
+    return parent.createNode("chopnet", node_name=network_name)
+
+
+def chop_node_info(node: Any) -> dict:
+    """Extract summary info from a CHOP node."""
+    info: Dict[str, Any] = {
+        "path": node.path(),
+        "name": node.name(),
+        "type": node.type().name(),
+    }
+    # Sample rate
+    try:
+        info["sample_rate"] = node.sampleRate()
+    except Exception:  # noqa: BLE001
+        info["sample_rate"] = None
+    # Segment length
+    try:
+        info["segment_length"] = node.segmentLength()
+    except Exception:  # noqa: BLE001
+        info["segment_length"] = None
+    # Channel names
+    try:
+        channels = node.channels()
+        info["channel_names"] = [c.name() for c in channels]
+        info["channel_count"] = len(info["channel_names"])
+    except Exception:  # noqa: BLE001
+        info["channel_names"] = []
+        info["channel_count"] = 0
+    # Time range
+    try:
+        track = node.timeRange()
+        info["time_range"] = [track[0], track[1]]
+    except Exception:  # noqa: BLE001
+        info["time_range"] = None
+    return info

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/apply_filter.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/apply_filter.py
@@ -1,0 +1,126 @@
+"""Apply a CHOP filter (lag, spring, noise, smooth) to a channel."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _chops_common import get_node  # noqa: E402
+
+# Map filter type → Houdini CHOP node type + key parameter name.
+_FILTER_TYPE_MAP = {
+    "lag": ("lag", "lag"),
+    "spring": ("spring", "mass"),
+    "noise": ("noise", "amp"),
+    "smooth": ("filter", "width"),
+    "peak": ("peak", "cutoff"),
+    "bandpass": ("bandpass", "freq"),
+    "comp": ("comp", "max"),
+    "limit": ("limit", "max"),
+}
+
+
+def apply_filter(
+    network_path: str,
+    source_node: str,
+    filter_type: str,
+    amount: float = 0.5,
+    node_name: Optional[str] = None,
+    extra_params: Optional[dict] = None,
+) -> dict:
+    """Apply a CHOP filter node to *source_node* inside *network_path*.
+
+    Supported filter types (CHOP node → key param):
+
+    - ``lag`` — exponential lag / inertia
+    - ``spring`` — spring/mass dynamics with damping
+    - ``noise`` — procedural noise overlay
+    - ``smooth`` — Gaussian / moving-average smoothing filter
+    - ``peak`` — peak / EQ filter
+    - ``bandpass`` — bandpass frequency filter
+    - ``comp`` — compression / limiting
+    - ``limit`` — value clamp
+
+    Args:
+        network_path: Path to the CHOP network container.
+        source_node: Name or path of the source CHOP node to filter.
+        filter_type: One of the supported filter type keys (see above).
+        amount: Primary filter strength (mapped to the key parameter).
+        node_name: Name for the new filter node (auto-generated if omitted).
+        extra_params: Additional parameter name → value overrides.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        network = get_node(hou, network_path)
+
+        # Resolve source node.
+        src = hou.node(source_node)
+        if src is None:
+            src = get_node(hou, "{}/{}".format(network.path(), source_node))
+
+        filter_info = _FILTER_TYPE_MAP.get(filter_type.lower())
+        if filter_info is None:
+            supported = ", ".join(sorted(_FILTER_TYPE_MAP.keys()))
+            return skill_error(
+                "Unknown filter type: {}".format(filter_type),
+                "supported_filters: {}".format(supported),
+                supported_filters=supported,
+            )
+
+        chop_type, key_parm = filter_info
+        name = node_name or "{}_{}".format(filter_type.lower(), "1")
+        filter_node = network.createNode(chop_type, node_name=name)
+        filter_node.setFirstInput(src)
+
+        # Set key parameter.
+        try:
+            filter_node.parm(key_parm).set(float(amount))
+        except Exception:  # noqa: BLE001
+            pass
+
+        applied_params = {key_parm: float(amount)}
+
+        # Apply extra overrides.
+        if extra_params:
+            for parm_name, value in extra_params.items():
+                try:
+                    filter_node.parm(parm_name).set(value)
+                    applied_params[parm_name] = value
+                except Exception:  # noqa: BLE001
+                    pass
+
+        filter_node.moveToGoodPosition()
+
+        return skill_success(
+            "Applied CHOP filter",
+            filter_path=filter_node.path(),
+            filter_type=filter_type,
+            chop_type=chop_type,
+            source_path=src.path(),
+            network_path=network_path,
+            applied_params=applied_params,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to apply CHOP filter")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return apply_filter(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/create_audio_driven.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/create_audio_driven.py
@@ -1,0 +1,93 @@
+"""Set up audio-driven animation using an Envelope CHOP driven by audio."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _chops_common import get_node  # noqa: E402
+
+
+def create_audio_driven(
+    network_path: str,
+    audio_file: str,
+    target_parm: str,
+    channel_name: str = "amplitude",
+    envelope_name: str = "envelope1",
+    amplitude_multiplier: float = 1.0,
+) -> dict:
+    """Create an audio-driven animation setup inside *network_path*.
+
+    Imports an audio file as a File CHOP, then creates an Envelope CHOP to
+    extract amplitude and drive a target parameter.  The chain is:
+
+    1. ``file`` CHOP → loads *audio_file*
+    2. ``envelope`` CHOP → extracts *channel_name* amplitude
+    3. Connect envelope output to *target_parm* via an export flag.
+
+    Args:
+        network_path: Path to the CHOP network container.
+        audio_file: Path to a ``.wav`` / ``.mp3`` / ``.aiff`` audio file.
+        target_parm: Target parameter path like ``/obj/geo1/tx``.
+        channel_name: Audio channel to extract (amplitude, bass, mid, treble).
+        envelope_name: Name for the Envelope CHOP node.
+        amplitude_multiplier: Scale factor applied to output.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        network = get_node(hou, network_path)
+
+        # 1. Create File CHOP for the audio.
+        file_node = network.createNode("file", node_name="audio_file1")
+        file_node.parm("file").set(audio_file)
+
+        # 2. Create Envelope CHOP to extract amplitude.
+        envelope = network.createNode("envelope", node_name=envelope_name)
+        envelope.setFirstInput(file_node)
+        envelope.parm("channel").set(channel_name)
+        if amplitude_multiplier != 1.0:
+            envelope.parm("amp").set(float(amplitude_multiplier))
+
+        # 3. Set export flag so CHOP drives the target parameter.
+        try:
+            envelope.setExportFlag(target_parm)
+        except Exception:  # noqa: BLE001
+            # Fallback: set generic export context.
+            envelope.setGenericFlag(hou.chopNode.ExportFlag, True)
+
+        file_node.moveToGoodPosition()
+        envelope.moveToGoodPosition()
+
+        return skill_success(
+            "Created audio-driven animation",
+            network_path=network_path,
+            audio_file_path=file_node.path(),
+            envelope_path=envelope.path(),
+            audio_file=audio_file,
+            channel_name=channel_name,
+            target_parm=target_parm,
+            amplitude_multiplier=amplitude_multiplier,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create audio-driven animation")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_audio_driven(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/create_chop_network.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/create_chop_network.py
@@ -1,0 +1,57 @@
+"""Create a CHOP network container at a given path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _chops_common import ensure_chop_network  # noqa: E402
+
+
+def create_chop_network(
+    parent_path: str,
+    network_name: str = "chopnet1",
+) -> dict:
+    """Create a CHOP network container under *parent_path*.
+
+    Args:
+        parent_path: Path to the parent node or context (e.g. ``/ch``).
+        network_name: Name for the new CHOP network node.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        network = ensure_chop_network(hou, parent_path, network_name)
+        # Move to default network editor pane for visibility.
+        try:
+            network.setCurrent(True, clear_all_selected=True)
+        except Exception:  # noqa: BLE001
+            pass
+        return skill_success(
+            "Created CHOP network",
+            network_path=network.path(),
+            parent_path=parent_path,
+            network_name=network.name(),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create CHOP network")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_chop_network(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/create_motionclip.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/create_motionclip.py
@@ -1,0 +1,73 @@
+"""Import or create a motion clip CHOP in a CHOP network."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _chops_common import get_node  # noqa: E402
+
+
+def create_motionclip(
+    network_path: str,
+    node_name: str = "motionclip1",
+    clip_file: Optional[str] = None,
+    start_frame: Optional[float] = None,
+) -> dict:
+    """Create a MotionClip CHOP inside *network_path*.
+
+    The MotionClip CHOP is the standard way to import character animation
+    clips (``.bclip`` / ``.clip``) into the CHOP context.
+
+    Args:
+        network_path: Path to the CHOP network (e.g. ``/ch/chopnet1``).
+        node_name: Name for the new MotionClip node.
+        clip_file: Optional path to a ``.bclip``/``.clip`` file to load.
+        start_frame: Optional start frame override for the clip.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        network = get_node(hou, network_path)
+        node = network.createNode("motionclip", node_name=node_name)
+
+        applied: dict = {}
+        if clip_file:
+            node.parm("file").set(clip_file)
+            applied["clip_file"] = clip_file
+        if start_frame is not None:
+            node.parm("start").set(float(start_frame))
+            applied["start_frame"] = float(start_frame)
+
+        node.moveToGoodPosition()
+
+        return skill_success(
+            "Created MotionClip CHOP",
+            node_path=node.path(),
+            node_name=node.name(),
+            network_path=network_path,
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create MotionClip CHOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_motionclip(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/export_to_keyframes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/export_to_keyframes.py
@@ -1,0 +1,122 @@
+"""Export CHOP channel data to object parameter keyframes."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _chops_common import get_node  # noqa: E402
+
+
+def export_to_keyframes(
+    node_path: str,
+    target_path: str,
+    parm_names: List[str],
+    frame_range: Optional[List[float]] = None,
+    resample_rate: Optional[float] = None,
+) -> dict:
+    """Bake CHOP channel data to keyframes on *target_path* parameters.
+
+    Evaluates the CHOP node's channels at every frame in *frame_range* and
+    writes constant keyframes on the matching *parm_names* of *target_path*.
+
+    When *frame_range* is omitted, the CHOP's own time range is used.
+    *resample_rate* controls the sample interval (default: 1.0 frame).
+
+    Args:
+        node_path: Path to the CHOP node whose channels are read.
+        target_path: Object node path to write keyframes to (e.g. ``/obj/geo1``).
+        parm_names: List of parameter names on *target_path* to drive.
+        frame_range: Optional ``[start, end]`` override for the bake range.
+        resample_rate: Sampling step between frames (default 1.0).
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        chop_node = get_node(hou, node_path)
+        target_node = get_node(hou, target_path)
+
+        # Determine frame range.
+        if frame_range and len(frame_range) >= 2:
+            start, end = float(frame_range[0]), float(frame_range[1])
+        else:
+            try:
+                tr = chop_node.timeRange()
+                start, end = float(tr[0]), float(tr[1])
+            except Exception:  # noqa: BLE001
+                start, end = float(hou.frame()), float(hou.frame() + 100)
+
+        step = float(resample_rate) if resample_rate else 1.0
+
+        # Collect channel data per frame.
+        exported: dict[str, int] = {}
+        current_frame = hou.frame()
+        try:
+            for frame in _frame_range(start, end, step):
+                hou.setFrame(frame)
+                # Evaluate CHOP channels.
+                try:
+                    values = [chop_node.evalAtFrame(frame, i) for i in range(len(parm_names))]
+                except Exception:  # noqa: BLE001
+                    # Try named evaluation.
+                    values = []
+                    for pn in parm_names:
+                        try:
+                            values.append(chop_node.evalAtChannel(frame, pn))
+                        except Exception:  # noqa: BLE001
+                            values.append(0.0)
+
+                for i, parm_name in enumerate(parm_names):
+                    if i >= len(values):
+                        break
+                    parm = target_node.parm(parm_name)
+                    if parm is None:
+                        continue
+                    kf = hou.Keyframe()
+                    kf.setFrame(float(frame))
+                    kf.setValue(float(values[i]))
+                    parm.setKeyframe(kf)
+                    exported[parm_name] = exported.get(parm_name, 0) + 1
+        finally:
+            hou.setFrame(current_frame)
+
+        return skill_success(
+            "Exported CHOP channels to keyframes",
+            chop_path=node_path,
+            target_path=target_node.path(),
+            frame_range=[start, end],
+            step=step,
+            exported_parameters=exported,
+            total_keyframes=sum(exported.values()),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to export CHOP to keyframes")
+
+
+def _frame_range(start: float, end: float, step: float):
+    """Generate frame numbers from *start* to *end* inclusive with *step*."""
+    f = start
+    while f <= end + 1e-9:
+        yield f
+        f += step
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return export_to_keyframes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-chops/scripts/get_channel_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/scripts/get_channel_info.py
@@ -1,0 +1,68 @@
+"""Inspect CHOP node channels — names, sample rate, length, value range."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _chops_common import chop_node_info, get_node  # noqa: E402
+
+
+def get_channel_info(node_path: str) -> dict:
+    """Return summary information for the CHOP node at *node_path*.
+
+    Includes: node type, sample rate, segment length, channel names/count,
+    time range, and metadata.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        info = chop_node_info(node)
+
+        # Per-channel details (value range at current frame).
+        channels_detail = []
+        try:
+            for ch in node.channels():
+                detail = {
+                    "name": ch.name(),
+                    "sample_rate": node.sampleRate() if hasattr(node, "sampleRate") else None,
+                }
+                # Try to read current values.
+                try:
+                    detail["value"] = ch.eval(hou.frame())
+                except Exception:  # noqa: BLE001
+                    detail["value"] = None
+                channels_detail.append(detail)
+        except Exception:  # noqa: BLE001
+            pass
+
+        info["channels"] = channels_detail
+
+        return skill_success(
+            "Retrieved CHOP channel info",
+            node_path=node.path(),
+            **info,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to get CHOP channel info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_channel_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-chops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/tools.yaml
@@ -1,0 +1,194 @@
+tools:
+  - name: create_chop_network
+    description: Create a CHOP network container at a given parent path.
+    source_file: scripts/create_chop_network.py
+    execution: sync
+    affinity: main
+    group: network
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [parent_path]
+      properties:
+        parent_path:
+          type: string
+          description: Path to the parent node or context (e.g. /ch).
+        network_name:
+          type: string
+          description: Name for the new CHOP network node.
+          default: "chopnet1"
+  - name: create_motionclip
+    description: Import or create a motion clip CHOP in a CHOP network.
+    source_file: scripts/create_motionclip.py
+    execution: sync
+    affinity: main
+    group: motion
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [network_path]
+      properties:
+        network_path:
+          type: string
+          description: Path to the CHOP network (e.g. /ch/chopnet1).
+        node_name:
+          type: string
+          description: Name for the new MotionClip node.
+          default: "motionclip1"
+        clip_file:
+          type: string
+          description: Optional path to a .bclip/.clip file to load.
+        start_frame:
+          type: number
+          description: Optional start frame override for the clip.
+  - name: create_audio_driven
+    description: Set up audio-driven animation using an Envelope CHOP driven by an audio file.
+    source_file: scripts/create_audio_driven.py
+    execution: sync
+    affinity: main
+    group: audio
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [network_path, audio_file, target_parm]
+      properties:
+        network_path:
+          type: string
+          description: Path to the CHOP network container.
+        audio_file:
+          type: string
+          description: Path to a .wav/.mp3/.aiff audio file.
+        target_parm:
+          type: string
+          description: Target parameter path like /obj/geo1/tx.
+        channel_name:
+          type: string
+          description: Audio channel to extract (amplitude, bass, mid, treble).
+          default: "amplitude"
+        envelope_name:
+          type: string
+          description: Name for the Envelope CHOP node.
+          default: "envelope1"
+        amplitude_multiplier:
+          type: number
+          description: Scale factor applied to output.
+          default: 1.0
+  - name: apply_filter
+    description: >-
+      Apply a CHOP filter (lag, spring, noise, smooth, peak, bandpass, comp,
+      limit) to a source channel.
+    source_file: scripts/apply_filter.py
+    execution: sync
+    affinity: main
+    group: filter
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [network_path, source_node, filter_type]
+      properties:
+        network_path:
+          type: string
+          description: Path to the CHOP network container.
+        source_node:
+          type: string
+          description: Name or path of the source CHOP node.
+        filter_type:
+          type: string
+          description: Filter type key.
+          enum: [lag, spring, noise, smooth, peak, bandpass, comp, limit]
+        amount:
+          type: number
+          description: Primary filter strength.
+          default: 0.5
+        node_name:
+          type: string
+          description: Name for the new filter node (auto-generated if omitted).
+        extra_params:
+          type: object
+          description: Additional parameter name to value overrides.
+  - name: export_to_keyframes
+    description: >-
+      Bake CHOP channel data to keyframes on object parameters over a frame
+      range.
+    source_file: scripts/export_to_keyframes.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: export
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [node_path, target_path, parm_names]
+      properties:
+        node_path:
+          type: string
+          description: Path to the CHOP node.
+        target_path:
+          type: string
+          description: Object node path to write keyframes to.
+        parm_names:
+          type: array
+          items: {type: string}
+          minItems: 1
+          description: List of parameter names on target_path to drive.
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+          description: Optional [start, end] bake range.
+        resample_rate:
+          type: number
+          description: Sampling step between frames (default 1.0).
+  - name: get_channel_info
+    description: >-
+      Inspect a CHOP node — node type, sample rate, segment length, channel
+      names, and per-channel value at the current frame.
+    source_file: scripts/get_channel_info.py
+    execution: sync
+    affinity: main
+    group: inspect
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Path to the CHOP node to inspect.

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: houdini-constraints
+description: >-
+  Pipeline skill — typed animation constraint tools for object-level
+  transform constraints. Create parent, blend, position, and orientation
+  constraints using OBJ-level blend nodes and CHOP-driven channel
+  referencing. List and delete existing constraints.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.14+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: pipeline
+    version: "1.0.0"
+    tags: [houdini, constraints, parent, blend, position, orient, animation, pipeline]
+    search-hint: "constraint parent blend position orient transform animation list delete"
+    tools: tools.yaml
+---
+
+# houdini-constraints
+
+Typed animation constraint tools for agents. All tools are `affinity: main`.
+
+Constraints are implemented via OBJ-level **blend** nodes (the idiomatic
+Houdini equivalent of Maya-style parent/position/orient constraints) and
+CHOP-driven channel referencing for finer control.
+
+## Tool groups
+
+- **`parent`:** `create_parent_constraint` — drive an object's full transform
+  from a single target.
+- **`blend`:** `create_blend_constraint` — blend between multiple target
+  transforms with per-target weights.
+- **`position`:** `create_position_constraint` — constrain only translation
+  channels.
+- **`orientation`:** `create_orient_constraint` — constrain only rotation
+  channels.
+- **`inspect`:** `list_constraints` — list constraint nodes/relationships in
+  the scene.
+- **`manage`:** `delete_constraint` (destructive) — remove a constraint node.
+
+## Tracer-bullet flow
+
+1. `create_parent_constraint(driven_path="/obj/geo2", target_path="/obj/geo1")`
+2. `list_constraints(context_path="/obj")` → verify the blend node exists
+3. `create_blend_constraint(driven_path="/obj/geo3", target_paths=["/obj/geo1", "/obj/geo2"], weights=[0.3, 0.7])`
+4. `delete_constraint(node_path="/obj/blend_geo2")`
+
+Position/orient constraints use CHOP extraction to isolate transform
+components, giving more granular control than a full parent constraint.

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/_constraint_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/_constraint_common.py
@@ -1,0 +1,112 @@
+"""Shared helpers for Houdini constraint skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def find_blend_constraints(hou: Any, context_path: str = "/obj") -> list:
+    """Return all blend nodes that act as constraints under *context_path*.
+
+    A blend node is considered a constraint when it has one or more inputs
+    connected from other OBJ nodes.
+    """
+    context = hou.node(context_path)
+    if context is None:
+        return []
+    constraints = []
+    for child in context.children():
+        if child.type().name() != "blend":
+            continue
+        inputs = child.inputs()
+        if not inputs:
+            continue
+        target_paths = [inp.path() for inp in inputs if inp is not None]
+        constraints.append(
+            {
+                "path": child.path(),
+                "name": child.name(),
+                "targets": target_paths,
+                "target_count": len(target_paths),
+            }
+        )
+    return constraints
+
+
+def ensure_not_exists(hou: Any, node_path: str) -> None:
+    """Raise if a node already exists at *node_path*."""
+    if hou.node(node_path) is not None:
+        raise ValueError("Node already exists: {}".format(node_path))
+
+
+def build_blend_node(
+    hou: Any,
+    driven_path: str,
+    target_paths: list,
+    weights: list | None = None,
+    blend_name: str | None = None,
+) -> Any:
+    """Create a ``blend`` OBJ node wiring *driven_path* to *target_paths*.
+
+    The blend node is created as a sibling of *driven_path* under the same
+    parent, with each target connected as an input.  The driven object's
+    transform parameters are expression-linked to the blend output.
+
+    Returns the created blend node.
+    """
+    driven_node = get_node(hou, driven_path)
+    parent = driven_node.parent()
+
+    name = blend_name or "blend_{}".format(driven_node.name())
+    blend_node = parent.createNode("blend", node_name=name)
+
+    # Connect targets as inputs.
+    connected = 0
+    for target_path in target_paths:
+        target_node = hou.node(target_path)
+        if target_node is None:
+            continue
+        blend_node.setInput(connected, target_node)
+        connected += 1
+
+    if connected == 0:
+        raise ValueError("No valid target paths connected")
+
+    # Set per-target weights.
+    if weights:
+        for i, w in enumerate(weights[:connected]):
+            blend_node.parm("weight{}".format(i + 1)).set(float(w))
+
+    # Drive the driven object's transform from the blend output.
+    driven_parms = {
+        "tx": "tx",
+        "ty": "ty",
+        "tz": "tz",
+        "rx": "rx",
+        "ry": "ry",
+        "rz": "rz",
+        "sx": "sx",
+        "sy": "sy",
+        "sz": "sz",
+    }
+    for driven_parm, blend_parm in driven_parms.items():
+        try:
+            parm = driven_node.parm(driven_parm)
+            if parm is not None:
+                parm.setExpression(
+                    'ch("{}")'.format(hou.hscriptExpression("{}/{}".format(blend_node.path(), blend_parm)))
+                )
+        except Exception:  # noqa: BLE001
+            pass
+
+    blend_node.moveToGoodPosition()
+
+    return blend_node

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_blend_constraint.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_blend_constraint.py
@@ -1,0 +1,79 @@
+"""Create a blend constraint — blend between multiple target transforms."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _constraint_common import build_blend_node  # noqa: E402
+
+
+def create_blend_constraint(
+    driven_path: str,
+    target_paths: List[str],
+    weights: Optional[List[float]] = None,
+) -> dict:
+    """Create a blend constraint between *driven_path* and *target_paths*.
+
+    Each target is wired as an input to a ``blend`` OBJ node, with optional
+    per-target weights.  The driven object's transform is expression-linked to
+    the blend output, producing a weighted average of the target transforms.
+
+    Args:
+        driven_path: Path to the object being constrained.
+        target_paths: List of target object paths to blend between.
+        weights: Optional per-target weight list (must match target count).
+            Default weights are evenly distributed.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    if len(target_paths) < 1:
+        return skill_error("Need at least one target", "target_paths must not be empty")
+
+    if weights and len(weights) != len(target_paths):
+        return skill_error(
+            "Weight count mismatch: {} weights for {} targets".format(len(weights), len(target_paths)),
+            "Ensure weights list length matches target_paths length",
+            target_count=len(target_paths),
+            weight_count=len(weights),
+        )
+
+    try:
+        blend_node = build_blend_node(
+            hou,
+            driven_path=driven_path,
+            target_paths=target_paths,
+            weights=weights,
+        )
+
+        return skill_success(
+            "Created blend constraint",
+            blend_node_path=blend_node.path(),
+            driven_path=driven_path,
+            target_paths=target_paths,
+            weights=weights if weights else None,
+            target_count=len(target_paths),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create blend constraint")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_blend_constraint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_orient_constraint.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_orient_constraint.py
@@ -1,0 +1,99 @@
+"""Create an orient constraint — constrain only rotation channels."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _constraint_common import get_node  # noqa: E402
+
+
+def create_orient_constraint(
+    driven_path: str,
+    target_path: str,
+    maintain_offset: bool = True,
+    constraint_name: str = "orient_constraint1",
+) -> dict:
+    """Constrain only rotation channels of *driven_path* to *target_path*.
+
+    Creates a CHOP network that extracts *target_path*'s world-space rotation
+    and drives *driven_path*'s ``rx``, ``ry``, ``rz`` parameters via channel
+    referencing.  Translation and scale remain free.
+
+    Args:
+        driven_path: Path to the object whose rotation is constrained.
+        target_path: Path to the target object.
+        maintain_offset: Preserve the current rotational offset.
+        constraint_name: Name for the constraint CHOP network.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        driven_node = get_node(hou, driven_path)
+        target_node = get_node(hou, target_path)
+
+        # Use object CHOP to extract world rotation from the target.
+        obj_context = hou.node("/ch")
+        if obj_context is None:
+            obj_context = hou.node("/obj").createNode("chopnet", node_name=constraint_name)
+
+        object_chop = obj_context.createNode("object", node_name="obj_rot_{}".format(target_node.name()))
+        object_chop.parm("target").set(target_path)
+
+        # Drive rotation channels via channel reference expressions.
+        offset_rx = offset_ry = offset_rz = 0.0
+        if maintain_offset:
+            try:
+                dr = driven_node.worldTransform().extractRotates()
+                tr = target_node.worldTransform().extractRotates()
+                offset_rx = dr[0] - tr[0]
+                offset_ry = dr[1] - tr[1]
+                offset_rz = dr[2] - tr[2]
+            except Exception:  # noqa: BLE001
+                pass
+
+        for axis, offset in [("rx", offset_rx), ("ry", offset_ry), ("rz", offset_rz)]:
+            parm = driven_node.parm(axis)
+            if parm is not None:
+                try:
+                    chop_path = "{}/{}".format(object_chop.path(), axis.upper())
+                    if abs(offset) > 1e-9:
+                        expr = 'chop("{}") + {}'.format(chop_path, offset)
+                    else:
+                        expr = 'chop("{}")'.format(chop_path)
+                    parm.setExpression(expr, language=hou.exprLanguage.Hscript)
+                except Exception:  # noqa: BLE001
+                    pass
+
+        object_chop.moveToGoodPosition()
+
+        return skill_success(
+            "Created orient constraint",
+            constraint_chop=object_chop.path(),
+            driven_path=driven_path,
+            target_path=target_path,
+            maintain_offset=maintain_offset,
+            offset={"rx": offset_rx, "ry": offset_ry, "rz": offset_rz},
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create orient constraint")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_orient_constraint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_parent_constraint.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_parent_constraint.py
@@ -1,0 +1,83 @@
+"""Create a parent constraint — drive one object's full transform from another."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _constraint_common import build_blend_node  # noqa: E402
+
+
+def create_parent_constraint(
+    driven_path: str,
+    target_path: str,
+    maintain_offset: bool = True,
+) -> dict:
+    """Make *driven_path* follow *target_path* transform (parent constraint).
+
+    Creates a ``blend`` OBJ node with *target_path* as the single input and
+    expression-links the driven object's transform parameters to the blend
+    output. When *maintain_offset* is ``True`` (default), the existing world-
+    space offset between the two objects is preserved.
+
+    Args:
+        driven_path: Path to the object being constrained (e.g. ``/obj/geo2``).
+        target_path: Path to the target/parent object (e.g. ``/obj/geo1``).
+        maintain_offset: Retain the current offset between objects.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        blend_node = build_blend_node(
+            hou,
+            driven_path=driven_path,
+            target_paths=[target_path],
+        )
+
+        offset_info = None
+        if maintain_offset:
+            try:
+                driven = hou.node(driven_path)
+                target = hou.node(target_path)
+                if driven and target:
+                    dt = driven.worldTransform()
+                    tt = target.worldTransform()
+                    offset_m = tt.inverted() * dt
+                    offset_info = {
+                        "tx": offset_m.extractTranslates()[0],
+                        "ty": offset_m.extractTranslates()[1],
+                        "tz": offset_m.extractTranslates()[2],
+                    }
+            except Exception:  # noqa: BLE001
+                pass
+
+        return skill_success(
+            "Created parent constraint",
+            blend_node_path=blend_node.path(),
+            driven_path=driven_path,
+            target_path=target_path,
+            maintain_offset=maintain_offset,
+            offset=offset_info,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create parent constraint")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_parent_constraint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_position_constraint.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/create_position_constraint.py
@@ -1,0 +1,99 @@
+"""Create a position constraint — constrain only translation channels."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _constraint_common import get_node  # noqa: E402
+
+
+def create_position_constraint(
+    driven_path: str,
+    target_path: str,
+    maintain_offset: bool = True,
+    constraint_name: str = "pos_constraint1",
+) -> dict:
+    """Constrain only translation channels of *driven_path* to *target_path*.
+
+    Creates a CHOP network that extracts *target_path*'s world-space position
+    and drives *driven_path*'s ``tx``, ``ty``, ``tz`` parameters via channel
+    referencing.  Rotation and scale remain free.
+
+    Args:
+        driven_path: Path to the object whose position is constrained.
+        target_path: Path to the target object.
+        maintain_offset: Preserve the current positional offset.
+        constraint_name: Name for the constraint CHOP network.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        driven_node = get_node(hou, driven_path)
+        target_node = get_node(hou, target_path)
+
+        # Use object CHOP to extract world position from the target.
+        obj_context = hou.node("/ch")
+        if obj_context is None:
+            obj_context = hou.node("/obj").createNode("chopnet", node_name=constraint_name)
+
+        object_chop = obj_context.createNode("object", node_name="obj_{}".format(target_node.name()))
+        object_chop.parm("target").set(target_path)
+
+        # Drive translation channels via channel reference expressions.
+        offset_tx = offset_ty = offset_tz = 0.0
+        if maintain_offset:
+            try:
+                dt = driven_node.worldTransform().extractTranslates()
+                tt = target_node.worldTransform().extractTranslates()
+                offset_tx = dt[0] - tt[0]
+                offset_ty = dt[1] - tt[1]
+                offset_tz = dt[2] - tt[2]
+            except Exception:  # noqa: BLE001
+                pass
+
+        for axis, offset in [("tx", offset_tx), ("ty", offset_ty), ("tz", offset_tz)]:
+            parm = driven_node.parm(axis)
+            if parm is not None:
+                try:
+                    chop_path = "{}/{}".format(object_chop.path(), axis.upper())
+                    if abs(offset) > 1e-9:
+                        expr = 'chop("{}") + {}'.format(chop_path, offset)
+                    else:
+                        expr = 'chop("{}")'.format(chop_path)
+                    parm.setExpression(expr, language=hou.exprLanguage.Hscript)
+                except Exception:  # noqa: BLE001
+                    pass
+
+        object_chop.moveToGoodPosition()
+
+        return skill_success(
+            "Created position constraint",
+            constraint_chop=object_chop.path(),
+            driven_path=driven_path,
+            target_path=target_path,
+            maintain_offset=maintain_offset,
+            offset={"tx": offset_tx, "ty": offset_ty, "tz": offset_tz},
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create position constraint")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_position_constraint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/delete_constraint.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/delete_constraint.py
@@ -1,0 +1,73 @@
+"""Delete a constraint node from the scene."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _constraint_common import get_node  # noqa: E402
+
+
+def delete_constraint(node_path: str) -> dict:
+    """Delete the constraint node at *node_path*.
+
+    Clears expression-driven channels on any driven objects (blend constraints)
+    before destroying the constraint node itself.  This is a **destructive**
+    operation — the constraint is permanently removed.
+
+    Args:
+        node_path: Path to the constraint node to delete.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, node_path)
+        node_info = {
+            "path": node.path(),
+            "name": node.name(),
+            "type": node.type().name(),
+        }
+
+        # For blend constraints, clear expressions on driven objects first.
+        if node.type().name() == "blend":
+            # Look for parms referencing this blend node via ch() expression.
+            parent = node.parent()
+            for child in parent.children():
+                if child.path() == node.path():
+                    continue
+                for parm in child.parms():
+                    try:
+                        raw = parm.rawValue()
+                        if isinstance(raw, str) and node.name() in raw:
+                            parm.revertToDefaults()
+                    except Exception:  # noqa: BLE001
+                        pass
+
+        node.destroy()
+
+        return skill_success(
+            "Deleted constraint",
+            deleted_node=node_info,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to delete constraint")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return delete_constraint(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/list_constraints.py
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/scripts/list_constraints.py
@@ -1,0 +1,94 @@
+"""List constraint nodes and relationships in the scene."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _constraint_common import find_blend_constraints  # noqa: E402
+
+
+def list_constraints(
+    context_path: str = "/obj",
+    constraint_type: Optional[str] = None,
+) -> dict:
+    """List constraint relationships under *context_path*.
+
+    Scans for ``blend`` OBJ nodes acting as constraints (connected inputs) and
+    for CHOP-based constraints (object CHOPs in ``/ch`` with target-driven
+    channels).
+
+    Args:
+        context_path: OBJ context to scan (e.g. ``/obj``).
+        constraint_type: Optional filter: ``blend``, ``chop``, or ``all``.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        all_constraints = []
+        filter_type = (constraint_type or "all").lower()
+
+        # 1. Blend-based constraints (OBJ level).
+        if filter_type in ("all", "blend"):
+            blends = find_blend_constraints(hou, context_path)
+            for b in blends:
+                b["type"] = "blend"
+            all_constraints.extend(blends)
+
+        # 2. CHOP-based constraints.
+        if filter_type in ("all", "chop"):
+            chop_context = hou.node("/ch")
+            if chop_context is not None:
+                for child in chop_context.children():
+                    if child.type().name() == "object":
+                        target = None
+                        try:
+                            target = child.parm("target").eval()
+                        except Exception:  # noqa: BLE001
+                            pass
+                        if target:
+                            all_constraints.append(
+                                {
+                                    "path": child.path(),
+                                    "name": child.name(),
+                                    "type": "chop",
+                                    "target": target,
+                                }
+                            )
+
+        # 3. Enrich with driven-object detection.
+        for c in all_constraints:
+            c.setdefault("targets", [])
+            if not c.get("targets"):
+                c["targets"] = [c.get("target")] if c.get("target") else []
+
+        return skill_success(
+            "Listed constraints",
+            context_path=context_path,
+            constraint_type=filter_type,
+            count=len(all_constraints),
+            constraints=all_constraints,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list constraints")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_constraints(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/tools.yaml
@@ -1,0 +1,175 @@
+tools:
+  - name: create_parent_constraint
+    description: >-
+      Drive an object's full transform from a single target, with optional
+      offset preservation.
+    source_file: scripts/create_parent_constraint.py
+    execution: sync
+    affinity: main
+    group: parent
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [driven_path, target_path]
+      properties:
+        driven_path:
+          type: string
+          description: Path to the object being constrained (e.g. /obj/geo2).
+        target_path:
+          type: string
+          description: Path to the target/parent object (e.g. /obj/geo1).
+        maintain_offset:
+          type: boolean
+          description: Retain the current world-space offset between objects.
+          default: true
+  - name: create_blend_constraint
+    description: >-
+      Blend between multiple target transforms with per-target weights
+      driving a single object.
+    source_file: scripts/create_blend_constraint.py
+    execution: sync
+    affinity: main
+    group: blend
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [driven_path, target_paths]
+      properties:
+        driven_path:
+          type: string
+          description: Path to the object being constrained.
+        target_paths:
+          type: array
+          items: {type: string}
+          minItems: 1
+          description: List of target object paths to blend between.
+        weights:
+          type: array
+          items: {type: number}
+          description: Optional per-target weight list (evenly distributed if omitted).
+  - name: create_position_constraint
+    description: >-
+      Constrain only translation channels (tx, ty, tz) using CHOP-driven
+      channel referencing. Rotation and scale remain free.
+    source_file: scripts/create_position_constraint.py
+    execution: sync
+    affinity: main
+    group: position
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [driven_path, target_path]
+      properties:
+        driven_path:
+          type: string
+          description: Path to the object whose position is constrained.
+        target_path:
+          type: string
+          description: Path to the target object.
+        maintain_offset:
+          type: boolean
+          description: Preserve the current positional offset.
+          default: true
+        constraint_name:
+          type: string
+          description: Name for the constraint CHOP network.
+          default: "pos_constraint1"
+  - name: create_orient_constraint
+    description: >-
+      Constrain only rotation channels (rx, ry, rz) using CHOP-driven
+      channel referencing. Translation and scale remain free.
+    source_file: scripts/create_orient_constraint.py
+    execution: sync
+    affinity: main
+    group: orientation
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [driven_path, target_path]
+      properties:
+        driven_path:
+          type: string
+          description: Path to the object whose rotation is constrained.
+        target_path:
+          type: string
+          description: Path to the target object.
+        maintain_offset:
+          type: boolean
+          description: Preserve the current rotational offset.
+          default: true
+        constraint_name:
+          type: string
+          description: Name for the constraint CHOP network.
+          default: "orient_constraint1"
+  - name: list_constraints
+    description: >-
+      List constraint relationships under a context path, including blend-
+      based and CHOP-based constraints.
+    source_file: scripts/list_constraints.py
+    execution: sync
+    affinity: main
+    group: inspect
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties:
+        context_path:
+          type: string
+          description: OBJ context to scan (e.g. /obj).
+          default: "/obj"
+        constraint_type:
+          type: string
+          description: Optional filter (blend, chop, all).
+          default: "all"
+  - name: delete_constraint
+    description: >-
+      Delete a constraint node, clearing driven-object expressions first
+      (destructive).
+    source_file: scripts/delete_constraint.py
+    execution: sync
+    affinity: main
+    group: manage
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Path to the constraint node to delete.

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: houdini-kinefx
+description: >-
+  Pipeline skill — typed KineFX character animation tools. Create and
+  configure rig skeletons, set rig poses, capture joint skinning weights,
+  and apply motion capture data via SOP-level KineFX nodes.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.18.14+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: pipeline
+    version: "1.0.0"
+    tags: [houdini, kinefx, rig, skeleton, capture, mocap, character, animation, pipeline]
+    search-hint: "kinefx rig skeleton pose joint capture mocap character skinning bone deform"
+    tools: tools.yaml
+---
+
+# houdini-kinefx
+
+Typed KineFX character animation tools for agents. All tools are `affinity: main`.
+
+KineFX operates at the SOP level — skeletons are geometry with joint point
+attributes, rigs are SOP networks, and mocap data is applied via SOP nodes.
+
+## Tool groups
+
+- **`rig`:** `create_rig` — build a KineFX skeleton rig with a joint chain
+  and optional rig pose/attachments.
+- **`pose`:** `set_rig_pose` — set the transform of a specific joint or the
+  entire rig pose.
+- **`capture`:** `capture_joints` — capture skinning weights from joints to
+  a target mesh using proximity or bone-capture SOP nodes.
+- **`mocap`:** `apply_mocap` — apply motion capture data (FBX, BVH, or
+  KineFX clip) onto a rig skeleton.
+
+## Tracer-bullet flow
+
+1. `create_rig(geo_path="/obj/geo1/rig1", joint_chain=[...])` → creates a
+   KineFX skeleton inside a Geometry SOP network.
+2. `set_rig_pose(rig_node="/obj/geo1/rig1", joint_index=2, translate=[0,1,0])`
+3. `capture_joints(geo_path="/obj/geo1", mesh_name="body", rig_name="rig1")`
+4. `apply_mocap(geo_path="/obj/geo1", rig_name="rig1", mocap_file="/path/to/walk.fbx")`

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/_kinefx_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/_kinefx_common.py
@@ -1,0 +1,84 @@
+"""Shared helpers for Houdini KineFX skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_node(hou: Any, node_path: str) -> Any:
+    """Return a Houdini node or raise a useful error."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    return node
+
+
+def get_geo_container(hou: Any, geo_path: str) -> Any:
+    """Return the geometry container at *geo_path*, ensuring it exists."""
+    node = hou.node(geo_path)
+    if node is not None:
+        return node
+    # Walk up to find parent, create geo container.
+    parts = geo_path.strip("/").split("/")
+    for i in range(len(parts) - 1, -1, -1):
+        parent_path = "/" + "/".join(parts[: i + 1])
+        parent = hou.node(parent_path)
+        if parent is not None:
+            for name in parts[i + 1 :]:
+                parent = parent.createNode("geo", node_name=name)
+            return parent
+    raise ValueError("Cannot resolve geometry path: {}".format(geo_path))
+
+
+def get_or_create_rig(
+    hou: Any,
+    geo_path: str,
+    rig_name: str,
+    joint_chain: list | None = None,
+) -> Any:
+    """Return or create a KineFX rig node inside *geo_path*.
+
+    If *joint_chain* is provided, creates a skeleton from joint definitions.
+    Each joint is ``[name, parent_index, translate]``.
+    """
+    geo = get_geo_container(hou, geo_path)
+
+    # Check if rig already exists.
+    existing = hou.node("{}/{}".format(geo.path(), rig_name))
+    if existing is not None:
+        return existing
+
+    # Create a KineFX skeleton by building a line of points with joint attrs.
+    # We use a 'bonedeform' as the main rig anchor and create joints via
+    # SOP chain.
+    rig_sop = geo.createNode("null", node_name=rig_name)
+
+    if joint_chain:
+        # Build skeleton using a chain of points.
+        points_positions = []
+        joint_names = []
+        for joint in joint_chain:
+            if isinstance(joint, dict):
+                name = joint.get("name", "joint")
+                pos = joint.get("translate", [0, 0, 0])
+            elif isinstance(joint, (list, tuple)):
+                name = str(joint[0]) if len(joint) > 0 else "joint"
+                pos = list(joint[2]) if len(joint) > 2 else [0, 0, 0]
+            else:
+                name = str(joint)
+                pos = [0, 0, 0]
+            joint_names.append(name)
+            points_positions.append(list(pos))
+
+        if points_positions:
+            # Create geometry with skeleton attributes.
+            rig_geo = rig_sop.geometry()
+            rig_geo.clear()
+            pts = rig_geo.createPoints(len(points_positions))
+            name_attr = rig_geo.addAttrib(hou.attribType.Point, "name", "")
+            for i, pt in enumerate(pts):
+                pt.setPosition(points_positions[i])
+                pt.setAttribValue(name_attr, joint_names[i])
+
+    rig_sop.moveToGoodPosition()
+    return rig_sop

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/apply_mocap.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/apply_mocap.py
@@ -1,0 +1,115 @@
+"""Apply motion capture data to a KineFX rig skeleton."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _kinefx_common import get_node  # noqa: E402
+
+
+def apply_mocap(
+    geo_path: str,
+    rig_name: str,
+    mocap_file: str,
+    start_frame: Optional[float] = None,
+    scale: float = 1.0,
+    mocap_node_name: str = "mocap1",
+) -> dict:
+    """Apply motion capture data onto *rig_name* in *geo_path*.
+
+    Imports a mocap file (FBX, BVH, or KineFX ``.bclip``/``.clip``) and
+    wires it through a ``motionclip`` or ``agentclip`` SOP node that drives
+    the rig skeleton.
+
+    Args:
+        geo_path: Path to the Geometry SOP container.
+        rig_name: Name of the rig SOP node to animate.
+        mocap_file: Path to the mocap file (.fbx, .bvh, .bclip, .clip).
+        start_frame: Start frame offset for the mocap data.
+        scale: Uniform scale applied to the mocap data.
+        mocap_node_name: Name for the mocap import SOP node.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    ext = mocap_file.rsplit(".", 1)[-1].lower() if "." in mocap_file else ""
+
+    try:
+        geo = get_node(hou, geo_path)
+        rig_node = get_node(hou, "{}/{}".format(geo.path(), rig_name))
+
+        # Determine import SOP type based on file extension.
+        if ext in ("bclip", "clip"):
+            # Native KineFX motion clip — use motionclip SOP.
+            import_node = geo.createNode("motionclip", node_name=mocap_node_name)
+            import_node.parm("file").set(mocap_file)
+        elif ext in ("bvh",):
+            # BVH file — use a file SOP (BVH comes in as points).
+            import_node = geo.createNode("file", node_name=mocap_node_name)
+            import_node.parm("file").set(mocap_file)
+        elif ext in ("fbx",):
+            # FBX — use the FBX character import SOP or agent SOP.
+            import_node = geo.createNode("file", node_name=mocap_node_name)
+            import_node.parm("file").set(mocap_file)
+        else:
+            # Unknown — try generic file SOP.
+            import_node = geo.createNode("file", node_name=mocap_node_name)
+            import_node.parm("file").set(mocap_file)
+
+        # Set scale.
+        if scale != 1.0:
+            try:
+                import_node.parm("scale").set(float(scale))
+            except Exception:  # noqa: BLE001
+                pass
+
+        # Set start frame.
+        if start_frame is not None:
+            try:
+                import_node.parm("start").set(float(start_frame))
+            except Exception:  # noqa: BLE001
+                pass
+
+        # Wire: mocap drives the rig via the second input of a bonedeform
+        # or by connecting directly as the skeleton source.
+        # Create a bonedeform to apply the mocap-driven animation.
+        bone_deform = geo.createNode("bonedeform", node_name="anim_{}".format(rig_name))
+        bone_deform.setInput(0, import_node, 0)  # animated skeleton
+        bone_deform.setInput(1, rig_node, 0)  # rest skeleton
+
+        import_node.moveToGoodPosition()
+        bone_deform.moveToGoodPosition()
+
+        return skill_success(
+            "Applied mocap",
+            mocap_node_path=import_node.path(),
+            bone_deform_path=bone_deform.path(),
+            geo_path=geo_path,
+            rig_name=rig_name,
+            mocap_file=mocap_file,
+            file_type=ext,
+            scale=scale,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to apply mocap")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return apply_mocap(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/capture_joints.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/capture_joints.py
@@ -1,0 +1,105 @@
+"""Capture skinning weights from a KineFX skeleton onto a geometry mesh."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _kinefx_common import get_node  # noqa: E402
+
+
+def capture_joints(
+    geo_path: str,
+    mesh_name: str,
+    rig_name: str,
+    method: str = "proximity",
+    max_joints: int = 4,
+    falloff: float = 1.0,
+    output_name: Optional[str] = None,
+) -> dict:
+    """Capture skinning weights from *rig_name* onto *mesh_name* in *geo_path*.
+
+    Wires a ``captureproximity`` (or ``bonecapture``) SOP node between the
+    mesh and rig, producing ``boneCapture`` point attributes that
+    ``bonedeform`` reads at deformation time.
+
+    Args:
+        geo_path: Path to the Geometry SOP container.
+        mesh_name: Name of the mesh SOP node to capture onto.
+        rig_name: Name of the rig SOP node (skeleton source).
+        method: Capture method — ``proximity``, ``bones``, or ``heat``.
+        max_joints: Maximum number of influencing joints per point.
+        falloff: Falloff distance multiplier for capture radius.
+        output_name: Name for the capture SOP node (auto-generated if omitted).
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        geo = get_node(hou, geo_path)
+        mesh_node = get_node(hou, "{}/{}".format(geo.path(), mesh_name))
+        rig_node = get_node(hou, "{}/{}".format(geo.path(), rig_name))
+
+        # Choose capture node type.
+        method_map = {
+            "proximity": "captureproximity",
+            "bones": "bonecapture",
+            "heat": "captureproximity",  # fallback: heat diffusion via proximity
+        }
+        node_type = method_map.get(method.lower(), "captureproximity")
+
+        capture_name = output_name or "capture_{}".format(rig_name)
+        capture_node = geo.createNode(node_type, node_name=capture_name)
+
+        # Wire: mesh in port 0, skeleton (rest geometry) in port 1.
+        capture_node.setFirstInput(mesh_node)
+        try:
+            capture_node.setInput(1, rig_node, 0)
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Configure capture parameters.
+        if node_type == "captureproximity":
+            try:
+                capture_node.parm("maxpoints").set(max_joints)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                capture_node.parm("falloff").set(float(falloff))
+            except Exception:  # noqa: BLE001
+                pass
+
+        capture_node.moveToGoodPosition()
+
+        return skill_success(
+            "Captured joints",
+            capture_node_path=capture_node.path(),
+            geo_path=geo_path,
+            mesh_name=mesh_name,
+            rig_name=rig_name,
+            method=method,
+            max_joints=max_joints,
+            falloff=falloff,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to capture joints")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return capture_joints(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/create_rig.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/create_rig.py
@@ -1,0 +1,95 @@
+"""Create a KineFX skeleton rig with a joint chain."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _kinefx_common import get_node, get_or_create_rig  # noqa: E402
+
+
+def create_rig(
+    geo_path: str,
+    rig_name: str = "rig1",
+    joint_chain: Optional[List[dict]] = None,
+    auto_capture: bool = False,
+    capture_mesh: Optional[str] = None,
+) -> dict:
+    """Create a KineFX skeleton rig inside *geo_path*.
+
+    Builds a SOP-level skeleton with joint points.  Each entry in
+    *joint_chain* specifies a joint:
+
+    .. code-block:: json
+
+        [
+            {"name": "hip",   "translate": [0, 0, 0]},
+            {"name": "spine", "translate": [0, 0.5, 0]},
+            {"name": "head",  "translate": [0, 1.0, 0]}
+        ]
+
+    When *auto_capture* is ``True`` and *capture_mesh* names an existing SOP
+    node in the same geo container, a ``bonedeform`` node is wired after the
+    rig for immediate skinning.
+
+    Args:
+        geo_path: Path to the Geometry SOP container (e.g. ``/obj/geo1``).
+        rig_name: Name for the rig null/container node.
+        joint_chain: List of joint definitions (name + translate).
+        auto_capture: If True, wire a bonedeform for immediate skinning.
+        capture_mesh: Name of the mesh SOP node to capture (for auto_capture).
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        rig_node = get_or_create_rig(
+            hou,
+            geo_path=geo_path,
+            rig_name=rig_name,
+            joint_chain=joint_chain,
+        )
+
+        created_nodes = [rig_node.path()]
+
+        # Optional: auto-capture with a bonedeform node.
+        if auto_capture and capture_mesh:
+            geo = get_node(hou, geo_path)
+            mesh_node = hou.node("{}/{}".format(geo.path(), capture_mesh))
+            if mesh_node is not None:
+                bone_deform = geo.createNode("bonedeform", node_name="bonedeform_{}".format(rig_name))
+                bone_deform.setFirstInput(mesh_node)
+                bone_deform.setInput(1, rig_node)
+                bone_deform.moveToGoodPosition()
+                created_nodes.append(bone_deform.path())
+
+        return skill_success(
+            "Created KineFX rig",
+            rig_path=rig_node.path(),
+            geo_path=geo_path,
+            joint_count=len(joint_chain) if joint_chain else 0,
+            auto_capture=auto_capture,
+            created_nodes=created_nodes,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create KineFX rig")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_rig(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/set_rig_pose.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/set_rig_pose.py
@@ -1,0 +1,118 @@
+"""Set the pose of a KineFX rig — joint transforms or overall rig pose."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _kinefx_common import get_node  # noqa: E402
+
+
+def set_rig_pose(
+    rig_node: str,
+    joint_index: Optional[int] = None,
+    joint_name: Optional[str] = None,
+    translate: Optional[List[float]] = None,
+    rotate: Optional[List[float]] = None,
+    scale: Optional[List[float]] = None,
+) -> dict:
+    """Set the pose transform on a joint in a KineFX rig.
+
+    Target the joint by *joint_index* or *joint_name*.  When both are
+    omitted, sets a uniform pose on the entire rig geometry (if applicable).
+
+    The transform is applied to the point position/attributes on the rig SOP
+    geometry.  For KineFX skeleton points, ``P`` (position), ``rot``, and
+    ``scale`` point attributes are the standard pose controls.
+
+    Args:
+        rig_node: Path to the rig SOP node (e.g. ``/obj/geo1/rig1``).
+        joint_index: Zero-based index of the joint point to modify.
+        joint_name: Name attribute value of the joint to modify.
+        translate: ``[x, y, z]`` translation to set.
+        rotate: ``[rx, ry, rz]`` rotation in degrees.
+        scale: ``[sx, sy, sz]`` scale factors.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = get_node(hou, rig_node)
+        geo = node.geometry()
+        if geo is None:
+            return skill_error("No geometry", "Rig node has no editable geometry")
+
+        # Find the target point(s).
+        target_pts = []
+        if joint_index is not None:
+            try:
+                target_pts = [geo.iterPoints()[joint_index]]
+            except IndexError:
+                return skill_error(
+                    "Joint index out of range",
+                    joint_index=joint_index,
+                    point_count=geo.floatListAttribValue("P") or 0,
+                )
+        elif joint_name is not None:
+            name_attr = geo.findPointAttrib("name")
+            if name_attr is None:
+                return skill_error("No name attribute", "Rig geometry has no 'name' point attribute")
+            for pt in geo.points():
+                if pt.attribValue("name") == joint_name:
+                    target_pts.append(pt)
+                    break
+            if not target_pts:
+                return skill_error("Joint not found", joint_name=joint_name, rig_path=node.path())
+        else:
+            target_pts = geo.points()
+
+        applied = {}
+        for pt in target_pts:
+            if translate is not None and len(translate) >= 3:
+                pt.setPosition(hou.Vector3(float(translate[0]), float(translate[1]), float(translate[2])))
+                applied["translate"] = translate
+            if rotate is not None and len(rotate) >= 3:
+                rot_attr = geo.findPointAttrib("rot")
+                if rot_attr:
+                    pt.setAttribValue(rot_attr, hou.Vector3(float(rotate[0]), float(rotate[1]), float(rotate[2])))
+                else:
+                    rot_attr = geo.addAttrib(hou.attribType.Point, "rot", hou.Vector3())
+                    pt.setAttribValue(rot_attr, hou.Vector3(float(rotate[0]), float(rotate[1]), float(rotate[2])))
+                applied["rotate"] = rotate
+            if scale is not None and len(scale) >= 3:
+                scale_attr = geo.findPointAttrib("scale")
+                if scale_attr:
+                    pt.setAttribValue(scale_attr, hou.Vector3(float(scale[0]), float(scale[1]), float(scale[2])))
+                else:
+                    scale_attr = geo.addAttrib(hou.attribType.Point, "scale", hou.Vector3())
+                    pt.setAttribValue(scale_attr, hou.Vector3(float(scale[0]), float(scale[1]), float(scale[2])))
+                applied["scale"] = scale
+
+        return skill_success(
+            "Set rig pose",
+            rig_path=node.path(),
+            joint_count=len(target_pts),
+            applied=applied,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to set rig pose")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_rig_pose(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/tools.yaml
@@ -1,0 +1,174 @@
+tools:
+  - name: create_rig
+    description: >-
+      Create a KineFX skeleton rig with a joint chain and optional
+      auto-capture onto a mesh.
+    source_file: scripts/create_rig.py
+    execution: sync
+    affinity: main
+    group: rig
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [geo_path]
+      properties:
+        geo_path:
+          type: string
+          description: Path to the Geometry SOP container (e.g. /obj/geo1).
+        rig_name:
+          type: string
+          description: Name for the rig null/container node.
+          default: "rig1"
+        joint_chain:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Joint name.
+              translate:
+                type: array
+                items: {type: number}
+                description: Joint position [x, y, z].
+          description: List of joint definitions.
+        auto_capture:
+          type: boolean
+          description: If true, wire a bonedeform for immediate skinning.
+          default: false
+        capture_mesh:
+          type: string
+          description: Name of the mesh SOP node to capture onto.
+  - name: set_rig_pose
+    description: >-
+      Set translation, rotation, and/or scale on one or all joints of a
+      KineFX rig.
+    source_file: scripts/set_rig_pose.py
+    execution: sync
+    affinity: main
+    group: pose
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [rig_node]
+      properties:
+        rig_node:
+          type: string
+          description: Path to the rig SOP node.
+        joint_index:
+          type: integer
+          description: Zero-based joint point index.
+        joint_name:
+          type: string
+          description: Name attribute value of the joint to modify.
+        translate:
+          type: array
+          items: {type: number}
+          maxItems: 3
+          description: Translation [x, y, z] to set.
+        rotate:
+          type: array
+          items: {type: number}
+          maxItems: 3
+          description: Rotation [rx, ry, rz] in degrees.
+        scale:
+          type: array
+          items: {type: number}
+          maxItems: 3
+          description: Scale [sx, sy, sz] factors.
+  - name: capture_joints
+    description: >-
+      Capture skinning weights from a KineFX skeleton onto a target mesh
+      using captureproximity or bonecapture SOP.
+    source_file: scripts/capture_joints.py
+    execution: sync
+    affinity: main
+    group: capture
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [geo_path, mesh_name, rig_name]
+      properties:
+        geo_path:
+          type: string
+          description: Path to the Geometry SOP container.
+        mesh_name:
+          type: string
+          description: Name of the mesh SOP node to capture onto.
+        rig_name:
+          type: string
+          description: Name of the rig SOP node (skeleton source).
+        method:
+          type: string
+          description: Capture method.
+          enum: [proximity, bones, heat]
+          default: "proximity"
+        max_joints:
+          type: integer
+          description: Maximum influencing joints per point.
+          default: 4
+        falloff:
+          type: number
+          description: Falloff distance multiplier.
+          default: 1.0
+        output_name:
+          type: string
+          description: Name for the capture SOP node (auto-generated if omitted).
+  - name: apply_mocap
+    description: >-
+      Apply motion capture data (FBX, BVH, or KineFX .bclip/.clip) onto a
+      rig skeleton.
+    source_file: scripts/apply_mocap.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: mocap
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [geo_path, rig_name, mocap_file]
+      properties:
+        geo_path:
+          type: string
+          description: Path to the Geometry SOP container.
+        rig_name:
+          type: string
+          description: Name of the rig SOP node to animate.
+        mocap_file:
+          type: string
+          description: Path to the mocap file (.fbx, .bvh, .bclip, .clip).
+        start_frame:
+          type: number
+          description: Start frame offset for the mocap data.
+        scale:
+          type: number
+          description: Uniform scale applied to the mocap data.
+          default: 1.0
+        mocap_node_name:
+          type: string
+          description: Name for the mocap import SOP node.
+          default: "mocap1"

--- a/tests/test_chops_skills.py
+++ b/tests/test_chops_skills.py
@@ -1,0 +1,250 @@
+"""Mock-hou unit tests for the houdini-chops skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-chops" / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"chops_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_channel(name, value=0.0):
+    ch = MagicMock()
+    ch.name.return_value = name
+    ch.eval.return_value = value
+    return ch
+
+
+class TestChopNetwork:
+    def test_create_chop_network(self) -> None:
+        mod = _load_script("create_chop_network.py")
+        child = MagicMock()
+        child.path.return_value = "/ch/chopnet1"
+        child.name.return_value = "chopnet1"
+        parent = MagicMock()
+        parent.path.return_value = "/ch"
+        parent.createNode.return_value = child
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: parent if p == "/ch" else None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_chop_network("/ch", network_name="chopnet1")
+
+        assert result["success"] is True
+        parent.createNode.assert_called_once_with("chopnet", node_name="chopnet1")
+        assert result["context"]["network_path"] == "/ch/chopnet1"
+
+    def test_create_chop_network_returns_existing(self) -> None:
+        mod = _load_script("create_chop_network.py")
+        existing = MagicMock()
+        existing.path.return_value = "/ch/chopnet1"
+        existing.name.return_value = "chopnet1"
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = existing
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_chop_network("/ch", network_name="chopnet1")
+
+        assert result["success"] is True
+        assert result["context"]["network_path"] == "/ch/chopnet1"
+
+
+class TestMotionClip:
+    def test_create_motionclip(self) -> None:
+        mod = _load_script("create_motionclip.py")
+        node = MagicMock()
+        node.path.return_value = "/ch/chopnet1/motionclip1"
+        node.name.return_value = "motionclip1"
+        file_parm = MagicMock()
+        start_parm = MagicMock()
+        node.parm.side_effect = lambda name: {"file": file_parm, "start": start_parm}.get(name)
+        network = MagicMock()
+        network.createNode.return_value = node
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = network
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_motionclip("/ch/chopnet1", clip_file="/tmp/clip.bclip", start_frame=10.0)
+
+        assert result["success"] is True
+        network.createNode.assert_called_once_with("motionclip", node_name="motionclip1")
+        file_parm.set.assert_called_once_with("/tmp/clip.bclip")
+        start_parm.set.assert_called_once_with(10.0)
+
+    def test_create_motionclip_minimal(self) -> None:
+        mod = _load_script("create_motionclip.py")
+        node = MagicMock()
+        node.path.return_value = "/ch/chopnet1/motionclip1"
+        node.name.return_value = "motionclip1"
+        network = MagicMock()
+        network.createNode.return_value = node
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = network
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_motionclip("/ch/chopnet1")
+
+        assert result["success"] is True
+        assert result["context"]["applied"] == {}
+
+
+class TestAudioDriven:
+    def test_create_audio_driven(self) -> None:
+        mod = _load_script("create_audio_driven.py")
+        file_node = MagicMock()
+        file_node.path.return_value = "/ch/chopnet1/audio_file1"
+        envelope = MagicMock()
+        envelope.path.return_value = "/ch/chopnet1/envelope1"
+        network = MagicMock()
+        network.createNode.side_effect = [file_node, envelope]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = network
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_audio_driven(
+                "/ch/chopnet1",
+                audio_file="/tmp/music.wav",
+                target_parm="/obj/geo1/tx",
+                channel_name="amplitude",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["audio_file"] == "/tmp/music.wav"
+        assert result["context"]["target_parm"] == "/obj/geo1/tx"
+        envelope.setExportFlag.assert_called_once()
+
+
+class TestApplyFilter:
+    def test_apply_filter_lag(self) -> None:
+        mod = _load_script("apply_filter.py")
+        src = MagicMock()
+        src.path.return_value = "/ch/chopnet1/audio_file1"
+        filter_node = MagicMock()
+        filter_node.path.return_value = "/ch/chopnet1/lag_1"
+        network = MagicMock()
+        network.path.return_value = "/ch/chopnet1"
+        network.createNode.return_value = filter_node
+        parm = MagicMock()
+        filter_node.parm.return_value = parm
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: network if p == "/ch/chopnet1" else src
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.apply_filter("/ch/chopnet1", "audio_file1", "lag", amount=0.8)
+
+        assert result["success"] is True
+        network.createNode.assert_called_once_with("lag", node_name="lag_1")
+        filter_node.setFirstInput.assert_called_once_with(src)
+        parm.set.assert_called_once_with(0.8)
+        assert result["context"]["filter_type"] == "lag"
+
+    def test_apply_filter_unknown_type_returns_error(self) -> None:
+        mod = _load_script("apply_filter.py")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.apply_filter("/ch/chopnet1", "src", "invalid_filter")
+
+        assert result["success"] is False
+
+
+class TestGetChannelInfo:
+    def test_get_channel_info(self) -> None:
+        mod = _load_script("get_channel_info.py")
+        channels = [_make_channel("tx", 0.5), _make_channel("ty", 2.0)]
+        node = MagicMock()
+        node.path.return_value = "/ch/chopnet1/lag1"
+        node.name.return_value = "lag1"
+        node.type.return_value.name.return_value = "lag"
+        node.sampleRate.return_value = 60.0
+        node.segmentLength.return_value = 200.0
+        node.channels.return_value = channels
+        node.timeRange.return_value = (1, 200)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        mock_hou.frame.return_value = 1.0
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_channel_info("/ch/chopnet1/lag1")
+
+        assert result["success"] is True
+        assert result["context"]["sample_rate"] == 60.0
+        assert result["context"]["channel_count"] == 2
+        assert result["context"]["channel_names"] == ["tx", "ty"]
+        assert len(result["context"]["channels"]) == 2
+
+
+class TestExportToKeyframes:
+    def test_export_to_keyframes(self) -> None:
+        mod = _load_script("export_to_keyframes.py")
+        parm = MagicMock()
+        target = MagicMock()
+        target.path.return_value = "/obj/geo1"
+        target.parm.return_value = parm
+        chop_node = MagicMock()
+        chop_node.path.return_value = "/ch/chopnet1/lag1"
+        chop_node.timeRange.return_value = (1, 5)
+        chop_node.evalAtFrame.return_value = 2.0
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/ch/chopnet1/lag1": chop_node,
+            "/obj/geo1": target,
+        }.get(p)
+        mock_hou.frame.return_value = 1.0
+        mock_hou.Keyframe.return_value = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_to_keyframes(
+                "/ch/chopnet1/lag1",
+                "/obj/geo1",
+                ["tx", "ty"],
+            )
+
+        assert result["success"] is True
+        assert result["context"]["total_keyframes"] == 10  # 5 frames × 2 parms
+        assert parm.setKeyframe.call_count == 10
+
+    def test_export_to_keyframes_with_frame_range(self) -> None:
+        mod = _load_script("export_to_keyframes.py")
+        parm = MagicMock()
+        target = MagicMock()
+        target.path.return_value = "/obj/geo1"
+        target.parm.return_value = parm
+        chop_node = MagicMock()
+        chop_node.path.return_value = "/ch/chopnet1/lag1"
+        chop_node.evalAtFrame.return_value = 3.0
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/ch/chopnet1/lag1": chop_node,
+            "/obj/geo1": target,
+        }.get(p)
+        mock_hou.frame.return_value = 1.0
+        mock_hou.Keyframe.return_value = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_to_keyframes(
+                "/ch/chopnet1/lag1",
+                "/obj/geo1",
+                ["tx"],
+                frame_range=[1, 3],
+            )
+
+        assert result["success"] is True
+        assert result["context"]["frame_range"] == [1.0, 3.0]
+        assert result["context"]["total_keyframes"] == 3

--- a/tests/test_constraints_skills.py
+++ b/tests/test_constraints_skills.py
@@ -1,0 +1,255 @@
+"""Mock-hou unit tests for the houdini-constraints skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-constraints" / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"ctr_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_obj_node(path, name, node_type="geo"):
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = node_type
+    return node
+
+
+class TestParentConstraint:
+    def test_create_parent_constraint(self) -> None:
+        mod = _load_script("create_parent_constraint.py")
+        driven = _make_obj_node("/obj/geo2", "geo2")
+        target = _make_obj_node("/obj/geo1", "geo1")
+        blend = _make_obj_node("/obj/blend_geo2", "blend_geo2", "blend")
+        parent = MagicMock()
+        parent.path.return_value = "/obj"
+        parent.createNode.return_value = blend
+        driven.parent.return_value = parent
+
+        # World transforms for offset calc.
+        driven_mat = MagicMock()
+        driven_mat.inverted.return_value = MagicMock()
+        driven.worldTransform.return_value = driven_mat
+        target.worldTransform.return_value = MagicMock()
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo2": driven,
+            "/obj/geo1": target,
+            "/obj": parent,
+        }.get(p)
+        mock_hou.hscriptExpression.return_value = "ch_test"
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_parent_constraint("/obj/geo2", "/obj/geo1")
+
+        assert result["success"] is True
+        assert result["context"]["driven_path"] == "/obj/geo2"
+        assert result["context"]["target_path"] == "/obj/geo1"
+        assert "blend_node_path" in result["context"]
+
+
+class TestBlendConstraint:
+    def test_create_blend_constraint(self) -> None:
+        mod = _load_script("create_blend_constraint.py")
+        driven = _make_obj_node("/obj/geo3", "geo3")
+        t1 = _make_obj_node("/obj/geo1", "geo1")
+        t2 = _make_obj_node("/obj/geo2", "geo2")
+        blend = _make_obj_node("/obj/blend_geo3", "blend_geo3", "blend")
+        parent = MagicMock()
+        parent.path.return_value = "/obj"
+        parent.createNode.return_value = blend
+        driven.parent.return_value = parent
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo3": driven,
+            "/obj/geo1": t1,
+            "/obj/geo2": t2,
+            "/obj": parent,
+        }.get(p)
+        mock_hou.hscriptExpression.return_value = "ch_test"
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_blend_constraint("/obj/geo3", ["/obj/geo1", "/obj/geo2"], weights=[0.3, 0.7])
+
+        assert result["success"] is True
+        assert result["context"]["target_count"] == 2
+        assert result["context"]["target_paths"] == ["/obj/geo1", "/obj/geo2"]
+
+    def test_create_blend_constraint_empty_targets_returns_error(self) -> None:
+        mod = _load_script("create_blend_constraint.py")
+        mock_hou = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_blend_constraint("/obj/geo3", [])
+
+        assert result["success"] is False
+
+    def test_create_blend_constraint_weight_mismatch_returns_error(self) -> None:
+        mod = _load_script("create_blend_constraint.py")
+        mock_hou = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_blend_constraint("/obj/geo3", ["/obj/geo1", "/obj/geo2"], weights=[1.0])
+
+        assert result["success"] is False
+
+
+class TestPositionConstraint:
+    def test_create_position_constraint(self) -> None:
+        mod = _load_script("create_position_constraint.py")
+        driven = _make_obj_node("/obj/geo2", "geo2")
+        target = _make_obj_node("/obj/geo1", "geo1")
+        object_chop = MagicMock()
+        object_chop.path.return_value = "/ch/pos_constraint1/obj_geo1"
+        chop_ctx = MagicMock()
+        chop_ctx.createNode.return_value = object_chop
+
+        driven_parm = MagicMock()
+        driven.parm.return_value = driven_parm
+
+        # Transform mocks for offset calculation.
+        dt = MagicMock()
+        dt.extractTranslates.return_value = [1.0, 2.0, 3.0]
+        tt = MagicMock()
+        tt.extractTranslates.return_value = [0.0, 0.0, 0.0]
+        driven.worldTransform.return_value = dt
+        target.worldTransform.return_value = tt
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo2": driven,
+            "/obj/geo1": target,
+            "/ch": chop_ctx,
+        }.get(p)
+
+        class MockExprLang:
+            Hscript = "hscript"
+
+        mock_hou.exprLanguage = MockExprLang()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_position_constraint("/obj/geo2", "/obj/geo1")
+
+        assert result["success"] is True
+        assert result["context"]["driven_path"] == "/obj/geo2"
+        assert result["context"]["offset"] == {"tx": 1.0, "ty": 2.0, "tz": 3.0}
+
+
+class TestOrientConstraint:
+    def test_create_orient_constraint(self) -> None:
+        mod = _load_script("create_orient_constraint.py")
+        driven = _make_obj_node("/obj/geo2", "geo2")
+        target = _make_obj_node("/obj/geo1", "geo1")
+        object_chop = MagicMock()
+        object_chop.path.return_value = "/ch/orient_constraint1/obj_rot_geo1"
+        chop_ctx = MagicMock()
+        chop_ctx.createNode.return_value = object_chop
+
+        driven_parm = MagicMock()
+        driven.parm.return_value = driven_parm
+
+        dt = MagicMock()
+        dt.extractRotates.return_value = [30.0, 45.0, 0.0]
+        tt = MagicMock()
+        tt.extractRotates.return_value = [0.0, 0.0, 0.0]
+        driven.worldTransform.return_value = dt
+        target.worldTransform.return_value = tt
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo2": driven,
+            "/obj/geo1": target,
+            "/ch": chop_ctx,
+        }.get(p)
+
+        class MockExprLang:
+            Hscript = "hscript"
+
+        mock_hou.exprLanguage = MockExprLang()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_orient_constraint("/obj/geo2", "/obj/geo1")
+
+        assert result["success"] is True
+        assert result["context"]["offset"] == {"rx": 30.0, "ry": 45.0, "rz": 0.0}
+
+
+class TestListConstraints:
+    def test_list_constraints_empty(self) -> None:
+        mod = _load_script("list_constraints.py")
+        obj_ctx = MagicMock()
+        obj_ctx.children.return_value = []
+        chop_ctx = MagicMock()
+        chop_ctx.children.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {"/obj": obj_ctx, "/ch": chop_ctx}.get(p)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_constraints("/obj")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 0
+        assert result["context"]["constraints"] == []
+
+    def test_list_constraints_finds_blend(self) -> None:
+        mod = _load_script("list_constraints.py")
+        inp = MagicMock()
+        inp.path.return_value = "/obj/geo1"
+        blend = MagicMock()
+        blend.path.return_value = "/obj/blend1"
+        blend.name.return_value = "blend1"
+        blend.type.return_value.name.return_value = "blend"
+        blend.inputs.return_value = [inp]
+        obj_ctx = MagicMock()
+        obj_ctx.children.return_value = [blend]
+        chop_ctx = MagicMock()
+        chop_ctx.children.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {"/obj": obj_ctx, "/ch": chop_ctx}.get(p)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_constraints("/obj")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["constraints"][0]["type"] == "blend"
+
+
+class TestDeleteConstraint:
+    def test_delete_constraint_blend(self) -> None:
+        mod = _load_script("delete_constraint.py")
+        blend = _make_obj_node("/obj/blend1", "blend1", "blend")
+        child = _make_obj_node("/obj/geo1", "geo1")
+        child_parm = MagicMock()
+        child_parm.rawValue.return_value = "ch('/obj/blend1/tx')"
+        child.parms.return_value = [child_parm]
+        parent = MagicMock()
+        parent.children.return_value = [blend, child]
+        blend.parent.return_value = parent
+        child.parent.return_value = parent
+
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = blend
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.delete_constraint("/obj/blend1")
+
+        assert result["success"] is True
+        assert result["context"]["deleted_node"]["path"] == "/obj/blend1"
+        blend.destroy.assert_called_once()

--- a/tests/test_kinefx_skills.py
+++ b/tests/test_kinefx_skills.py
@@ -1,0 +1,267 @@
+"""Mock-hou unit tests for the houdini-kinefx skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / "houdini-kinefx" / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(f"kfx_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestCreateRig:
+    def test_create_rig_with_joint_chain(self) -> None:
+        mod = _load_script("create_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+
+        # rig_sop = geo.createNode("null", node_name=rig_name)
+        rig_sop = MagicMock()
+        rig_sop.path.return_value = "/obj/geo1/rig1"
+        rig_geo = MagicMock()
+        rig_sop.geometry.return_value = rig_geo
+
+        geo.createNode.return_value = rig_sop
+
+        mock_hou = MagicMock()
+        # Use side_effect to differentiate: rig doesn't exist yet, return None
+        mock_hou.node.side_effect = lambda p: None if "rig1" in p else geo
+
+        class MockAttribType:
+            Point = "point"
+
+        mock_hou.attribType = MockAttribType()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_rig(
+                "/obj/geo1",
+                rig_name="rig1",
+                joint_chain=[
+                    {"name": "hip", "translate": [0, 0, 0]},
+                    {"name": "spine", "translate": [0, 0.5, 0]},
+                    {"name": "head", "translate": [0, 1.0, 0]},
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["context"]["rig_path"] == "/obj/geo1/rig1"
+        assert result["context"]["joint_count"] == 3
+
+    def test_create_rig_with_auto_capture(self) -> None:
+        mod = _load_script("create_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+
+        rig_sop = MagicMock()
+        rig_sop.path.return_value = "/obj/geo1/rig1"
+        rig_geo = MagicMock()
+        rig_sop.geometry.return_value = rig_geo
+
+        bone_deform = MagicMock()
+        bone_deform.path.return_value = "/obj/geo1/bonedeform_rig1"
+
+        mesh_node = MagicMock()
+        mesh_node.path.return_value = "/obj/geo1/body"
+
+        geo.createNode.side_effect = [rig_sop, bone_deform]
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo1": geo,
+            "/obj/geo1/body": mesh_node,
+        }.get(p)
+
+        class MockAttribType:
+            Point = "point"
+
+        mock_hou.attribType = MockAttribType()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_rig(
+                "/obj/geo1",
+                rig_name="rig1",
+                joint_chain=[{"name": "root", "translate": [0, 0, 0]}],
+                auto_capture=True,
+                capture_mesh="body",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["auto_capture"] is True
+        assert len(result["context"]["created_nodes"]) == 2
+        bone_deform.setFirstInput.assert_called_once_with(mesh_node)
+        bone_deform.setInput.assert_called_with(1, rig_sop)
+
+
+class TestSetRigPose:
+    def test_set_rig_pose_by_index(self) -> None:
+        mod = _load_script("set_rig_pose.py")
+        pt = MagicMock()
+        geo = MagicMock()
+        geo.iterPoints.return_value = [pt]
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/rig1"
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        mock_hou.Vector3 = lambda *args: list(args) if args else [0.0, 0.0, 0.0]
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_rig_pose(
+                "/obj/geo1/rig1",
+                joint_index=0,
+                translate=[0.0, 1.0, 0.0],
+            )
+
+        assert result["success"] is True
+        assert result["context"]["applied"]["translate"] == [0.0, 1.0, 0.0]
+        pt.setPosition.assert_called_once()
+
+    def test_set_rig_pose_with_rotation(self) -> None:
+        mod = _load_script("set_rig_pose.py")
+        pt = MagicMock()
+        geo = MagicMock()
+        geo.iterPoints.return_value = [pt]
+        geo.points.return_value = [pt]
+        geo.findPointAttrib.return_value = None  # rot attr doesn't exist yet
+        geo.addAttrib.return_value = "rot"
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/rig1"
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+        mock_hou.Vector3 = lambda *args: list(args) if args else [0.0, 0.0, 0.0]
+        mock_hou.attribType.Point = "point"
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_rig_pose(
+                "/obj/geo1/rig1",
+                rotate=[90.0, 0.0, 0.0],
+            )
+
+        assert result["success"] is True
+        assert result["context"]["applied"]["rotate"] == [90.0, 0.0, 0.0]
+        geo.addAttrib.assert_called_once()
+
+    def test_set_rig_pose_no_geometry_returns_error(self) -> None:
+        mod = _load_script("set_rig_pose.py")
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/rig1"
+        node.geometry.return_value = None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_rig_pose("/obj/geo1/rig1")
+
+        assert result["success"] is False
+
+
+class TestCaptureJoints:
+    def test_capture_joints_proximity(self) -> None:
+        mod = _load_script("capture_joints.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        mesh = MagicMock()
+        mesh.path.return_value = "/obj/geo1/body"
+        rig = MagicMock()
+        rig.path.return_value = "/obj/geo1/rig1"
+        capture_node = MagicMock()
+        capture_node.path.return_value = "/obj/geo1/capture_rig1"
+        geo.createNode.return_value = capture_node
+
+        parm_max = MagicMock()
+        parm_falloff = MagicMock()
+        capture_node.parm.side_effect = lambda n: {
+            "maxpoints": parm_max,
+            "falloff": parm_falloff,
+        }.get(n)
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo1": geo,
+            "/obj/geo1/body": mesh,
+            "/obj/geo1/rig1": rig,
+        }.get(p)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.capture_joints(
+                "/obj/geo1",
+                mesh_name="body",
+                rig_name="rig1",
+                method="proximity",
+                max_joints=4,
+                falloff=1.0,
+            )
+
+        assert result["success"] is True
+        geo.createNode.assert_called_once_with("captureproximity", node_name="capture_rig1")
+        capture_node.setFirstInput.assert_called_once_with(mesh)
+        parm_max.set.assert_called_once_with(4)
+        parm_falloff.set.assert_called_once_with(1.0)
+
+    def test_capture_joints_bones_method(self) -> None:
+        mod = _load_script("capture_joints.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        mesh = MagicMock()
+        rig = MagicMock()
+        capture_node = MagicMock()
+        geo.createNode.return_value = capture_node
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo1": geo,
+            "/obj/geo1/body": mesh,
+            "/obj/geo1/rig1": rig,
+        }.get(p)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.capture_joints("/obj/geo1", "body", "rig1", method="bones")
+
+        assert result["success"] is True
+        geo.createNode.assert_called_once_with("bonecapture", node_name="capture_rig1")
+
+
+class TestApplyMocap:
+    def test_apply_mocap_bclip(self) -> None:
+        mod = _load_script("apply_mocap.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        rig = MagicMock()
+        rig.path.return_value = "/obj/geo1/rig1"
+        import_node = MagicMock()
+        import_node.path.return_value = "/obj/geo1/mocap1"
+        bone_deform = MagicMock()
+        bone_deform.path.return_value = "/obj/geo1/anim_rig1"
+        geo.createNode.side_effect = [import_node, bone_deform]
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda p: {
+            "/obj/geo1": geo,
+            "/obj/geo1/rig1": rig,
+        }.get(p)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.apply_mocap(
+                "/obj/geo1",
+                rig_name="rig1",
+                mocap_file="/tmp/walk.bclip",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["file_type"] == "bclip"
+        geo.createNode.assert_any_call("motionclip", node_name="mocap1")
+        bone_deform.setInput.assert_any_call(0, import_node, 0)
+        bone_deform.setInput.assert_any_call(1, rig, 0)


### PR DESCRIPTION
## Summary

Add 3 new animation domain skills (~16 typed tools) to extend Animation / Motion FX capabilities in Houdini:

### houdini-chops (6 tools)
- `create_chop_network` — create CHOP network containers
- `create_motionclip` — import/create motion clips
- `create_audio_driven` — audio-driven animation via Envelope CHOP
- `apply_filter` — procedural filters (lag, spring, noise, smooth, peak, bandpass, comp, limit)
- `export_to_keyframes` — bake CHOP data to object keyframes
- `get_channel_info` — inspect channel metadata

### houdini-constraints (6 tools)
- `create_parent_constraint` — full transform parent constraint via OBJ blend
- `create_blend_constraint` — multi-target weighted blend
- `create_position_constraint` — translation-only CHOP-driven constraint
- `create_orient_constraint` — rotation-only CHOP-driven constraint
- `list_constraints` — scan blend and CHOP constraints
- `delete_constraint` — destructive removal with expression cleanup

### houdini-kinefx (4 tools)
- `create_rig` — KineFX skeleton rig with joint chain
- `set_rig_pose` — joint transform via point attributes
- `capture_joints` — skinning weights via captureproximity/bonecapture
- `apply_mocap` — import FBX/BVH/bclip onto rig with bonedeform

## Test plan

- 27 mock-hou unit tests across all 3 skills
- All pass in CI-safe mode (no live Houdini needed)
- `pytest tests/test_chops_skills.py tests/test_constraints_skills.py tests/test_kinefx_skills.py -v`