### PR TITLE
docs: update example wheel URL from v0.1.0 to v0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install dcc-mcp-houdini
 For an unreleased GitHub asset, install a release wheel directly:
 
 ```bash
-pip install https://github.com/loonghao/dcc-mcp-houdini/releases/download/v0.1.0/dcc_mcp_houdini-0.1.0-py3-none-any.whl
+pip install https://github.com/loonghao/dcc-mcp-houdini/releases/download/v0.9.1/dcc_mcp_houdini-0.9.1-py3-none-any.whl
 ```
 
 ### Houdini Quickinstall ZIP


### PR DESCRIPTION
The README example pip install URL referenced v0.1.0 which is two years
old and predates most of the project's features. Updated to the latest
release v0.9.1 so users following the example install a current version.