### PR TITLE
Fix Houdini standalone main-thread execution

### DIFF
--- a/src/dcc_mcp_houdini/_readiness.py
+++ b/src/dcc_mcp_houdini/_readiness.py
@@ -95,7 +95,13 @@ class ReadinessBinder:
 
         server._server.set_readiness_probe(self.probe)
         self.published_to_server = True
-        self.mark_dispatcher_ready()
+        bridge = getattr(server, "_execution_bridge", None)
+        host_dispatcher = bridge.resolve_host_dispatcher() if bridge is not None else None
+        execution_ready = host_dispatcher is not None
+        self.mark_dispatcher_ready(
+            host_execution_bridge_ready=execution_ready,
+            main_thread_executor_ready=execution_ready,
+        )
 
         dispatcher = getattr(server, "_houdini_dispatcher", None)
         if dispatcher is None:
@@ -108,9 +114,19 @@ class ReadinessBinder:
         self.dcc_scheduled = bool(self.probe_scheduler(dispatcher, self.mark_dcc_ready))
         return self.dcc_scheduled
 
-    def mark_dispatcher_ready(self, value: bool = True) -> None:
+    def mark_dispatcher_ready(
+        self,
+        value: bool = True,
+        *,
+        host_execution_bridge_ready: Optional[bool] = None,
+        main_thread_executor_ready: Optional[bool] = None,
+    ) -> None:
         """Flip the ``dispatcher`` bit."""
         self.probe.set_dispatcher_ready(value)
+        if host_execution_bridge_ready is not None:
+            self.probe.set_host_execution_bridge_ready(host_execution_bridge_ready)
+        if main_thread_executor_ready is not None:
+            self.probe.set_main_thread_executor_ready(main_thread_executor_ready)
 
     def mark_dcc_ready(self, value: bool = True) -> None:
         """Flip the ``dcc`` bit."""

--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -67,7 +67,7 @@ def build_minimal_mode_config(
 ) -> MinimalModeConfig:
     """Build the default Houdini minimal-mode descriptor."""
     skills = tuple(skill_names) if skill_names is not None else MINIMAL_SKILLS
-    return MinimalModeConfig(skills=skills, deactivate_groups=())
+    return MinimalModeConfig(skills=skills, deactivate_groups={})
 
 
 def build_minimal_mode_for_stages(stages: Iterable[str]) -> MinimalModeConfig:
@@ -83,4 +83,4 @@ def build_minimal_mode_for_stages(stages: Iterable[str]) -> MinimalModeConfig:
     for skill in STAGE_SKILLS.get("bootstrap", ()):
         if skill not in seen:
             names.insert(0, skill)
-    return MinimalModeConfig(skills=tuple(names), deactivate_groups=())
+    return MinimalModeConfig(skills=tuple(names), deactivate_groups={})

--- a/src/dcc_mcp_houdini/dispatcher/__init__.py
+++ b/src/dcc_mcp_houdini/dispatcher/__init__.py
@@ -17,21 +17,21 @@ def create_execution_stack():
     """Create the dispatcher + optional host adapter for the current environment.
 
     Returns:
-        ``(dispatcher, host)`` where *host* is a started :class:`HoudiniHost`
-        in interactive mode, or ``None`` in headless ``hython``.
+        ``(dispatcher, host)`` where *host* is a started :class:`HoudiniHost`.
+        Interactive Houdini uses its UI event loop; headless ``hython`` uses
+        the host adapter's blocking queue pump.
     """
     try:
         import hou  # noqa: PLC0415
 
-        if hou.isUIAvailable():
-            from dcc_mcp_core.host import BlockingDispatcher
-
-            blocking = BlockingDispatcher()
-            dispatcher = HoudiniCallableDispatcher(blocking)
-            host = HoudiniHost(blocking)
-            host.start()
-            return dispatcher, host
+        _ = hou.isUIAvailable()
     except ImportError:
         pass
 
-    return HoudiniStandaloneDispatcher(), None
+    from dcc_mcp_core.host import BlockingDispatcher
+
+    blocking = BlockingDispatcher()
+    dispatcher = HoudiniCallableDispatcher(blocking)
+    host = HoudiniHost(blocking)
+    host.start()
+    return dispatcher, host

--- a/src/dcc_mcp_houdini/host.py
+++ b/src/dcc_mcp_houdini/host.py
@@ -60,6 +60,26 @@ class HoudiniCallableDispatcher:
         return bool(self._dispatcher.is_shutdown())
 
 
+class HoudiniInlineCallableDispatcher:
+    """Execute after the HTTP layer has already hopped to the host queue."""
+
+    def dispatch_callable(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        affinity: str = "main",
+        context: Any = None,
+        action_name: str = "",
+        skill_name: Optional[str] = None,
+        execution: str = "sync",
+        timeout_hint_secs: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run inline without posting a second job to the same queue."""
+        _ = (affinity, context, action_name, skill_name, execution, timeout_hint_secs)
+        return func(*args, **kwargs)
+
+
 class HoudiniHost(HostAdapter):
     """Drive a dcc-mcp-core dispatcher from Houdini's main thread.
 

--- a/src/dcc_mcp_houdini/server.py
+++ b/src/dcc_mcp_houdini/server.py
@@ -79,8 +79,13 @@ class HoudiniServerOptions:
         execution_bridge = self.execution_bridge
         if execution_bridge is None and dispatcher is not None:
             host_dispatcher = _host_dispatcher_from(dispatcher)
+            bridge_dispatcher = dispatcher
+            if host_dispatcher is not None:
+                from dcc_mcp_houdini.host import HoudiniInlineCallableDispatcher
+
+                bridge_dispatcher = HoudiniInlineCallableDispatcher()
             execution_bridge = HostExecutionBridge(
-                dispatcher=dispatcher,
+                dispatcher=bridge_dispatcher,
                 host_dispatcher=host_dispatcher,
                 default_thread_affinity="main",
             )

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/save_hip_file.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/save_hip_file.py
@@ -31,7 +31,7 @@ def save_hip_file(file_path: Optional[str] = None) -> dict:
             hou.hipFile.save(file_name=resolved)
         else:
             hou.hipFile.save()
-            resolved = hou.hipFile.name() if hou.hipFile.hasFile() else None
+            resolved = hou.hipFile.name() if not hou.hipFile.isNewFile() else None
         return skill_success("Saved Houdini hip file", hip_file=resolved)
     except Exception as exc:
         return skill_exception(exc, message="Failed to save Houdini hip file")

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/save_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/save_scene.py
@@ -22,7 +22,7 @@ def save_scene(file_path: Optional[str] = None) -> dict:
         if file_path:
             hou.hipFile.save(file_name=file_path)
         else:
-            if not hou.hipFile.hasFile():
+            if hou.hipFile.isNewFile():
                 return skill_error(
                     "Scene has never been saved",
                     "No hip path is set; pass file_path to choose a destination",

--- a/src/dcc_mcp_houdini/skills/houdini-scene/scripts/get_scene_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/scripts/get_scene_info.py
@@ -15,9 +15,9 @@ def get_scene_info() -> dict:
         playback = hou.playbar
         return skill_success(
             "Retrieved Houdini scene information",
-            hip_file=hou.hipFile.name() if hou.hipFile.hasFile() else None,
-            hip_has_file=bool(hou.hipFile.hasFile()),
-            frame=playback.frame(),
+            hip_file=hou.hipFile.name() if not hou.hipFile.isNewFile() else None,
+            hip_has_file=not hou.hipFile.isNewFile(),
+            frame=hou.frame(),
             start_frame=playback.playbackRange()[0],
             end_frame=playback.playbackRange()[1],
             obj_node_count=node_count,

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/scripts/get_session_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/scripts/get_session_info.py
@@ -19,7 +19,7 @@ def get_session_info() -> dict:
             "python_executable": sys.executable,
             "platform": sys.platform,
             "ui_available": bool(hou.isUIAvailable()),
-            "hip_file": hou.hipFile.name() if hou.hipFile.hasFile() else None,
+            "hip_file": hou.hipFile.name() if not hou.hipFile.isNewFile() else None,
         }
         return skill_success(
             "Houdini session info retrieved",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ def test_minimal_mode_config() -> None:
 
     cfg = build_minimal_mode_config()
     assert tuple(cfg.skills) == MINIMAL_SKILLS
+    assert cfg.deactivate_groups == {}
 
 
 def test_resolve_minimal_mode_default() -> None:
@@ -22,20 +23,30 @@ def test_resolve_minimal_mode_default() -> None:
 
 
 def test_houdini_server_options_port() -> None:
+    from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniInlineCallableDispatcher
     from dcc_mcp_houdini.server import HoudiniServerOptions
 
-    opts = HoudiniServerOptions(port=9001)
+    dispatcher = HoudiniCallableDispatcher()
+    opts = HoudiniServerOptions(port=9001, dispatcher=dispatcher)
     core = opts.to_core_options()
+    bridge = core.execution.mode.bridge
     assert core.port == 9001
+    assert isinstance(bridge.dispatcher, HoudiniInlineCallableDispatcher)
+    assert bridge.host_dispatcher is dispatcher.host_dispatcher
 
 
 def test_create_execution_stack_without_hou() -> None:
     from dcc_mcp_houdini.dispatcher import create_execution_stack
-    from dcc_mcp_houdini.dispatcher.standalone import HoudiniStandaloneDispatcher
+    from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
 
     dispatcher, host = create_execution_stack()
-    assert isinstance(dispatcher, HoudiniStandaloneDispatcher)
-    assert host is None
+    try:
+        assert isinstance(dispatcher, HoudiniCallableDispatcher)
+        assert isinstance(host, HoudiniHost)
+        assert host.is_running
+        assert dispatcher.host_dispatcher is not None
+    finally:
+        host.stop()
 
 
 def test_wait_until_ready_uses_urllib(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -90,7 +90,7 @@ class TestGetSessionInfoSkill:
         mock_hou.applicationVersion.return_value = (20, 5, 0)
         mock_hou.applicationVersionString.return_value = "20.5.0"
         mock_hou.isUIAvailable.return_value = True
-        mock_hou.hipFile.hasFile.return_value = True
+        mock_hou.hipFile.isNewFile.return_value = False
         mock_hou.hipFile.name.return_value = "/tmp/test.hip"
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
@@ -106,9 +106,9 @@ class TestGetSceneInfoSkill:
         mod = _load_script("houdini-scene", "get_scene_info.py")
         mock_hou = MagicMock()
         mock_hou.node.return_value = MagicMock(children=lambda: [1, 2, 3])
-        mock_hou.hipFile.hasFile.return_value = False
+        mock_hou.hipFile.isNewFile.return_value = True
         mock_hou.hipFile.name.return_value = ""
-        mock_hou.playbar.frame.return_value = 1
+        mock_hou.frame.return_value = 1
         mock_hou.playbar.playbackRange.return_value = (1, 240)
 
         with patch.dict(sys.modules, {"hou": mock_hou}):


### PR DESCRIPTION
## Summary
- attach the core host queue in interactive and headless Houdini
- avoid double dispatch inside the execution bridge
- publish accurate execution readiness
- use supported Houdini 20.5 scene APIs

## Tests
- 83 focused adapter tests
- live standalone and GUI MCP/REST calls