### PR TITLE
fix: silence Houdini HTTP logs

### DIFF
--- a/src/dcc_mcp_houdini/_env.py
+++ b/src/dcc_mcp_houdini/_env.py
@@ -17,9 +17,7 @@ DEFAULT_CORE_LOG_LEVEL = "WARN"
 def configure_core_logging() -> None:
     """Keep dcc-mcp-core's default HTTP tracing out of Houdini's console."""
     log_level = (
-        os.environ.get(CORE_LOG_LEVEL_ENV)
-        or os.environ.get(LEGACY_CORE_LOG_LEVEL_ENV)
-        or DEFAULT_CORE_LOG_LEVEL
+        os.environ.get(CORE_LOG_LEVEL_ENV) or os.environ.get(LEGACY_CORE_LOG_LEVEL_ENV) or DEFAULT_CORE_LOG_LEVEL
     )
     os.environ.setdefault(CORE_LOG_LEVEL_ENV, log_level)
     os.environ.setdefault(LEGACY_CORE_LOG_LEVEL_ENV, log_level)

--- a/src/dcc_mcp_houdini/_env.py
+++ b/src/dcc_mcp_houdini/_env.py
@@ -9,6 +9,24 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+CORE_LOG_LEVEL_ENV = "DCC_MCP_LOG_LEVEL"
+LEGACY_CORE_LOG_LEVEL_ENV = "MCP_LOG_LEVEL"
+DEFAULT_CORE_LOG_LEVEL = "WARN"
+
+
+def configure_core_logging() -> None:
+    """Keep dcc-mcp-core's default HTTP tracing out of Houdini's console."""
+    log_level = (
+        os.environ.get(CORE_LOG_LEVEL_ENV)
+        or os.environ.get(LEGACY_CORE_LOG_LEVEL_ENV)
+        or DEFAULT_CORE_LOG_LEVEL
+    )
+    os.environ.setdefault(CORE_LOG_LEVEL_ENV, log_level)
+    os.environ.setdefault(LEGACY_CORE_LOG_LEVEL_ENV, log_level)
+
+
+configure_core_logging()
+
 ENV_METRICS = "DCC_MCP_HOUDINI_METRICS"
 ENV_JOB_STORAGE = "DCC_MCP_HOUDINI_JOB_STORAGE_PATH"
 ENV_ENABLE_WORKFLOWS = "DCC_MCP_HOUDINI_ENABLE_WORKFLOWS"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,27 @@ def test_minimal_mode_config() -> None:
     cfg = build_minimal_mode_config()
     assert tuple(cfg.skills) == MINIMAL_SKILLS
     assert cfg.deactivate_groups == {}
+
+
+def test_configure_core_logging_defaults_to_warn(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dcc_mcp_houdini._env import configure_core_logging
+
+    monkeypatch.delenv("MCP_LOG_LEVEL", raising=False)
+    configure_core_logging()
+
+    assert "WARN" == os.environ["MCP_LOG_LEVEL"]
+    assert "WARN" == os.environ["DCC_MCP_LOG_LEVEL"]
+
+
+def test_configure_core_logging_preserves_user_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    from dcc_mcp_houdini._env import configure_core_logging
+
+    monkeypatch.delenv("MCP_LOG_LEVEL", raising=False)
+    monkeypatch.setenv("DCC_MCP_LOG_LEVEL", "DEBUG")
+    configure_core_logging()
+
+    assert "DEBUG" == os.environ["DCC_MCP_LOG_LEVEL"]
+    assert "DEBUG" == os.environ["MCP_LOG_LEVEL"]
 
 
 def test_resolve_minimal_mode_default() -> None:


### PR DESCRIPTION
## Summary
- Default embedded core logging to `WARN` to suppress HTTP request noise in the Houdini Console.
- Use `DCC_MCP_LOG_LEVEL` as the public setting and bridge it to the legacy core variable during the transition.

## Validation
- `python -m pytest tests/test_server.py`
- `ruff check src/dcc_mcp_houdini/_env.py tests/test_server.py`