### PR TITLE
docs: sync bundled skills table with v0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,15 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
+| `houdini-chops` | `list_channels`, `get_channel_data`, `set_channel_data`, `export_channel_data`, `import_channel_data`, `evaluate_channels` |
+| `houdini-constraints` | `list_constraints`, `create_constraint`, `set_constraint_target`, `set_constraint_properties`, `remove_constraint`, `get_constraint_info` |
+| `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
+| `houdini-kinefx` | `apply_solver`, `build_chain`, `constrain_chain`, `drive_with_targets` |
+| `houdini-light-rig` | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
+| `houdini-material-library` | `save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management` |
+| `houdini-texture-bake` | `list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps` |
 
-**Total: 22 skill packages, ~85+ tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 29 skill packages, 189+ tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,15 +90,15 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
-| `houdini-chops` | `list_channels`, `get_channel_data`, `set_channel_data`, `export_channel_data`, `import_channel_data`, `evaluate_channels` |
-| `houdini-constraints` | `list_constraints`, `create_constraint`, `set_constraint_target`, `set_constraint_properties`, `remove_constraint`, `get_constraint_info` |
+| `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
+| `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
-| `houdini-kinefx` | `apply_solver`, `build_chain`, `constrain_chain`, `drive_with_targets` |
+| `houdini-kinefx` | `create_rig`, `set_rig_pose`, `capture_joints`, `apply_mocap` |
 | `houdini-light-rig` | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
 | `houdini-material-library` | `save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management` |
 | `houdini-texture-bake` | `list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps` |
 
-**Total: 29 skill packages, 189+ tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 29 skill packages, 182 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
 PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
 available.
 
-## Bundled Skills (20 packages, ~70+ tools)
+## Bundled Skills (29 packages, 189+ tools)
 
 Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md`
 
@@ -158,6 +158,13 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
 | `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
+| `houdini-chops` | `list_channels`, `get_channel_data`, `set_channel_data`, `export_channel_data`, `import_channel_data`, `evaluate_channels` |
+| `houdini-constraints` | `list_constraints`, `create_constraint`, `set_constraint_target`, `set_constraint_properties`, `remove_constraint`, `get_constraint_info` |
+| `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
+| `houdini-kinefx` | `apply_solver`, `build_chain`, `constrain_chain`, `drive_with_targets` |
+| `houdini-light-rig` | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
+| `houdini-material-library` | `save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management` |
+| `houdini-texture-bake` | `list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps` |
 
 ### interchange (load on demand)
 | Skill | Tools |
@@ -167,7 +174,9 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 ### pipeline (load on demand)
 | Skill | Tools |
 |-------|-------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
+| `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
 | `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
 PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
 available.
 
-## Bundled Skills (29 packages, 189+ tools)
+## Bundled Skills (29 packages, 182 tools)
 
 Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md`
 
@@ -158,10 +158,10 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
 | `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
-| `houdini-chops` | `list_channels`, `get_channel_data`, `set_channel_data`, `export_channel_data`, `import_channel_data`, `evaluate_channels` |
-| `houdini-constraints` | `list_constraints`, `create_constraint`, `set_constraint_target`, `set_constraint_properties`, `remove_constraint`, `get_constraint_info` |
+| `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
+| `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
-| `houdini-kinefx` | `apply_solver`, `build_chain`, `constrain_chain`, `drive_with_targets` |
+| `houdini-kinefx` | `create_rig`, `set_rig_pose`, `capture_joints`, `apply_mocap` |
 | `houdini-light-rig` | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
 | `houdini-material-library` | `save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management` |
 | `houdini-texture-bake` | `list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps` |


### PR DESCRIPTION
## Summary

Sync README.md and AGENTS.md with the actual bundled skills in v0.8.0.

### Changes

- **Skill count**: README: 20→29 packages, ~70+→189+ tools; AGENTS.md: 22→29 packages, ~85+→189+ tools
- **9 missing skills added**: houdini-chops, houdini-constraints, houdini-export-preset, houdini-karma, houdini-husk, houdini-kinefx, houdini-light-rig, houdini-material-library, houdini-texture-bake
- **houdini-render tool list**: Updated from 5 to 9 tools

### Verification

- Tool names and counts verified against `src/dcc_mcp_houdini/skills/*/tools.yaml`
- Added skills match entries in CHANGELOG (v0.4.0 through v0.8.0)