### PR TITLE
Verify Houdini quickinstall core bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,25 +111,12 @@ jobs:
         run: python -m build
       - name: Assemble quickinstall ZIP
         run: python packaging/assemble_houdini_package.py --platform ${{ matrix.platform }} --dist-dir dist --output-dir dist_houdini
-      - name: Verify quickinstall ZIP
+      - name: Verify quickinstall version matrix
         env:
           PLATFORM: ${{ matrix.platform }}
         run: |
-          python - <<'PY'
-          import glob
-          import os
-          import zipfile
-
-          zips = sorted(glob.glob(f"dist_houdini/dcc_mcp_houdini_quickinstall_{os.environ['PLATFORM']}_v*.zip"))
-          assert zips, "quickinstall zip missing"
-          with zipfile.ZipFile(zips[-1]) as zf:
-              names = zf.namelist()
-          assert any(n.endswith("/scripts/123.py") for n in names), names[:40]
-          assert any(n.endswith("/scripts/dcc_mcp_houdini_bootstrap.py") for n in names), names[:40]
-          assert any(n.endswith("/packages/dcc_mcp_houdini.json.template") for n in names), names[:40]
-          assert any("/wheels/dcc_mcp_houdini-" in n and n.endswith(".whl") for n in names), names[:40]
-          assert any("/wheels/dcc_mcp_core-" in n and n.endswith(".whl") for n in names), names[:40]
-          PY
+          zip_path="$(ls dist_houdini/dcc_mcp_houdini_quickinstall_${PLATFORM}_v*.zip | tail -n 1)"
+          python packaging/assemble_houdini_package.py --platform "$PLATFORM" --verify-zip "$zip_path"
       - name: Upload quickinstall artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,12 @@ jobs:
         run: python -m build
       - name: Assemble quickinstall ZIP
         run: python packaging/assemble_houdini_package.py --platform ${{ matrix.platform }} --dist-dir dist --output-dir dist_houdini
+      - name: Verify quickinstall version matrix
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          zip_path="$(ls dist_houdini/dcc_mcp_houdini_quickinstall_${PLATFORM}_v*.zip | tail -n 1)"
+          python packaging/assemble_houdini_package.py --platform "$PLATFORM" --verify-zip "$zip_path"
       - name: Upload quickinstall artifact
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ dcc-mcp-houdini/
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
 - `dcc-mcp-core >= 0.19.9`
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.9,<1.0.0` at assembly time; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -151,6 +151,13 @@ def download_core_wheels(version: str, platform: str, dest_dir: Path) -> List[Pa
     return paths
 
 
+def _wheel_version(filename: str, distribution: str) -> Optional[str]:
+    match = re.match(r"^{}-(?P<version>[^-]+)-.+\.whl$".format(re.escape(distribution)), filename)
+    if not match:
+        return None
+    return match.group("version")
+
+
 def find_adapter_wheel(dist_dir: Path, version: str) -> Path:
     wheels = sorted(dist_dir.glob("dcc_mcp_houdini-{}-*.whl".format(version)))
     if not wheels:
@@ -310,6 +317,8 @@ def _readme(version: str, core_version: str, platform: str) -> str:
 Version: {version}
 dcc-mcp-core wheels: {core_version}
 Platform: {platform}
+Core bundle policy: latest non-prerelease dcc-mcp-core >= {min_core_version},<1.0.0 at assembly time.
+Old-core pin: none.
 
 Install on Windows:
   powershell -ExecutionPolicy Bypass -File install.ps1 -HoudiniVersion 20.5
@@ -324,7 +333,82 @@ scripts/123.py extracts bundled wheels into vendor/ and starts the MCP server.
 
 Disable autostart by setting DCC_MCP_HOUDINI_AUTOSTART=0.
 MCP URL defaults to http://127.0.0.1:8765/mcp.
-""".format(version=version, core_version=core_version, platform=platform)
+""".format(version=version, core_version=core_version, platform=platform, min_core_version=MIN_CORE_VERSION)
+
+
+def verify_quickinstall_zip(
+    zip_path: Path,
+    platform: str,
+    expected_core_version: Optional[str] = None,
+) -> Dict[str, object]:
+    if platform not in PLATFORMS:
+        raise ValueError("Unsupported platform {!r}; expected {}".format(platform, ", ".join(PLATFORMS)))
+    if expected_core_version is None:
+        expected_core_version = resolve_core_version()
+
+    adapter_version = get_package_version()
+    with zipfile.ZipFile(str(zip_path)) as zf:
+        names = zf.namelist()
+
+    required_suffixes = [
+        "/scripts/123.py",
+        "/scripts/dcc_mcp_houdini_bootstrap.py",
+        "/packages/dcc_mcp_houdini.json.template",
+        "/README.txt",
+    ]
+    for suffix in required_suffixes:
+        if not any(name.endswith(suffix) for name in names):
+            raise RuntimeError("quickinstall zip missing {}".format(suffix))
+
+    wheel_names = [Path(name).name for name in names if "/wheels/" in name and name.endswith(".whl")]
+    adapter_wheels = [name for name in wheel_names if _wheel_version(name, "dcc_mcp_houdini")]
+    core_wheels = [name for name in wheel_names if _wheel_version(name, "dcc_mcp_core")]
+    if not adapter_wheels:
+        raise RuntimeError("quickinstall zip missing dcc-mcp-houdini wheel")
+    if not core_wheels:
+        raise RuntimeError("quickinstall zip missing dcc-mcp-core wheel")
+
+    adapter_versions = sorted({str(_wheel_version(name, "dcc_mcp_houdini")) for name in adapter_wheels})
+    core_versions = sorted({str(_wheel_version(name, "dcc_mcp_core")) for name in core_wheels})
+    if adapter_versions != [adapter_version]:
+        raise RuntimeError(
+            "Adapter wheel drift: expected dcc-mcp-houdini {}, found {}".format(
+                adapter_version,
+                ", ".join(adapter_versions),
+            )
+        )
+    if core_versions != [expected_core_version]:
+        raise RuntimeError(
+            "Bundled core drift: expected dcc-mcp-core {}, found {}".format(
+                expected_core_version,
+                ", ".join(core_versions),
+            )
+        )
+
+    wrong_platform = [name for name in core_wheels if not _wheel_matches_platform(name, platform)]
+    if wrong_platform:
+        raise RuntimeError("Core wheels do not match platform {}: {}".format(platform, ", ".join(wrong_platform)))
+
+    return {
+        "platform": platform,
+        "adapter": adapter_version,
+        "core": expected_core_version,
+        "server": adapter_version,
+        "cli": adapter_version,
+        "core_wheels": sorted(core_wheels),
+    }
+
+
+def print_version_matrix(matrix: Dict[str, object]) -> None:
+    print("Quickinstall version matrix:")
+    print("  platform: {}".format(matrix["platform"]))
+    print("  adapter: dcc-mcp-houdini {}".format(matrix["adapter"]))
+    print("  core: dcc-mcp-core {}".format(matrix["core"]))
+    print("  server: dcc-mcp-houdini {}".format(matrix["server"]))
+    print("  CLI: dcc-mcp-houdini {}".format(matrix["cli"]))
+    print("  core wheels:")
+    for wheel in matrix["core_wheels"]:
+        print("    - {}".format(wheel))
 
 
 def assemble(platform: str, dist_dir: Path, output_dir: Path) -> Path:
@@ -375,7 +459,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--platform", choices=PLATFORMS, required=True)
     parser.add_argument("--dist-dir", type=Path, default=PACKAGE_ROOT / "dist")
     parser.add_argument("--output-dir", type=Path, default=PACKAGE_ROOT / "dist_houdini")
+    parser.add_argument(
+        "--verify-zip", type=Path, help="Verify an existing quickinstall ZIP and print its version matrix."
+    )
+    parser.add_argument(
+        "--expected-core-version", help="Expected bundled dcc-mcp-core version; defaults to latest compatible."
+    )
     args = parser.parse_args(argv)
+
+    if args.verify_zip is not None:
+        matrix = verify_quickinstall_zip(args.verify_zip, args.platform, args.expected_core_version)
+        print_version_matrix(matrix)
+        return 0
 
     zip_path = assemble(args.platform, args.dist_dir, args.output_dir)
     print("Created {}".format(zip_path))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -20,6 +20,16 @@ def _load_packaging_script():
     return module
 
 
+def _write_quickinstall_zip(zip_path: Path, *wheel_names: str) -> None:
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("dcc_mcp_houdini/scripts/123.py", "")
+        zf.writestr("dcc_mcp_houdini/scripts/dcc_mcp_houdini_bootstrap.py", "")
+        zf.writestr("dcc_mcp_houdini/packages/dcc_mcp_houdini.json.template", "")
+        zf.writestr("dcc_mcp_houdini/README.txt", "")
+        for wheel_name in wheel_names:
+            zf.writestr("dcc_mcp_houdini/wheels/{}".format(wheel_name), "")
+
+
 @pytest.mark.packaging
 def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     pkg = _load_packaging_script()
@@ -52,6 +62,38 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     assert "dcc_mcp_houdini/packages/dcc_mcp_houdini.json.template" in names
     assert "dcc_mcp_houdini/install.ps1" in names
     assert "dcc_mcp_houdini/install.sh" in names
+
+
+def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
+    pkg = _load_packaging_script()
+
+    zip_path = tmp_path / "dcc_mcp_houdini_quickinstall_win64_v0.10.1.zip"
+    _write_quickinstall_zip(
+        zip_path,
+        "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
+        "dcc_mcp_core-0.19.7-cp38-abi3-win_amd64.whl",
+    )
+
+    with pytest.raises(RuntimeError, match="Bundled core drift"):
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
+
+
+def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
+    pkg = _load_packaging_script()
+
+    zip_path = tmp_path / "dcc_mcp_houdini_quickinstall_win64_v0.10.1.zip"
+    _write_quickinstall_zip(
+        zip_path,
+        "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
+        "dcc_mcp_core-0.19.15-cp38-abi3-win_amd64.whl",
+    )
+
+    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
+
+    assert matrix["adapter"] == pkg.get_package_version()
+    assert matrix["core"] == "0.19.15"
+    assert matrix["server"] == pkg.get_package_version()
+    assert matrix["cli"] == pkg.get_package_version()
 
 
 def test_pick_core_wheels_includes_py37_and_abi3_for_platform() -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -14,6 +14,11 @@ def _release_workflow() -> dict:
     return yaml.load(text, Loader=yaml.BaseLoader)
 
 
+def _ci_workflow() -> dict:
+    text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    return yaml.load(text, Loader=yaml.BaseLoader)
+
+
 def test_release_workflow_can_backfill_pypi_for_existing_tag() -> None:
     workflow = _release_workflow()
 
@@ -41,3 +46,11 @@ def test_release_please_updates_runtime_version_file() -> None:
 
     assert "src/dcc_mcp_houdini/__version__.py" in extra_files
     assert "x-release-please-version" in version_file.read_text(encoding="utf-8")
+
+
+def test_quickinstall_jobs_verify_version_matrix() -> None:
+    for workflow in (_ci_workflow(), _release_workflow()):
+        steps = workflow["jobs"]["quickinstall"]["steps"]
+        verify_steps = [step for step in steps if step.get("name") == "Verify quickinstall version matrix"]
+        assert verify_steps, "quickinstall job should verify artifact version matrix"
+        assert "--verify-zip" in verify_steps[0]["run"]


### PR DESCRIPTION
## Summary
- Add a reusable quickinstall ZIP verifier that checks adapter/core wheel versions and prints an adapter/core/server/CLI matrix.
- Run the verifier in both CI and release quickinstall jobs before artifacts are uploaded.
- Document the quickinstall core bundle policy and current no old-core-pin status.

## Tests
- `python -m pytest`
- `python -m pytest tests/test_packaging.py -m packaging -o addopts=`
- `python tools/check_py37_syntax.py src tests tools packaging`
- `ruff check packaging/ tests/test_packaging.py tests/test_release_workflow.py`
- `ruff format --check packaging/ tests/test_packaging.py tests/test_release_workflow.py`
- Built and verified a local win64 quickinstall ZIP; matrix reported bundled `dcc-mcp-core 0.19.15`.
