### PR TITLE
Add Houdini quickinstall shelf controls

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -6,6 +6,7 @@ The output ZIP contains:
 * compatible ``dcc-mcp-core`` wheels from PyPI for the requested platform;
 * a Houdini package JSON template;
 * ``scripts/123.py`` autostart bootstrap;
+* ``toolbar/DCC-MCP.shelf`` with basic user-visible controls;
 * PowerShell and POSIX installer scripts.
 
 Install flow:
@@ -260,6 +261,91 @@ except Exception as exc:
 '''
 
 
+def _shelf_file() -> str:
+    return r"""<?xml version="1.0" encoding="UTF-8"?>
+<shelfDocument>
+  <toolshelf name="DCC-MCP" label="DCC-MCP">
+    <memberTool name="dcc_mcp_houdini_start"/>
+    <memberTool name="dcc_mcp_houdini_stop"/>
+    <memberTool name="dcc_mcp_houdini_status"/>
+    <memberTool name="dcc_mcp_houdini_docs"/>
+  </toolshelf>
+  <tool name="dcc_mcp_houdini_start" label="Start MCP" icon="MISC_python" helpText="Start the DCC-MCP Houdini server.">
+    <script scriptType="python"><![CDATA[
+try:
+    import dcc_mcp_houdini
+
+    server = dcc_mcp_houdini.start_server(wait_ready=False)
+    message = "DCC-MCP Houdini server: {}".format(server.mcp_url)
+except Exception as exc:
+    message = "DCC-MCP Houdini start failed: {}".format(exc)
+
+try:
+    import hou
+
+    hou.ui.setStatusMessage(message)
+except Exception:
+    print(message)
+]]></script>
+  </tool>
+  <tool name="dcc_mcp_houdini_stop" label="Stop MCP" icon="MISC_python" helpText="Stop the DCC-MCP Houdini server.">
+    <script scriptType="python"><![CDATA[
+try:
+    import dcc_mcp_houdini
+
+    dcc_mcp_houdini.stop_server()
+    message = "DCC-MCP Houdini server stopped."
+except Exception as exc:
+    message = "DCC-MCP Houdini stop failed: {}".format(exc)
+
+try:
+    import hou
+
+    hou.ui.setStatusMessage(message)
+except Exception:
+    print(message)
+]]></script>
+  </tool>
+  <tool name="dcc_mcp_houdini_status" label="Status" icon="BUTTONS_info" helpText="Show the DCC-MCP Houdini server status.">
+    <script scriptType="python"><![CDATA[
+try:
+    import dcc_mcp_houdini
+
+    server = dcc_mcp_houdini.get_server()
+    if server is not None and getattr(server, "is_running", False):
+        message = "DCC-MCP Houdini server is running: {}".format(server.mcp_url)
+    else:
+        message = "DCC-MCP Houdini server is not running."
+except Exception as exc:
+    message = "DCC-MCP Houdini status failed: {}".format(exc)
+
+try:
+    import hou
+
+    hou.ui.setStatusMessage(message)
+except Exception:
+    print(message)
+]]></script>
+  </tool>
+  <tool name="dcc_mcp_houdini_docs" label="Docs" icon="BUTTONS_help" helpText="Open DCC-MCP Houdini documentation.">
+    <script scriptType="python"><![CDATA[
+import webbrowser
+
+url = "https://github.com/dcc-mcp/dcc-mcp-houdini"
+webbrowser.open(url)
+
+try:
+    import hou
+
+    hou.ui.setStatusMessage("Opened DCC-MCP Houdini docs: {}".format(url))
+except Exception:
+    print("Opened DCC-MCP Houdini docs: {}".format(url))
+]]></script>
+  </tool>
+</shelfDocument>
+"""
+
+
 def _install_ps1() -> str:
     return r"""param(
   [string]$HoudiniVersion = "20.5",
@@ -321,6 +407,7 @@ Install on Linux/macOS:
 The installer writes a Houdini package JSON into the user Houdini preferences
 folder and points it at this extracted package directory. On Houdini startup,
 scripts/123.py extracts bundled wheels into vendor/ and starts the MCP server.
+The DCC-MCP shelf is loaded from toolbar/DCC-MCP.shelf.
 
 Disable autostart by setting DCC_MCP_HOUDINI_AUTOSTART=0.
 MCP URL defaults to http://127.0.0.1:8765/mcp.
@@ -344,9 +431,11 @@ def assemble(platform: str, dist_dir: Path, output_dir: Path) -> Path:
         wheels_dir = root / "wheels"
         packages_dir = root / "packages"
         scripts_dir = root / "scripts"
+        toolbar_dir = root / "toolbar"
         wheels_dir.mkdir(parents=True)
         packages_dir.mkdir(parents=True)
         scripts_dir.mkdir(parents=True)
+        toolbar_dir.mkdir(parents=True)
 
         shutil.copy2(str(adapter_wheel), str(wheels_dir / adapter_wheel.name))
         for core_wheel in download_core_wheels(core_version, platform, tmp_dir / "wheel-cache"):
@@ -355,6 +444,7 @@ def assemble(platform: str, dist_dir: Path, output_dir: Path) -> Path:
         (packages_dir / "dcc_mcp_houdini.json.template").write_text(_package_json_template(), encoding="utf-8")
         (scripts_dir / "dcc_mcp_houdini_bootstrap.py").write_text(_bootstrap_py(), encoding="utf-8")
         (scripts_dir / "123.py").write_text(_startup_py(), encoding="utf-8")
+        (toolbar_dir / "DCC-MCP.shelf").write_text(_shelf_file(), encoding="utf-8")
         (root / "install.ps1").write_text(_install_ps1(), encoding="utf-8")
         install_sh = root / "install.sh"
         install_sh.write_text(_install_sh(), encoding="utf-8")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
 
@@ -44,14 +45,29 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     assert zip_path.is_file()
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
+        shelf_xml = zf.read("dcc_mcp_houdini/toolbar/DCC-MCP.shelf").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(adapter_wheel.name) in names
     for core_wheel in core_wheels:
         assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
     assert "dcc_mcp_houdini/scripts/123.py" in names
     assert "dcc_mcp_houdini/scripts/dcc_mcp_houdini_bootstrap.py" in names
+    assert "dcc_mcp_houdini/toolbar/DCC-MCP.shelf" in names
     assert "dcc_mcp_houdini/packages/dcc_mcp_houdini.json.template" in names
     assert "dcc_mcp_houdini/install.ps1" in names
     assert "dcc_mcp_houdini/install.sh" in names
+
+    shelf = ET.fromstring(shelf_xml)
+    tool_names = {tool.attrib["name"] for tool in shelf.findall("tool")}
+    assert tool_names == {
+        "dcc_mcp_houdini_start",
+        "dcc_mcp_houdini_stop",
+        "dcc_mcp_houdini_status",
+        "dcc_mcp_houdini_docs",
+    }
+    assert "wait_ready=False" in shelf_xml
+    assert "get_server" in shelf_xml
+    assert "setStatusMessage" in shelf_xml
+    assert "displayMessage" not in shelf_xml
 
 
 def test_pick_core_wheels_includes_py37_and_abi3_for_platform() -> None:


### PR DESCRIPTION
## Summary
- add a generated `DCC-MCP` Houdini shelf to the quickinstall package with Start, Stop, Status, and Docs tools
- keep shelf actions lightweight with `wait_ready=False` startup and status-bar notifications instead of modal dialogs
- extend the package assembly test to assert the shelf is present and non-blocking controls are shipped

## Tests
- `python -m pytest -v --tb=short`
- `python -m pytest tests/test_packaging.py -m packaging -v --tb=short`
- `python -m ruff check src/ tests/ tools/ packaging/`
- `python -m ruff format --check src/ tests/ tools/ packaging/`
- `python tools/check_py37_syntax.py src tests tools packaging`
- `python -m build`
- `python packaging/assemble_houdini_package.py --platform win64 --dist-dir dist --output-dir dist_houdini`