### PR TITLE
fix: forward explicit frame ranges to ROP renders

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -18,7 +18,7 @@ if _SCRIPT_DIR not in sys.path:
 from _background_render import launch_background_render  # noqa: E402
 from _render_common import eval_first_parm, expanded_outputs, get_node, node_summary, render_node  # noqa: E402
 
-_OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
+_OUTPUT_PARMS = ("picture", "vm_picture", "outputimage", "lopoutput", "sopoutput", "filename")
 
 
 def _expand_outputs(pattern: Optional[str]) -> list:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import glob
+import os
 import sys
 import time
 from pathlib import Path
@@ -14,9 +16,24 @@ if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
 from _background_render import launch_background_render  # noqa: E402
-from _render_common import eval_first_parm, expanded_outputs, get_node, node_summary, render_node  # noqa: E402
+from _render_common import apply_frame_range, eval_first_parm, get_node, node_summary  # noqa: E402
 
-_OUTPUT_PARMS = ("outputimage", "picture", "vm_picture", "sopoutput", "filename", "lopoutput")
+_OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
+
+
+def _expand_outputs(pattern: Optional[str]) -> list:
+    if not pattern:
+        return []
+    if isinstance(pattern, (list, tuple)):
+        pattern = pattern[0] if len(pattern) == 1 else None
+    if not pattern:
+        return []
+    globbed = pattern
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        globbed = globbed.replace(token, "*")
+    if "*" in globbed:
+        return sorted(glob.glob(globbed))
+    return [pattern] if os.path.isfile(pattern) else []
 
 
 def render_rop(
@@ -55,12 +72,21 @@ def render_rop(
         warnings: List[str] = []
         start = time.time()
         rendered = True
+        render_kwargs = {}
+        if frame_range:
+            render_kwargs["frame_range"] = (
+                float(frame_range[0]),
+                float(frame_range[1]),
+                float(frame_range[2]) if len(frame_range) > 2 else 1.0,
+            )
+        applied_range = apply_frame_range(rop, frame_range) if frame_range else None
         try:
-            applied_range, execution_mode = render_node(rop, frame_range)
+            rop.render(verbose=False, **render_kwargs)
+        except TypeError:
+            rop.render(**render_kwargs)
         except Exception as render_exc:  # noqa: BLE001
             rendered = False
             applied_range = None
-            execution_mode = None
             errors.append("Render failed: {}".format(render_exc))
         elapsed = round(time.time() - start, 3)
         rop_errors = getattr(rop, "errors", None)
@@ -69,12 +95,11 @@ def render_rop(
         rop_warnings = getattr(rop, "warnings", None)
         if callable(rop_warnings):
             warnings.extend(str(warning) for warning in rop_warnings())
-        written = expanded_outputs(output_pattern)
+        written = _expand_outputs(output_pattern)
         return skill_success(
             "Rendered ROP",
             rop=node_summary(rop),
             rendered=rendered,
-            execution_mode=execution_mode,
             elapsed_secs=elapsed,
             frame_range=applied_range,
             output_pattern=output_pattern,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -16,7 +16,7 @@ if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
 from _background_render import launch_background_render  # noqa: E402
-from _render_common import apply_frame_range, eval_first_parm, get_node, node_summary  # noqa: E402
+from _render_common import eval_first_parm, expanded_outputs, get_node, node_summary, render_node  # noqa: E402
 
 _OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
 
@@ -72,21 +72,12 @@ def render_rop(
         warnings: List[str] = []
         start = time.time()
         rendered = True
-        render_kwargs = {}
-        if frame_range:
-            render_kwargs["frame_range"] = (
-                float(frame_range[0]),
-                float(frame_range[1]),
-                float(frame_range[2]) if len(frame_range) > 2 else 1.0,
-            )
-        applied_range = apply_frame_range(rop, frame_range) if frame_range else None
         try:
-            rop.render(verbose=False, **render_kwargs)
-        except TypeError:
-            rop.render(**render_kwargs)
+            applied_range, execution_mode = render_node(rop, frame_range)
         except Exception as render_exc:  # noqa: BLE001
             rendered = False
             applied_range = None
+            execution_mode = None
             errors.append("Render failed: {}".format(render_exc))
         elapsed = round(time.time() - start, 3)
         rop_errors = getattr(rop, "errors", None)
@@ -95,11 +86,12 @@ def render_rop(
         rop_warnings = getattr(rop, "warnings", None)
         if callable(rop_warnings):
             warnings.extend(str(warning) for warning in rop_warnings())
-        written = _expand_outputs(output_pattern)
+        written = expanded_outputs(output_pattern)
         return skill_success(
             "Rendered ROP",
             rop=node_summary(rop),
             rendered=rendered,
+            execution_mode=execution_mode,
             elapsed_secs=elapsed,
             frame_range=applied_range,
             output_pattern=output_pattern,

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -2110,7 +2110,7 @@ class TestRenderExecution:
         mock_hou.node.return_value = rop
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
-            result = mod.render_rop("/out/mantra1", frame_range=[1, 1, 1])
+            result = mod.render_rop("/out/mantra1", frame_range=[1, 1, 1], background=False)
 
         assert result["success"] is True
         rop.render.assert_called_once_with(verbose=False, frame_range=(1.0, 1.0, 1.0))

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -2009,6 +2009,13 @@ class TestRenderExecution:
         launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 720, 1], str(tmp_path / "beauty.$F4.exr"))
         rop.render.assert_not_called()
 
+    def test_expand_outputs_accepts_single_value_parm_tuple(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        out = tmp_path / "beauty.0001.exr"
+        out.write_bytes(b"exr")
+
+        assert mod._expand_outputs([str(out)]) == [str(out)]
+
     def test_render_rop_reports_written_and_elapsed(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
         out = tmp_path / "beauty.exr"
@@ -2089,3 +2096,21 @@ class TestRenderExecution:
         for parm, value in zip(frame_parms, (1.0, 1.0, 1.0)):
             parm.deleteAllKeyframes.assert_called_once_with()
             parm.set.assert_called_once_with(value)
+
+    def test_render_rop_forwards_explicit_frame_range_to_hom(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        out = tmp_path / "beauty.0001.exr"
+        picture = _scalar_parm(str(out))
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        rop.render.side_effect = lambda **_kwargs: out.write_bytes(b"exr")
+        rop.errors.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.render_rop("/out/mantra1", frame_range=[1, 1, 1])
+
+        assert result["success"] is True
+        rop.render.assert_called_once_with(verbose=False, frame_range=(1.0, 1.0, 1.0))


### PR DESCRIPTION
## Summary
- pass requested frame ranges directly to Houdini HOM render calls
- retain the frame range when retrying without the verbose keyword
- normalize single-value output parameter tuples before file discovery

## Validation
- python -m pytest tests/test_render_camera_light_skills.py -q (13 passed)
- python -m ruff check src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py tests/test_render_camera_light_skills.py
- live Mantra smoke: [1,1,1] produced only frame 0001 and returned the written EXR