### PR TITLE
fix: enforce Husk render contracts

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_common.py
@@ -6,6 +6,28 @@ import os
 import shutil
 from typing import Any, Optional, Sequence
 
+_RENDERER_ALIASES = {
+    "karma": "BRAY_HdKarma",
+    "karma_cpu": "BRAY_HdKarma",
+    "karma_xpu": "BRAY_HdKarmaXPU",
+}
+
+
+def resolve_husk_renderer(renderer: str) -> str:
+    """Resolve user-facing renderer aliases to Hydra delegate identifiers."""
+    return _RENDERER_ALIASES.get(renderer.casefold(), renderer)
+
+
+def husk_subprocess_environment(base: Optional[dict] = None) -> dict:
+    """Return a child environment with Houdini's default search paths enabled."""
+    environment = dict(os.environ if base is None else base)
+    for name in ("HOUDINI_PATH", "HOUDINI_SCRIPT_PATH"):
+        parts = [part for part in environment.get(name, "").split(os.pathsep) if part]
+        if "&" not in parts:
+            parts.append("&")
+        environment[name] = os.pathsep.join(parts)
+    return environment
+
 
 def get_node(hou: Any, node_path: str) -> Any:
     """Return a Houdini node or raise a useful error."""
@@ -92,7 +114,7 @@ def build_husk_command(
     cmd = ["husk"]
 
     if renderer:
-        cmd.extend(["--renderer", renderer])
+        cmd.extend(["--renderer", resolve_husk_renderer(renderer)])
 
     if resolution and len(resolution) >= 2:
         cmd.extend(["--res", str(int(resolution[0])), str(int(resolution[1]))])

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/render_with_husk.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/render_with_husk.py
@@ -15,7 +15,13 @@ _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
-from _husk_common import build_husk_command, find_husk, find_hython  # noqa: E402
+from _husk_common import (  # noqa: E402
+    build_husk_command,
+    find_husk,
+    find_hython,
+    husk_subprocess_environment,
+    resolve_husk_renderer,
+)
 
 
 def render_with_husk(
@@ -80,6 +86,7 @@ def render_with_husk(
         )
 
     try:
+        resolved_renderer = resolve_husk_renderer(renderer)
         cmd = build_husk_command(
             usd_file=usd_file,
             output_path=output_path,
@@ -97,6 +104,7 @@ def render_with_husk(
             capture_output=True,
             text=True,
             timeout=3600,  # 1 hour timeout
+            env=husk_subprocess_environment(),
         )
         elapsed = round(time.time() - start, 3)
 
@@ -110,17 +118,30 @@ def render_with_husk(
             base, ext = os.path.splitext(output_path)
             written_files = sorted(glob.glob("{}.*{}".format(base, ext)))
 
+        context = {
+            "usd_file": usd_file,
+            "output_path": output_path,
+            "renderer": resolved_renderer,
+            "requested_renderer": renderer,
+            "elapsed_secs": elapsed,
+            "returncode": result.returncode,
+            "written_files": written_files,
+            "stdout": result.stdout[-2000:] if result.stdout else "",
+            "stderr": result.stderr[-2000:] if result.stderr else "",
+            "command": " ".join(cmd),
+        }
+        if result.returncode != 0:
+            details = context["stderr"] or context["stdout"] or f"husk exited with code {result.returncode}"
+            return skill_error(
+                "Husk render failed",
+                details,
+                prompt="Inspect the renderer delegate and Houdini search-path diagnostics.",
+                **context,
+            )
+
         return skill_success(
-            "Husk render completed" if result.returncode == 0 else "Husk render finished with errors",
-            usd_file=usd_file,
-            output_path=output_path,
-            renderer=renderer,
-            elapsed_secs=elapsed,
-            returncode=result.returncode,
-            written_files=written_files,
-            stdout=result.stdout[-2000:] if result.stdout else "",
-            stderr=result.stderr[-2000:] if result.stderr else "",
-            command=" ".join(cmd),
+            "Husk render completed",
+            **context,
         )
     except subprocess.TimeoutExpired:
         elapsed = round(time.time() - start, 3)

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -1,0 +1,57 @@
+"""Unit coverage for native Husk command and result contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills" / "houdini-husk" / "scripts"
+
+
+def _load_script(filename: str):
+    path = SCRIPTS / filename
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(f"husk_test_{path.stem}", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_husk_command_resolves_karma_alias() -> None:
+    common = _load_script("_husk_common.py")
+
+    command = common.build_husk_command("scene.usda", "beauty.exr", renderer="karma")
+
+    assert command[:3] == ["husk", "--renderer", "BRAY_HdKarma"]
+
+
+def test_husk_environment_restores_houdini_default_paths() -> None:
+    common = _load_script("_husk_common.py")
+    base = {"HOUDINI_PATH": "custom", "HOUDINI_SCRIPT_PATH": ""}
+
+    environment = common.husk_subprocess_environment(base)
+
+    assert environment["HOUDINI_PATH"].split(os.pathsep)[-1] == "&"
+    assert environment["HOUDINI_SCRIPT_PATH"].split(os.pathsep)[-1] == "&"
+    assert base == {"HOUDINI_PATH": "custom", "HOUDINI_SCRIPT_PATH": ""}
+
+
+def test_render_with_husk_returns_failure_for_nonzero_exit(tmp_path: Path) -> None:
+    render = _load_script("render_with_husk.py")
+    process = SimpleNamespace(returncode=1, stdout="", stderr="delegate failed")
+
+    with patch.object(render, "find_husk", return_value="husk"), patch.object(
+        render.subprocess, "run", return_value=process
+    ):
+        result = render.render_with_husk(str(tmp_path / "scene.usda"), str(tmp_path / "beauty.exr"))
+
+    assert result["success"] is False
+    assert result["context"]["returncode"] == 1
+    assert result["context"]["written_files"] == []
+    assert "delegate failed" in result["error"]


### PR DESCRIPTION
## Summary
- resolve Karma aliases to valid Hydra delegate identifiers
- restore default Houdini search paths for Husk subprocesses
- return a failure envelope for nonzero renderer exits

## Validation
- 409 passed, 1 skipped, 2 deselected
- ruff check and format check passed
- reproduced with a real Houdini 21 USD render