### PR TITLE
docs: correct gateway port and bundled skill/tool counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 29 skill packages, 173 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 30 skill packages, 183 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## What This Project Does
 
-`dcc-mcp-houdini` embeds an MCP Streamable HTTP server directly inside SideFX Houdini. Claude Desktop (or any Anthropic API client using MCP) can call 170+ Houdini tools across 29 skill packages over HTTP — scene inspection, node authoring, HDA execution, rendering, and more.
+`dcc-mcp-houdini` embeds an MCP Streamable HTTP server directly inside SideFX Houdini. Claude Desktop (or any Anthropic API client using MCP) can call 180+ Houdini tools across 30 skill packages over HTTP — scene inspection, node authoring, HDA execution, rendering, and more.
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@
 
 ## What This Project Does
 
-`dcc-mcp-houdini` embeds an MCP Streamable HTTP server directly inside SideFX Houdini. Gemini (via an MCP-compatible client or custom integration) can discover and invoke 170+ Houdini tools across 29 skill packages over HTTP.
+`dcc-mcp-houdini` embeds an MCP Streamable HTTP server directly inside SideFX Houdini. Gemini (via an MCP-compatible client or custom integration) can discover and invoke 180+ Houdini tools across 30 skill packages over HTTP.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ skills-first Houdini automation tools to agents.
 
 ## Features
 
-- Embedded MCP Streamable HTTP server inside Houdini
-- Auto-gateway with first-wins port competition (port 8765)
+- Embedded MCP Streamable HTTP server inside Houdini (port 8765)
+- Auto-gateway with first-wins election (gateway port 9765)
 - Progressive skill loading (discover → load → unload)
 - Houdini Python (`hython`) and interactive UI-thread dispatch
 - Python 3.7+ package metadata for older Houdini runtimes
@@ -130,7 +130,7 @@ manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
 PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
 available.
 
-## Bundled Skills (29 packages, 173 tools)
+## Bundled Skills (30 packages, 183 tools)
 
 Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md`
 

--- a/llms.txt
+++ b/llms.txt
@@ -32,7 +32,7 @@ server.list_skills()
 - `houdini_success`, `houdini_error`, `with_houdini`
 - `build_minimal_mode_config`, `build_minimal_mode_for_stages`, `MINIMAL_SKILLS`, `STAGES`, `STAGE_SKILLS`
 
-## Bundled tools (29 skills, 170+ tools)
+## Bundled tools (30 skills, 180+ tools)
 
 ### bootstrap (default)
 - `houdini_scripting__execute_python`, `get_session_info`


### PR DESCRIPTION
## Summary

Fixes two outdated/incorrect descriptions in the Houdini docs so they match actual current behavior.

### 1. Gateway port (README Features)
The README described the auto-gateway as competing on the MCP port `8765`. In reality the MCP Streamable HTTP server listens on `8765` (`DCC_MCP_HOUDINI_PORT`), while the gateway election uses `9765` (`DCC_MCP_GATEWAY_PORT`). Both lines are now clarified.

### 2. Stale bundled-skill / tool counts (5 files)
The counts were stale and duplicated across `README.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` and `llms.txt` as **29 packages / 173 tools**. The package now ships **30 skill directories totalling 183 tools**. All five docs are updated to **30 packages / 183 tools** so they stay consistent.

## Verification
- `git ls-tree -d origin/main:src/dcc_mcp_houdini/skills` → **30** `houdini-*` skill directories.
- Summing `- name:` across every skill `tools.yaml` → **183** tools.
- Port facts confirmed against `src/dcc_mcp_houdini/_env.py` (`DCC_MCP_HOUDINI_PORT`, `DCC_MCP_GATEWAY_PORT`) and the `AGENTS.md` env-var table.
- `pytest tests/test_agent_instruction_files.py` → **2 passed** (agent-doc guards still green).

## Scope
Docs only — 7 insertions / 7 deletions, no code changes.
