### PR TITLE
fix: allow validated core pin for Houdini quickinstall

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: boolean
         default: false
+      core_version:
+        description: "Validated dcc-mcp-core version to bundle in quickinstall assets. Leave empty to resolve latest compatible from PyPI."
+        required: false
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}${{ inputs.tag_name && format('-{0}', inputs.tag_name) || '' }}
@@ -139,13 +143,25 @@ jobs:
       - name: Build wheel
         run: python -m build
       - name: Assemble quickinstall ZIP
-        run: python packaging/assemble_houdini_package.py --platform ${{ matrix.platform }} --dist-dir dist --output-dir dist_houdini
+        env:
+          CORE_VERSION: ${{ inputs.core_version }}
+        run: |
+          args=()
+          if [ -n "$CORE_VERSION" ]; then
+            args+=(--core-version "$CORE_VERSION")
+          fi
+          python packaging/assemble_houdini_package.py --platform ${{ matrix.platform }} --dist-dir dist --output-dir dist_houdini "${args[@]}"
       - name: Verify quickinstall version matrix
         env:
           PLATFORM: ${{ matrix.platform }}
+          CORE_VERSION: ${{ inputs.core_version }}
         run: |
           zip_path="$(ls dist_houdini/dcc_mcp_houdini_quickinstall_${PLATFORM}_v*.zip | tail -n 1)"
-          python packaging/assemble_houdini_package.py --platform "$PLATFORM" --verify-zip "$zip_path"
+          args=(--platform "$PLATFORM" --verify-zip "$zip_path")
+          if [ -n "$CORE_VERSION" ]; then
+            args+=(--expected-core-version "$CORE_VERSION")
+          fi
+          python packaging/assemble_houdini_package.py "${args[@]}"
       - name: Upload quickinstall artifact
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ dcc-mcp-houdini/
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
 - `dcc-mcp-core >= 0.19.9`
-- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.9,<1.0.0` at assembly time; no old-core pin is active.
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.9,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -85,6 +85,25 @@ def resolve_core_version(min_version: str = MIN_CORE_VERSION) -> str:
     return str(sorted(compatible)[-1])
 
 
+def validate_core_version(version: str, min_version: str = MIN_CORE_VERSION) -> str:
+    parsed = Version(version)
+    if parsed.is_prerelease or parsed < Version(min_version) or parsed >= Version("1.0.0"):
+        raise RuntimeError(
+            "Requested {} version {!r} is outside the supported range >= {},<1.0.0".format(
+                CORE_PACKAGE,
+                version,
+                min_version,
+            )
+        )
+    return str(parsed)
+
+
+def select_core_version(core_version: Optional[str] = None) -> str:
+    if core_version:
+        return validate_core_version(core_version)
+    return resolve_core_version()
+
+
 def _wheel_matches_platform(filename: str, platform: str) -> bool:
     if not filename.endswith(".whl"):
         return False
@@ -396,14 +415,18 @@ echo "Start Houdini $HOUDINI_VERSION; MCP defaults to http://127.0.0.1:8765/mcp"
 """
 
 
-def _readme(version: str, core_version: str, platform: str) -> str:
+def _readme(version: str, core_version: str, platform: str, explicit_core_version: bool = False) -> str:
+    if explicit_core_version:
+        core_policy = "explicit validated dcc-mcp-core {}.".format(core_version)
+    else:
+        core_policy = "latest non-prerelease dcc-mcp-core >= {},<1.0.0 at assembly time.".format(MIN_CORE_VERSION)
     return """dcc-mcp-houdini quick install package
 ======================================
 
 Version: {version}
 dcc-mcp-core wheels: {core_version}
 Platform: {platform}
-Core bundle policy: latest non-prerelease dcc-mcp-core >= {min_core_version},<1.0.0 at assembly time.
+Core bundle policy: {core_policy}
 Old-core pin: none.
 
 Install on Windows:
@@ -420,7 +443,7 @@ The DCC-MCP shelf is loaded from toolbar/DCC-MCP.shelf.
 
 Disable autostart by setting DCC_MCP_HOUDINI_AUTOSTART=0.
 MCP URL defaults to http://127.0.0.1:8765/mcp.
-""".format(version=version, core_version=core_version, platform=platform, min_core_version=MIN_CORE_VERSION)
+""".format(version=version, core_version=core_version, platform=platform, core_policy=core_policy)
 
 
 def verify_quickinstall_zip(
@@ -431,7 +454,9 @@ def verify_quickinstall_zip(
     if platform not in PLATFORMS:
         raise ValueError("Unsupported platform {!r}; expected {}".format(platform, ", ".join(PLATFORMS)))
     if expected_core_version is None:
-        expected_core_version = resolve_core_version()
+        expected_core_version = select_core_version()
+    else:
+        expected_core_version = validate_core_version(expected_core_version)
 
     adapter_version = get_package_version()
     with zipfile.ZipFile(str(zip_path)) as zf:
@@ -498,13 +523,14 @@ def print_version_matrix(matrix: Dict[str, object]) -> None:
         print("    - {}".format(wheel))
 
 
-def assemble(platform: str, dist_dir: Path, output_dir: Path) -> Path:
+def assemble(platform: str, dist_dir: Path, output_dir: Path, core_version: Optional[str] = None) -> Path:
     if platform not in PLATFORMS:
         raise ValueError("Unsupported platform {!r}; expected {}".format(platform, ", ".join(PLATFORMS)))
     assert_versions_aligned()
     version = get_package_version()
     adapter_wheel = find_adapter_wheel(dist_dir, version)
-    core_version = resolve_core_version()
+    explicit_core_version = core_version is not None
+    core_version = select_core_version(core_version)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     zip_path = output_dir / "dcc_mcp_houdini_quickinstall_{}_v{}.zip".format(platform, version)
@@ -533,7 +559,10 @@ def assemble(platform: str, dist_dir: Path, output_dir: Path) -> Path:
         install_sh = root / "install.sh"
         install_sh.write_text(_install_sh(), encoding="utf-8")
         install_sh.chmod(0o755)
-        (root / "README.txt").write_text(_readme(version, core_version, platform), encoding="utf-8")
+        (root / "README.txt").write_text(
+            _readme(version, core_version, platform, explicit_core_version),
+            encoding="utf-8",
+        )
 
         if zip_path.exists():
             zip_path.unlink()
@@ -555,14 +584,19 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--expected-core-version", help="Expected bundled dcc-mcp-core version; defaults to latest compatible."
     )
+    parser.add_argument(
+        "--core-version", help="Bundle this validated dcc-mcp-core version instead of resolving latest."
+    )
     args = parser.parse_args(argv)
 
     if args.verify_zip is not None:
-        matrix = verify_quickinstall_zip(args.verify_zip, args.platform, args.expected_core_version)
+        matrix = verify_quickinstall_zip(
+            args.verify_zip, args.platform, args.expected_core_version or args.core_version
+        )
         print_version_matrix(matrix)
         return 0
 
-    zip_path = assemble(args.platform, args.dist_dir, args.output_dir)
+    zip_path = assemble(args.platform, args.dist_dir, args.output_dir, args.core_version)
     print("Created {}".format(zip_path))
     return 0
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -80,6 +80,42 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     assert "displayMessage" not in shelf_xml
 
 
+@pytest.mark.packaging
+def test_assemble_houdini_package_can_pin_validated_core(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pkg = _load_packaging_script()
+
+    version = pkg.get_package_version()
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
+    adapter_wheel.write_bytes(b"adapter")
+    core_wheel = tmp_path / "dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"
+    core_wheel.write_bytes(b"core")
+
+    def fail_resolve(min_version=pkg.MIN_CORE_VERSION):
+        raise AssertionError("explicit core version should skip PyPI latest resolution")
+
+    def download_core_wheels(version_arg, platform, dest_dir):
+        assert version_arg == "0.19.17"
+        assert platform == "win64"
+        return [core_wheel]
+
+    monkeypatch.setattr(pkg, "resolve_core_version", fail_resolve)
+    monkeypatch.setattr(pkg, "download_core_wheels", download_core_wheels)
+
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.17")
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        readme = zf.read("dcc_mcp_houdini/README.txt").decode("utf-8")
+    assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
+    assert "dcc-mcp-core wheels: 0.19.17" in readme
+    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.17." in readme
+
+
 def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
     pkg = _load_packaging_script()
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -54,3 +54,18 @@ def test_quickinstall_jobs_verify_version_matrix() -> None:
         verify_steps = [step for step in steps if step.get("name") == "Verify quickinstall version matrix"]
         assert verify_steps, "quickinstall job should verify artifact version matrix"
         assert "--verify-zip" in verify_steps[0]["run"]
+
+
+def test_release_quickinstall_can_pin_validated_core_version() -> None:
+    workflow = _release_workflow()
+
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert inputs["core_version"]["default"] == ""
+
+    steps = workflow["jobs"]["quickinstall"]["steps"]
+    assemble_steps = [step for step in steps if step.get("name") == "Assemble quickinstall ZIP"]
+    verify_steps = [step for step in steps if step.get("name") == "Verify quickinstall version matrix"]
+    assert assemble_steps, "quickinstall job should assemble release artifacts"
+    assert verify_steps, "quickinstall job should verify release artifacts"
+    assert "--core-version" in assemble_steps[0]["run"]
+    assert "--expected-core-version" in verify_steps[0]["run"]


### PR DESCRIPTION
## Summary

- Add `--core-version` to quickinstall assembly so release backfills can bundle a validated core instead of whatever PyPI resolves at that moment.
- Wire `workflow_dispatch.core_version` into release quickinstall assembly and version-matrix verification.
- Update README policy text and tests for the explicit-core path.

## Validation

- `python -m pytest tests/test_packaging.py tests/test_release_workflow.py -m "packaging or not packaging"`
- `python tools/check_py37_syntax.py packaging/assemble_houdini_package.py tests/test_packaging.py tests/test_release_workflow.py`
- `python -m pytest tests/test_version_consistency.py`
- `python -m build`
- `python packaging/assemble_houdini_package.py --platform win64 --dist-dir dist --output-dir ../artifacts/houdini-core-0.19.17 --core-version 0.19.17`
- `python packaging/assemble_houdini_package.py --platform win64 --verify-zip ../artifacts/houdini-core-0.19.17/dcc_mcp_houdini_quickinstall_win64_v0.11.0.zip --expected-core-version 0.19.17`
- `python -m pytest`

## Artifact Check

- Built `dcc_mcp_houdini_quickinstall_win64_v0.11.0.zip` locally with SHA256 `49E183B471D1772C4D48487622A231D6011EEFAEF1E590BE1D3D3B4C778CCAE1`.
- `README.txt` reports `dcc-mcp-core wheels: 0.19.17` and `Core bundle policy: explicit validated dcc-mcp-core 0.19.17.`
- `wheels/` includes `dcc_mcp_core-0.19.17-cp37-cp37m-win_amd64.whl`, `dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl`, and `dcc_mcp_houdini-0.11.0-py3-none-any.whl`.
