### PR TITLE
Keep Houdini registry registration enabled

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -255,7 +255,13 @@ def bootstrap_and_start() -> object:
     port = int(os.environ.get("DCC_MCP_HOUDINI_PORT", "8765"))
     gateway_raw = os.environ.get("DCC_MCP_GATEWAY_PORT")
     gateway_port = int(gateway_raw) if gateway_raw and gateway_raw.isdigit() else None
-    return dcc_mcp_houdini.start_server(port=port, gateway_port=gateway_port, wait_ready=False)
+    registry_dir = os.environ.get("DCC_MCP_REGISTRY_DIR") or None
+    return dcc_mcp_houdini.start_server(
+        port=port,
+        gateway_port=gateway_port,
+        registry_dir=registry_dir,
+        wait_ready=False,
+    )
 '''
 
 

--- a/src/dcc_mcp_houdini/server.py
+++ b/src/dcc_mcp_houdini/server.py
@@ -177,9 +177,10 @@ class HoudiniMcpServer(DccServerBase):
             except Exception as exc:  # noqa: BLE001
                 logger.warning("[%s] Workflow enable failed: %s", _DCC_NAME, exc)
 
-        if options.gateway_port == 0 or (
-            options.gateway_port is None and not _env.resolve_enable_gateway_failover(options.enable_gateway_failover)
-        ):
+        # FileRegistry self-registration is controlled by gateway_port in core.
+        # Keep explicit gateway_port=0 as the opt-out, but do not let the
+        # failover flag suppress registration for live discovery.
+        if options.gateway_port == 0:
             self._config.gateway_port = 0
 
         from dcc_mcp_houdini._readiness import install_readiness

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -42,6 +42,31 @@ def test_server_options_to_core() -> None:
     assert core_opts.port == 9000
 
 
+def test_file_registry_registration_survives_disabled_failover(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabling failover must not disable FileRegistry self-registration."""
+    monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "19876")
+
+    from dcc_mcp_houdini.server import HoudiniMcpServer
+
+    server = HoudiniMcpServer(port=0, enable_gateway_failover=False, job_storage_path="")
+    try:
+        assert server._enable_gateway_failover is False
+        assert server._config.gateway_port == 19876
+    finally:
+        server.stop()
+
+
+def test_explicit_zero_gateway_port_disables_registration() -> None:
+    """gateway_port=0 remains the explicit opt-out for FileRegistry registration."""
+    from dcc_mcp_houdini.server import HoudiniMcpServer
+
+    server = HoudiniMcpServer(port=0, gateway_port=0, enable_gateway_failover=False, job_storage_path="")
+    try:
+        assert server._config.gateway_port == 0
+    finally:
+        server.stop()
+
+
 @pytest.mark.skip(reason="Requires Houdini environment")
 def test_server_creation() -> None:
     """Test HoudiniMcpServer creation (requires Houdini)."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -56,6 +56,7 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
         shelf_xml = zf.read("dcc_mcp_houdini/toolbar/DCC-MCP.shelf").decode("utf-8")
+        bootstrap = zf.read("dcc_mcp_houdini/scripts/dcc_mcp_houdini_bootstrap.py").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(adapter_wheel.name) in names
     for core_wheel in core_wheels:
         assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
@@ -75,6 +76,8 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
         "dcc_mcp_houdini_docs",
     }
     assert "wait_ready=False" in shelf_xml
+    assert 'os.environ.get("DCC_MCP_REGISTRY_DIR")' in bootstrap
+    assert "registry_dir=registry_dir" in bootstrap
     assert "get_server" in shelf_xml
     assert "setStatusMessage" in shelf_xml
     assert "displayMessage" not in shelf_xml


### PR DESCRIPTION
## Summary
- Keep FileRegistry self-registration enabled when Houdini gateway failover is disabled; explicit `gateway_port=0` remains the opt-out.
- Pass `DCC_MCP_REGISTRY_DIR` through the quick-install bootstrap when starting Houdini MCP.
- Add regression coverage for failover-disabled registration and package bootstrap wiring.

## Tests
- `python -m pytest tests/test_basic.py tests/test_packaging.py -m "not e2e and not integration" -q`
- `python -m ruff check src/dcc_mcp_houdini/server.py packaging/assemble_houdini_package.py tests/test_basic.py tests/test_packaging.py`
- Local smoke: start `HoudiniMcpServer` with `DCC_MCP_HOUDINI_ENABLE_GATEWAY_FAILOVER=0`, `DCC_MCP_GATEWAY_PORT`, and `DCC_MCP_REGISTRY_DIR`; verified FileRegistry contains `houdini` and gateway `/instances` reports `total=1`.
