### PR TITLE
docs: fix stage classification in llms.txt for 5 misplaced skills

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -52,23 +52,23 @@ server.list_skills()
 - `houdini_materials__create_material`, `assign_material`
 - `houdini_lookdev__list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset`
 - `houdini_hda__install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`
-- `houdini_chops__create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info`
-- `houdini_constraints__create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint`
-- `houdini_export_preset__list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset`
-- `houdini_kinefx__create_rig`, `set_rig_pose`, `capture_joints`, `apply_mocap`
 - `houdini_light_rig__create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary`
 - `houdini_material_library__save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management`
-- `houdini_texture_bake__list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps`
 
 ### interchange (load on demand)
 - `houdini_interchange__probe_file`, `import_geometry`, `export_geometry`, `export_alembic`, `export_fbx`, `export_usd`
 - `houdini_import_to_scene__import_to_scene`
+- `houdini_export_preset__list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset`
 
 ### pipeline (load on demand)
 - `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
 - `houdini_karma__configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output`
 - `houdini_husk__render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
 - `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`
+- `houdini_chops__create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info`
+- `houdini_constraints__create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint`
+- `houdini_kinefx__create_rig`, `set_rig_pose`, `capture_joints`, `apply_mocap`
+- `houdini_texture_bake__list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps`
 - `houdini_hda_automation__scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain`
 - `houdini_pipeline__set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package`
 - `houdini_dev__attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action`
@@ -78,9 +78,9 @@ server.list_skills()
 
 - `bootstrap`: `houdini-scripting` (default loaded)
 - `scene`: `houdini-scene`, `houdini-scene-edit` (partial default)
-- `authoring`: `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`, `houdini-chops`, `houdini-constraints`, `houdini-export-preset`, `houdini-kinefx`, `houdini-light-rig`, `houdini-material-library`, `houdini-texture-bake`
-- `interchange`: `houdini-interchange`, `houdini-import-to-scene`
-- `pipeline`: `houdini-render`, `houdini-karma`, `houdini-husk`, `houdini-animation`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`
+- `authoring`: `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-hda`, `houdini-light-rig`, `houdini-material-library`
+- `interchange`: `houdini-interchange`, `houdini-export-preset`, `houdini-import-to-scene`
+- `pipeline`: `houdini-render`, `houdini-karma`, `houdini-husk`, `houdini-animation`, `houdini-chops`, `houdini-constraints`, `houdini-kinefx`, `houdini-texture-bake`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`
 
 ## Dev (Windows)
 


### PR DESCRIPTION
## Summary
Fix stage misalignment in `llms.txt` where 5 skills were incorrectly listed under `authoring` instead of their correct stages per `SKILLS_INDEX.md`:

- `houdini-chops` → **pipeline**
- `houdini-constraints` → **pipeline**
- `houdini-kinefx` → **pipeline**
- `houdini-texture-bake` → **pipeline**
- `houdini-export-preset` → **interchange**

Both the tool listing and the stage summary are now aligned with the authoritative index.
Fixes #68.