### PR TITLE
feat: add non-blocking Houdini ROP render jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The package writes a Houdini package JSON into the user preferences folder.
 On startup, `scripts/123.py` extracts bundled wheels into `vendor/` and starts
 the MCP server unless `DCC_MCP_HOUDINI_AUTOSTART=0`.
 
+Isolated background ROP workers receive `DCC_MCP_BACKGROUND_RENDER=1` in their
+child environment. Package and custom `123.py`/`456.py` startup hooks must skip
+MCP adapter autostart when that marker is present; the parent Houdini environment
+is not modified.
+
 ## Usage
 
 ```python

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -241,6 +241,8 @@ def ensure_vendor(root: Path) -> Path:
 
 
 def bootstrap_and_start() -> object:
+    if os.environ.get("DCC_MCP_BACKGROUND_RENDER") == "1":
+        return None
     root = _package_root()
     vendor = ensure_vendor(root)
     vendor_str = str(vendor)
@@ -448,6 +450,8 @@ scripts/123.py extracts bundled wheels into vendor/ and starts the MCP server.
 The DCC-MCP shelf is loaded from toolbar/DCC-MCP.shelf.
 
 Disable autostart by setting DCC_MCP_HOUDINI_AUTOSTART=0.
+Background render children set DCC_MCP_BACKGROUND_RENDER=1; startup hooks must
+not start another MCP adapter when this child-only marker is present.
 MCP URL defaults to http://127.0.0.1:8765/mcp.
 """.format(version=version, core_version=core_version, platform=platform, core_policy=core_policy)
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -31,8 +31,9 @@ agent can detect and skip cleanly when rendering is unavailable.
 - **`viewport`:** `capture_viewport` (single frame), `flipbook` (range). Both
   clamp resolution to 4096 and return `written_files` / `skipped` / `warnings`.
 - **`render`:** `get_render_settings` (read-only), `set_render_settings`
-  (reports `unsupported` fields per ROP type), `render_rop` (async, long
-  timeout, reports `elapsed_secs` + `written_files`), `configure_aovs` (add/remove
+  (reports `unsupported` fields per ROP type), `render_rop` (foreground or
+  isolated `hython` background job), `get_render_job` (polls status without
+  blocking the UI), `configure_aovs` (add/remove
   AOVs with 15+ presets), `get_render_stats` (read resolution/samples/renderer/output).
 - **`render_layer`:** `create_render_layer` (Solaris RenderProduct or ROP merge),
   `manage_takes` (create/switch/delete/list takes for render layer variants).
@@ -59,6 +60,9 @@ agent can detect and skip cleanly when rendering is unavailable.
 2. `manage_takes(action="switch", take_name="lighting_variant_a")`
 3. `manage_takes(action="list")` → review all takes
 
-`render_rop` is `async` with a 30-minute timeout hint; output-path and
+Use `render_rop(..., background=true)` for production renders, then poll
+`get_render_job(job_id)`. The main thread only validates the ROP and launches
+the isolated process; Mantra/Karma work never occupies Houdini's event loop.
+Foreground `render_rop` retains the 30-minute timeout hint; output-path and
 resolution parameter writes are defensive (candidate names) so Mantra, Karma,
 and ROP geometry/USD drivers are all tolerated.

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -75,6 +75,8 @@ def launch_background_render(
         }
     )
     _write_json(status_path, status)
+    child_env = dict(os.environ)
+    child_env["DCC_MCP_BACKGROUND_RENDER"] = "1"
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
     with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
         process = subprocess.Popen(  # noqa: S603
@@ -83,6 +85,7 @@ def launch_background_render(
             stdout=stdout,
             stderr=stderr,
             cwd=str(job_dir),
+            env=child_env,
             creationflags=creationflags,
             close_fds=True,
         )

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -1,0 +1,85 @@
+"""Launch and inspect isolated hython render jobs."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    pending = path.with_suffix(".tmp")
+    pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(str(pending), str(path))
+
+
+def launch_background_render(
+    hou: Any,
+    rop_path: str,
+    frame_range: Optional[list[float]],
+    output_pattern: Optional[str],
+) -> dict[str, Any]:
+    hip_path = Path(hou.hipFile.path())
+    if not hip_path.is_file():
+        raise ValueError("Background rendering requires the current HIP file to be saved")
+
+    job_id = uuid.uuid4().hex
+    job_dir = Path(tempfile.gettempdir()) / "dcc-mcp-houdini-render-jobs" / job_id
+    job_dir.mkdir(parents=True)
+    status_path = job_dir / "status.json"
+    stdout_path = job_dir / "stdout.log"
+    stderr_path = job_dir / "stderr.log"
+    worker_path = Path(__file__).with_name("_render_worker.py")
+    executable_name = "hython.exe" if os.name == "nt" else "hython"
+    executable = Path(sys.executable).with_name(executable_name)
+    if not executable.is_file() and os.environ.get("HFS"):
+        executable = Path(os.environ["HFS"]) / "bin" / executable_name
+    if not executable.is_file():
+        raise FileNotFoundError("hython executable was not found beside Houdini")
+    command = [
+        str(executable),
+        str(worker_path),
+        str(hip_path),
+        rop_path,
+        json.dumps(frame_range),
+        str(status_path),
+        json.dumps(output_pattern),
+    ]
+    initial = {
+        "job_id": job_id,
+        "state": "queued",
+        "hip_path": str(hip_path),
+        "rop_path": rop_path,
+        "frame_range": frame_range,
+        "output_pattern": output_pattern,
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+    }
+    _write_json(status_path, initial)
+    creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+    with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+        process = subprocess.Popen(  # noqa: S603
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=stderr,
+            cwd=str(job_dir),
+            creationflags=creationflags,
+            close_fds=True,
+        )
+    initial.update({"pid": process.pid})
+    return initial
+
+
+def read_render_job(job_id: str) -> dict[str, Any]:
+    if not job_id or any(char not in "0123456789abcdef" for char in job_id.lower()):
+        raise ValueError("job_id must be a hexadecimal identifier")
+    status_path = Path(tempfile.gettempdir()) / "dcc-mcp-houdini-render-jobs" / job_id / "status.json"
+    if not status_path.is_file():
+        raise FileNotFoundError("Render job was not found")
+    return json.loads(status_path.read_text(encoding="utf-8"))

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -15,31 +15,13 @@ _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
-from _render_common import expanded_outputs, output_snapshot
+from _render_common import output_snapshot, requested_outputs
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     pending = path.with_suffix(".tmp")
     pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     os.replace(str(pending), str(path))
-
-
-def _requested_outputs(hou: Any, pattern: Optional[str], frame_range: Optional[list[float]]) -> list[str]:
-    if not pattern:
-        return []
-    if not frame_range:
-        return expanded_outputs(pattern)
-    start, end = float(frame_range[0]), float(frame_range[1])
-    step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
-    if step == 0 or (end - start) * step < 0:
-        raise ValueError("frame_range step must move from start toward end")
-    frame = start
-    tolerance = abs(step) * 1e-9
-    outputs = []
-    while (step > 0 and frame <= end + tolerance) or (step < 0 and frame >= end - tolerance):
-        outputs.append(hou.text.expandStringAtFrame(pattern, frame))
-        frame += step
-    return list(dict.fromkeys(outputs))
 
 
 def launch_background_render(
@@ -74,7 +56,7 @@ def launch_background_render(
         str(status_path),
         json.dumps(output_pattern),
     ]
-    expected_outputs = _requested_outputs(hou, output_pattern, frame_range)
+    expected_outputs = requested_outputs(hou, output_pattern, frame_range)
     initial = {
         "job_id": job_id,
         "state": "queued",

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -11,11 +11,35 @@ import uuid
 from pathlib import Path
 from typing import Any, Optional
 
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import expanded_outputs, output_snapshot
+
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     pending = path.with_suffix(".tmp")
     pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     os.replace(str(pending), str(path))
+
+
+def _requested_outputs(hou: Any, pattern: Optional[str], frame_range: Optional[list[float]]) -> list[str]:
+    if not pattern:
+        return []
+    if not frame_range:
+        return expanded_outputs(pattern)
+    start, end = float(frame_range[0]), float(frame_range[1])
+    step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+    if step == 0 or (end - start) * step < 0:
+        raise ValueError("frame_range step must move from start toward end")
+    frame = start
+    tolerance = abs(step) * 1e-9
+    outputs = []
+    while (step > 0 and frame <= end + tolerance) or (step < 0 and frame >= end - tolerance):
+        outputs.append(hou.text.expandStringAtFrame(pattern, frame))
+        frame += step
+    return list(dict.fromkeys(outputs))
 
 
 def launch_background_render(
@@ -50,6 +74,7 @@ def launch_background_render(
         str(status_path),
         json.dumps(output_pattern),
     ]
+    expected_outputs = _requested_outputs(hou, output_pattern, frame_range)
     initial = {
         "job_id": job_id,
         "state": "queued",
@@ -60,7 +85,14 @@ def launch_background_render(
         "stdout_path": str(stdout_path),
         "stderr_path": str(stderr_path),
     }
-    _write_json(status_path, initial)
+    status = dict(initial)
+    status.update(
+        {
+            "expected_outputs": expected_outputs,
+            "output_snapshot": output_snapshot(expected_outputs),
+        }
+    )
+    _write_json(status_path, status)
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
     with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
         process = subprocess.Popen(  # noqa: S603

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -143,6 +143,25 @@ def expanded_outputs(pattern: Optional[str]) -> list:
     return [pattern] if os.path.isfile(pattern) else []
 
 
+def output_snapshot(paths: Sequence[str]) -> dict:
+    """Return JSON-safe file signatures for existing output paths."""
+    snapshot = {}
+    for output in paths:
+        try:
+            stat = os.stat(output)
+        except OSError:
+            continue
+        if os.path.isfile(output):
+            snapshot[output] = {"mtime_ns": stat.st_mtime_ns, "size": stat.st_size}
+    return snapshot
+
+
+def updated_outputs(paths: Sequence[str], before: dict) -> list:
+    """Return outputs created or updated since *before*."""
+    current = output_snapshot(paths)
+    return sorted(output for output, signature in current.items() if signature != before.get(output))
+
+
 def node_summary(node: Any) -> dict:
     """Return a small, JSON-safe node summary."""
     type_obj = node.type()

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -143,6 +143,25 @@ def expanded_outputs(pattern: Optional[str]) -> list:
     return [pattern] if os.path.isfile(pattern) else []
 
 
+def requested_outputs(hou: Any, pattern: Optional[str], frame_range: Optional[Sequence[float]]) -> list:
+    """Expand the output paths for the exact requested frame range."""
+    if not pattern:
+        return []
+    if not frame_range:
+        return expanded_outputs(pattern)
+    start, end = float(frame_range[0]), float(frame_range[1])
+    step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+    if step == 0 or (end - start) * step < 0:
+        raise ValueError("frame_range step must move from start toward end")
+    frame = start
+    tolerance = abs(step) * 1e-9
+    outputs = []
+    while (step > 0 and frame <= end + tolerance) or (step < 0 and frame >= end - tolerance):
+        outputs.append(hou.text.expandStringAtFrame(pattern, frame))
+        frame += step
+    return list(dict.fromkeys(outputs))
+
+
 def output_snapshot(paths: Sequence[str]) -> dict:
     """Return JSON-safe file signatures for existing output paths."""
     snapshot = {}

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import glob
 import os
+import re
 from typing import Any, Optional, Sequence
 
 MAX_DIMENSION = 4096
@@ -56,16 +58,21 @@ def set_first_parm(node: Any, names: Sequence[str], value: Any) -> Optional[str]
     return None
 
 
-def eval_first_parm(node: Any, names: Sequence[str]):
+def eval_first_parm(node: Any, names: Sequence[str], preserve_string: bool = False):
     """Eval the first existing parm/parm-tuple in *names*, else None."""
     for name in names:
+        parm = node.parm(name)
+        if preserve_string and parm is not None:
+            try:
+                return parm.unexpandedString()
+            except Exception:  # noqa: BLE001
+                continue
         parm_tuple = node.parmTuple(name)
         if parm_tuple is not None:
             try:
                 return list(parm_tuple.eval())
             except Exception:  # noqa: BLE001
                 continue
-        parm = node.parm(name)
         if parm is not None:
             try:
                 return parm.eval()
@@ -80,12 +87,60 @@ def apply_frame_range(node: Any, frame_range: Optional[Sequence[float]]) -> Opti
         return None
     start, end = float(frame_range[0]), float(frame_range[1])
     step = float(frame_range[2]) if len(frame_range) > 2 else 1.0
-    set_parm_if_exists(node, "trange", 1)
-    if not set_parm_if_exists(node, "f", [start, end, step]):
-        set_parm_if_exists(node, "f1", start)
-        set_parm_if_exists(node, "f2", end)
-        set_parm_if_exists(node, "f3", step)
+    trange = node.parm("trange")
+    if trange is not None:
+        trange.deleteAllKeyframes()
+        trange.set(1)
+    frame_tuple = node.parmTuple("f")
+    if frame_tuple is not None:
+        for parm, value in zip(frame_tuple, (start, end, step)):
+            parm.deleteAllKeyframes()
+            parm.set(value)
+    else:
+        for name, value in zip(("f1", "f2", "f3"), (start, end, step)):
+            parm = node.parm(name)
+            if parm is not None:
+                parm.deleteAllKeyframes()
+                parm.set(value)
     return [start, end]
+
+
+def render_node(node: Any, frame_range: Optional[Sequence[float]] = None) -> tuple:
+    """Execute a render using the host contract for the node type."""
+    applied_range = apply_frame_range(node, frame_range)
+    type_name = node.type().name().split("::", 1)[0]
+    if type_name == "usdrender_rop":
+        execute = node.parm("execute")
+        if execute is None:
+            raise ValueError("Solaris USD Render node has no execute button")
+        execute.pressButton()
+        return applied_range, "execute"
+
+    render = getattr(node, "render", None)
+    if not callable(render):
+        raise ValueError("Node has no render(); expected a ROP/output driver")
+    kwargs = {}
+    if frame_range:
+        kwargs["frame_range"] = (
+            float(frame_range[0]),
+            float(frame_range[1]),
+            float(frame_range[2]) if len(frame_range) > 2 else 1.0,
+        )
+    try:
+        render(verbose=False, **kwargs)
+    except TypeError:
+        render(**kwargs)
+    return applied_range, "render"
+
+
+def expanded_outputs(pattern: Optional[str]) -> list:
+    """Return existing files matching a Houdini frame-token output pattern."""
+    if not pattern:
+        return []
+    globbed = re.sub(r"\$F\d*", "*", pattern)
+    if "*" in globbed:
+        return sorted(glob.glob(globbed))
+    return [pattern] if os.path.isfile(pattern) else []
 
 
 def node_summary(node: Any) -> dict:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -9,7 +9,7 @@ import time
 import traceback
 from pathlib import Path
 
-from _render_common import expanded_outputs, render_node, updated_outputs
+from _render_common import expanded_outputs, output_snapshot, render_node, requested_outputs, updated_outputs
 
 
 def write_status(path: Path, payload: dict) -> None:
@@ -52,11 +52,21 @@ def main() -> None:
         rop = hou.node(rop_path)
         if rop is None:
             raise ValueError("ROP node not found: {}".format(rop_path))
+        expected_outputs = (
+            status["expected_outputs"]
+            if frame_range and "expected_outputs" in status
+            else requested_outputs(hou, output_pattern, frame_range)
+        )
+        before = status.get("output_snapshot")
+        if before is None:
+            before = output_snapshot(expected_outputs)
+        status.update({"expected_outputs": expected_outputs, "output_snapshot": before})
+        write_status(status_path, status)
         _, execution_mode = render_node(rop, frame_range)
         rop_errors = [str(error) for error in rop.errors()] if hasattr(rop, "errors") else []
         logged_cook_errors = _cook_errors(status)
-        candidates = status.get("expected_outputs", []) if frame_range else expanded_outputs(output_pattern)
-        written_files = updated_outputs(candidates, status.get("output_snapshot", {}))
+        candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
+        written_files = updated_outputs(candidates, before)
         if logged_cook_errors:
             raise RuntimeError("ROP cook error: {}".format("; ".join(logged_cook_errors[:3])))
         if rop_errors:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -9,13 +9,29 @@ import time
 import traceback
 from pathlib import Path
 
-from _render_common import expanded_outputs, render_node
+from _render_common import expanded_outputs, render_node, updated_outputs
 
 
 def write_status(path: Path, payload: dict) -> None:
     pending = path.with_suffix(".tmp")
     pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     os.replace(str(pending), str(path))
+
+
+def _cook_errors(status: dict) -> list:
+    """Return cook-error lines emitted by this job."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+    lines = []
+    for key in ("stdout_path", "stderr_path"):
+        path = Path(status.get(key, ""))
+        if path.is_file():
+            lines.extend(
+                line.strip()
+                for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+                if "cook error" in line.lower()
+            )
+    return lines
 
 
 def main() -> None:
@@ -29,19 +45,31 @@ def main() -> None:
     started = time.time()
     status.update({"state": "running", "pid": os.getpid(), "started_at": started})
     write_status(status_path, status)
+    written_files = []
+    rop_errors = []
     try:
         hou.hipFile.load(hip_path, suppress_save_prompt=True)
         rop = hou.node(rop_path)
         if rop is None:
             raise ValueError("ROP node not found: {}".format(rop_path))
         _, execution_mode = render_node(rop, frame_range)
+        rop_errors = [str(error) for error in rop.errors()] if hasattr(rop, "errors") else []
+        logged_cook_errors = _cook_errors(status)
+        candidates = status.get("expected_outputs", []) if frame_range else expanded_outputs(output_pattern)
+        written_files = updated_outputs(candidates, status.get("output_snapshot", {}))
+        if logged_cook_errors:
+            raise RuntimeError("ROP cook error: {}".format("; ".join(logged_cook_errors[:3])))
+        if rop_errors:
+            raise RuntimeError("ROP errors: {}".format("; ".join(rop_errors)))
+        if not written_files:
+            raise RuntimeError("Render produced no new or updated output for the requested frame range")
         status.update(
             {
                 "state": "completed",
                 "execution_mode": execution_mode,
                 "elapsed_secs": round(time.time() - started, 3),
-                "written_files": expanded_outputs(output_pattern),
-                "warnings": list(rop.errors()) if hasattr(rop, "errors") else [],
+                "written_files": written_files,
+                "warnings": [],
             }
         )
     except Exception as exc:  # noqa: BLE001
@@ -51,6 +79,8 @@ def main() -> None:
                 "elapsed_secs": round(time.time() - started, 3),
                 "error": str(exc),
                 "traceback": traceback.format_exc(),
+                "written_files": written_files,
+                "warnings": rop_errors,
             }
         )
     finally:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -1,0 +1,62 @@
+"""Isolated hython worker used by background ROP jobs."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from _render_common import expanded_outputs, render_node
+
+
+def write_status(path: Path, payload: dict) -> None:
+    pending = path.with_suffix(".tmp")
+    pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(str(pending), str(path))
+
+
+def main() -> None:
+    import hou  # Lazy import: requires Houdini's embedded Python.
+
+    hip_path, rop_path, range_json, status_arg, output_json = sys.argv[1:6]
+    status_path = Path(status_arg)
+    frame_range = json.loads(range_json)
+    output_pattern = json.loads(output_json)
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    started = time.time()
+    status.update({"state": "running", "pid": os.getpid(), "started_at": started})
+    write_status(status_path, status)
+    try:
+        hou.hipFile.load(hip_path, suppress_save_prompt=True)
+        rop = hou.node(rop_path)
+        if rop is None:
+            raise ValueError("ROP node not found: {}".format(rop_path))
+        _, execution_mode = render_node(rop, frame_range)
+        status.update(
+            {
+                "state": "completed",
+                "execution_mode": execution_mode,
+                "elapsed_secs": round(time.time() - started, 3),
+                "written_files": expanded_outputs(output_pattern),
+                "warnings": list(rop.errors()) if hasattr(rop, "errors") else [],
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        status.update(
+            {
+                "state": "failed",
+                "elapsed_secs": round(time.time() - started, 3),
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+            }
+        )
+    finally:
+        status["finished_at"] = time.time()
+        write_status(status_path, status)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_job.py
@@ -1,0 +1,26 @@
+"""Read an isolated background render job without touching Houdini state."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _background_render import read_render_job  # noqa: E402
+
+
+def get_render_job(job_id: str) -> dict:
+    try:
+        return skill_success("Read background render job", **read_render_job(job_id))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read background render job")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_render_job(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import glob
-import os
 import sys
 import time
 from pathlib import Path
@@ -15,30 +13,16 @@ _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
-from _render_common import (  # noqa: E402
-    apply_frame_range,
-    eval_first_parm,
-    get_node,
-    node_summary,
-)
+from _background_render import launch_background_render  # noqa: E402
+from _render_common import eval_first_parm, expanded_outputs, get_node, node_summary, render_node  # noqa: E402
 
-_OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
-
-
-def _expand_outputs(pattern: Optional[str]) -> list:
-    if not pattern:
-        return []
-    globbed = pattern
-    for token in ("$F4", "$F3", "$F2", "$F"):
-        globbed = globbed.replace(token, "*")
-    if "*" in globbed:
-        return sorted(glob.glob(globbed))
-    return [pattern] if os.path.isfile(pattern) else []
+_OUTPUT_PARMS = ("outputimage", "picture", "vm_picture", "sopoutput", "filename", "lopoutput")
 
 
 def render_rop(
     rop_path: str,
     frame_range: Optional[List[float]] = None,
+    background: bool = False,
 ) -> dict:
     """Render the ROP at *rop_path*, returning written files and elapsed time."""
     try:
@@ -48,32 +32,43 @@ def render_rop(
 
     try:
         rop = get_node(hou, rop_path)
-        if not hasattr(rop, "render"):
+        is_solaris = rop.type().name().split("::", 1)[0] == "usdrender_rop"
+        if (is_solaris and rop.parm("execute") is None) or (
+            not is_solaris and not callable(getattr(rop, "render", None))
+        ):
             return skill_error(
                 "Not a render node",
-                "Node has no render(); expected a ROP/output driver",
+                "Node has no supported render action; expected a ROP/output driver",
                 node_path=rop.path(),
             )
-        applied_range = apply_frame_range(rop, frame_range) if frame_range else None
-        output_pattern = eval_first_parm(rop, _OUTPUT_PARMS)
+        output_pattern = eval_first_parm(rop, _OUTPUT_PARMS, preserve_string=True)
+        if background:
+            job = launch_background_render(hou, rop.path(), frame_range, output_pattern)
+            return skill_success(
+                "Started background ROP render",
+                rop=node_summary(rop),
+                background=True,
+                **job,
+            )
         warnings: List[str] = []
         start = time.time()
         rendered = True
         try:
-            rop.render(verbose=False)
-        except TypeError:
-            rop.render()
+            applied_range, execution_mode = render_node(rop, frame_range)
         except Exception as render_exc:  # noqa: BLE001
             rendered = False
+            applied_range = None
+            execution_mode = None
             warnings.append("Render failed: {}".format(render_exc))
         elapsed = round(time.time() - start, 3)
         if hasattr(rop, "errors"):
             warnings.extend(list(rop.errors()))
-        written = _expand_outputs(output_pattern)
+        written = expanded_outputs(output_pattern)
         return skill_success(
             "Rendered ROP",
             rop=node_summary(rop),
             rendered=rendered,
+            execution_mode=execution_mode,
             elapsed_secs=elapsed,
             frame_range=applied_range,
             output_pattern=output_pattern,

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -147,6 +147,29 @@ tools:
           items: {type: number}
           minItems: 2
           maxItems: 3
+        background:
+          type: boolean
+          default: false
+          description: Launch an isolated hython job and return immediately, keeping the Houdini UI responsive.
+  - name: get_render_job
+    description: Read status, elapsed time, and written files for a background ROP render job.
+    source_file: scripts/get_render_job.py
+    execution: sync
+    affinity: any
+    group: render
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
   - name: create_render_layer
     description: >-
       Create a render layer (Render Product in Solaris /stage or merge in ROP

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -78,6 +78,7 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     assert "wait_ready=False" in shelf_xml
     assert 'os.environ.get("DCC_MCP_REGISTRY_DIR")' in bootstrap
     assert "registry_dir=registry_dir" in bootstrap
+    assert 'os.environ.get("DCC_MCP_BACKGROUND_RENDER") == "1"' in bootstrap
     assert "get_server" in shelf_xml
     assert "setStatusMessage" in shelf_xml
     assert "displayMessage" not in shelf_xml

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -22,6 +22,12 @@ def _load_script(skill_name: str, script_name: str) -> ModuleType:
     return module
 
 
+def _load_render_worker() -> ModuleType:
+    scripts = _SKILLS_ROOT / "houdini-render" / "scripts"
+    with patch.object(sys, "path", [str(scripts), *sys.path]):
+        return _load_script("houdini-render", "_render_worker.py")
+
+
 def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
     node = MagicMock()
     node.path.return_value = path
@@ -35,6 +41,45 @@ def _scalar_parm(value):
     parm.eval.return_value = value
     parm.unexpandedString.return_value = value
     return parm
+
+
+def _run_render_worker(tmp_path, frame_range, expected_outputs, snapshot, render, stderr_text=""):
+    mod = _load_render_worker()
+    pattern = str(tmp_path / "beauty.$F4.exr")
+    stdout = tmp_path / "stdout.log"
+    stderr = tmp_path / "stderr.log"
+    stdout.write_text("", encoding="utf-8")
+    stderr.write_text(stderr_text, encoding="utf-8")
+    status_path = tmp_path / "status.json"
+    status_path.write_text(
+        json.dumps(
+            {
+                "state": "queued",
+                "stdout_path": str(stdout),
+                "stderr_path": str(stderr),
+                "expected_outputs": [str(path) for path in expected_outputs],
+                "output_snapshot": snapshot,
+            }
+        ),
+        encoding="utf-8",
+    )
+    rop = _node("/stage/karma", "karma", "usdrender_rop")
+    rop.errors.return_value = []
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = rop
+    argv = [
+        "_render_worker.py",
+        "scene.hip",
+        "/stage/karma",
+        json.dumps(frame_range),
+        str(status_path),
+        json.dumps(pattern),
+    ]
+    with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod.sys, "argv", argv), patch.object(
+        mod, "render_node", side_effect=render
+    ):
+        mod.main()
+    return json.loads(status_path.read_text(encoding="utf-8"))
 
 
 class TestCameraSkills:
@@ -212,23 +257,87 @@ class TestRenderExecution:
         mod = _load_script("houdini-render", "_background_render.py")
         hip = tmp_path / "scene.hip"
         hip.write_bytes(b"hip")
+        requested = tmp_path / "beauty.0001.exr"
+        requested.write_bytes(b"old")
+        (tmp_path / "beauty.0002.exr").write_bytes(b"outside requested range")
         hython = tmp_path / ("hython.exe" if mod.os.name == "nt" else "hython")
         hython.write_bytes(b"exe")
         mock_hou = MagicMock()
         mock_hou.hipFile.path.return_value = str(hip)
+        mock_hou.text.expandStringAtFrame.side_effect = lambda pattern, frame: pattern.replace(
+            "$F4", "{:04d}".format(int(frame))
+        )
         process = MagicMock(pid=4321)
 
         with patch.object(mod.sys, "executable", str(tmp_path / "houdini.exe")), patch.object(
             mod.tempfile, "gettempdir", return_value=str(tmp_path)
         ), patch.object(mod.subprocess, "Popen", return_value=process) as popen:
-            job = mod.launch_background_render(mock_hou, "/stage/karma", [1, 2, 1], "beauty.$F4.exr")
+            job = mod.launch_background_render(
+                mock_hou,
+                "/stage/karma",
+                [1, 9, 4],
+                str(tmp_path / "beauty.$F4.exr"),
+            )
 
         status = json.loads((tmp_path / "dcc-mcp-houdini-render-jobs" / job["job_id"] / "status.json").read_text())
         assert job["pid"] == 4321
         assert status["state"] == "queued"
         assert "pid" not in status
+        assert status["output_snapshot"] == {
+            str(requested): {"mtime_ns": requested.stat().st_mtime_ns, "size": requested.stat().st_size}
+        }
         assert popen.call_args.kwargs["cwd"].endswith(job["job_id"])
         assert popen.call_args.args[0][0] == str(hython)
+
+    def test_background_worker_reports_only_updated_requested_outputs(self, tmp_path: Path) -> None:
+        stale = tmp_path / "beauty.0001.exr"
+        stale.write_bytes(b"stale")
+        outside = tmp_path / "beauty.0002.exr"
+
+        def render(_rop, _frame_range):
+            outside.write_bytes(b"new but not requested")
+            (tmp_path / "beauty.0005.exr").write_bytes(b"new requested frame")
+            return [1.0, 9.0], "execute"
+
+        status = _run_render_worker(
+            tmp_path,
+            [1, 9, 4],
+            [tmp_path / "beauty.0001.exr", tmp_path / "beauty.0005.exr", tmp_path / "beauty.0009.exr"],
+            {str(stale): {"mtime_ns": stale.stat().st_mtime_ns, "size": stale.stat().st_size}},
+            render,
+        )
+        assert status["state"] == "completed"
+        assert status["written_files"] == [str(tmp_path / "beauty.0005.exr")]
+
+    def test_background_worker_fails_when_only_stale_output_exists(self, tmp_path: Path) -> None:
+        stale = tmp_path / "beauty.0001.exr"
+        stale.write_bytes(b"stale")
+        status = _run_render_worker(
+            tmp_path,
+            [1, 1, 1],
+            [stale],
+            {str(stale): {"mtime_ns": stale.stat().st_mtime_ns, "size": stale.stat().st_size}},
+            lambda _rop, _frame_range: ([1.0, 1.0], "execute"),
+        )
+        assert status["state"] == "failed"
+        assert status["written_files"] == []
+        assert "no new or updated output" in status["error"].lower()
+
+    def test_background_worker_fails_on_rop_cook_error_log(self, tmp_path: Path) -> None:
+        def render(_rop, _frame_range):
+            (tmp_path / "beauty.0001.exr").write_bytes(b"new")
+            return [1.0, 1.0], "execute"
+
+        status = _run_render_worker(
+            tmp_path,
+            [1, 1, 1],
+            [tmp_path / "beauty.0001.exr"],
+            {},
+            render,
+            stderr_text="Error: ROP cook error",
+        )
+        assert status["state"] == "failed"
+        assert "rop cook error" in status["error"].lower()
 
     def test_render_rop_background_returns_job_without_rendering_in_ui(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -32,6 +33,7 @@ def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
 def _scalar_parm(value):
     parm = MagicMock()
     parm.eval.return_value = value
+    parm.unexpandedString.return_value = value
     return parm
 
 
@@ -206,6 +208,48 @@ class TestRenderSettings:
 
 
 class TestRenderExecution:
+    def test_background_render_launches_isolated_hython(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        hip = tmp_path / "scene.hip"
+        hip.write_bytes(b"hip")
+        hython = tmp_path / "hython.exe"
+        hython.write_bytes(b"exe")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.path.return_value = str(hip)
+        process = MagicMock(pid=4321)
+
+        with patch.object(mod.sys, "executable", str(tmp_path / "houdini.exe")), patch.object(
+            mod.tempfile, "gettempdir", return_value=str(tmp_path)
+        ), patch.object(mod.subprocess, "Popen", return_value=process) as popen:
+            job = mod.launch_background_render(mock_hou, "/stage/karma", [1, 2, 1], "beauty.$F4.exr")
+
+        status = json.loads((tmp_path / "dcc-mcp-houdini-render-jobs" / job["job_id"] / "status.json").read_text())
+        assert job["pid"] == 4321
+        assert status["state"] == "queued"
+        assert "pid" not in status
+        assert popen.call_args.kwargs["cwd"].endswith(job["job_id"])
+        assert popen.call_args.args[0][0] == str(hython)
+
+    def test_render_rop_background_returns_job_without_rendering_in_ui(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        picture = _scalar_parm(str(tmp_path / "beauty.$F4.exr"))
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        job = {"job_id": "a" * 32, "state": "running", "pid": 1234}
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            with patch.object(mod, "launch_background_render", return_value=job) as launch:
+                result = mod.render_rop("/out/mantra1", frame_range=[1, 9, 4], background=True)
+
+        assert result["success"] is True
+        assert result["context"]["background"] is True
+        assert result["context"]["job_id"] == "a" * 32
+        launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 9, 4], str(tmp_path / "beauty.$F4.exr"))
+        rop.render.assert_not_called()
+
     def test_render_rop_reports_written_and_elapsed(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
         out = tmp_path / "beauty.exr"
@@ -225,3 +269,35 @@ class TestRenderExecution:
         assert result["context"]["rendered"] is True
         assert result["context"]["written_files"] == [str(out)]
         assert "elapsed_secs" in result["context"]
+
+    def test_render_rop_uses_solaris_execute_and_outputimage(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        out = tmp_path / "karma.0001.exr"
+        output = _scalar_parm(str(out).replace("0001", "$F4"))
+        output.eval.return_value = str(out)
+        execute = MagicMock()
+        execute.pressButton.side_effect = lambda: out.write_bytes(b"exr")
+        frame_parms = [MagicMock(), MagicMock(), MagicMock()]
+        rop = _node("/stage/karma_rop", "karma_rop", "usdrender_rop")
+        rop.parmTuple.side_effect = lambda n: tuple(frame_parms) if n == "f" else None
+        rop.parm.side_effect = lambda n: {
+            "outputimage": output,
+            "lopoutput": _scalar_parm("__render__.usd"),
+            "execute": execute,
+        }.get(n)
+        rop.errors.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.render_rop("/stage/karma_rop", frame_range=[1, 1], background=False)
+
+        assert result["success"] is True
+        assert result["context"]["execution_mode"] == "execute"
+        assert result["context"]["output_pattern"].endswith("karma.$F4.exr")
+        assert result["context"]["written_files"] == [str(out)]
+        execute.pressButton.assert_called_once_with()
+        rop.render.assert_not_called()
+        for parm, value in zip(frame_parms, (1.0, 1.0, 1.0)):
+            parm.deleteAllKeyframes.assert_called_once_with()
+            parm.set.assert_called_once_with(value)

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -212,7 +212,7 @@ class TestRenderExecution:
         mod = _load_script("houdini-render", "_background_render.py")
         hip = tmp_path / "scene.hip"
         hip.write_bytes(b"hip")
-        hython = tmp_path / "hython.exe"
+        hython = tmp_path / ("hython.exe" if mod.os.name == "nt" else "hython")
         hython.write_bytes(b"exe")
         mock_hou = MagicMock()
         mock_hou.hipFile.path.return_value = str(hip)

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -278,15 +278,18 @@ class TestRenderExecution:
         )
         process = MagicMock(pid=4321)
 
-        with patch.object(mod.sys, "executable", str(tmp_path / "houdini.exe")), patch.object(
-            mod.tempfile, "gettempdir", return_value=str(tmp_path)
-        ), patch.object(mod.subprocess, "Popen", return_value=process) as popen:
+        with patch.dict(mod.os.environ, {"PARENT_ONLY": "keep"}, clear=True), patch.object(
+            mod.sys, "executable", str(tmp_path / "houdini.exe")
+        ), patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod.subprocess, "Popen", return_value=process
+        ) as popen:
             job = mod.launch_background_render(
                 mock_hou,
                 "/stage/karma",
                 [1, 9, 4],
                 str(tmp_path / "beauty.$F4.exr"),
             )
+            assert "DCC_MCP_BACKGROUND_RENDER" not in mod.os.environ
 
         status = json.loads((tmp_path / "dcc-mcp-houdini-render-jobs" / job["job_id"] / "status.json").read_text())
         assert job["pid"] == 4321
@@ -297,6 +300,8 @@ class TestRenderExecution:
         }
         assert popen.call_args.kwargs["cwd"].endswith(job["job_id"])
         assert popen.call_args.args[0][0] == str(hython)
+        assert popen.call_args.kwargs["env"]["PARENT_ONLY"] == "keep"
+        assert popen.call_args.kwargs["env"]["DCC_MCP_BACKGROUND_RENDER"] == "1"
 
     def test_background_worker_reports_only_updated_requested_outputs(self, tmp_path: Path) -> None:
         stale = tmp_path / "beauty.0001.exr"

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -43,30 +43,39 @@ def _scalar_parm(value):
     return parm
 
 
-def _run_render_worker(tmp_path, frame_range, expected_outputs, snapshot, render, stderr_text=""):
+def _run_render_worker(
+    tmp_path,
+    frame_range,
+    expected_outputs,
+    snapshot,
+    render,
+    stderr_text="",
+    pattern=None,
+    include_launch_snapshot=True,
+):
     mod = _load_render_worker()
-    pattern = str(tmp_path / "beauty.$F4.exr")
+    pattern = pattern or str(tmp_path / "beauty.$F4.exr")
     stdout = tmp_path / "stdout.log"
     stderr = tmp_path / "stderr.log"
     stdout.write_text("", encoding="utf-8")
     stderr.write_text(stderr_text, encoding="utf-8")
     status_path = tmp_path / "status.json"
-    status_path.write_text(
-        json.dumps(
+    status = {"state": "queued", "stdout_path": str(stdout), "stderr_path": str(stderr)}
+    if include_launch_snapshot:
+        status.update(
             {
-                "state": "queued",
-                "stdout_path": str(stdout),
-                "stderr_path": str(stderr),
                 "expected_outputs": [str(path) for path in expected_outputs],
                 "output_snapshot": snapshot,
             }
-        ),
-        encoding="utf-8",
-    )
+        )
+    status_path.write_text(json.dumps(status), encoding="utf-8")
     rop = _node("/stage/karma", "karma", "usdrender_rop")
     rop.errors.return_value = []
     mock_hou = MagicMock()
     mock_hou.node.return_value = rop
+    mock_hou.text.expandStringAtFrame.side_effect = lambda value, frame: value.replace(
+        "$F4", "{:04d}".format(int(frame))
+    )
     argv = [
         "_render_worker.py",
         "scene.hip",
@@ -308,6 +317,26 @@ class TestRenderExecution:
         )
         assert status["state"] == "completed"
         assert status["written_files"] == [str(tmp_path / "beauty.0005.exr")]
+
+    def test_background_worker_recovers_from_cached_launcher_without_snapshot(self, tmp_path: Path) -> None:
+        output = tmp_path / "karma_beauty.1080.exr"
+        pattern = "{}/karma_beauty.$F4.exr".format(tmp_path.as_posix())
+
+        def render(_rop, _frame_range):
+            output.write_bytes(b"new frame")
+            return [1080.0, 1080.0], "execute"
+
+        status = _run_render_worker(
+            tmp_path,
+            [1080, 1080, 1],
+            [],
+            {},
+            render,
+            pattern=pattern,
+            include_launch_snapshot=False,
+        )
+        assert status["state"] == "completed"
+        assert status["written_files"] == [output.as_posix()]
 
     def test_background_worker_fails_when_only_stale_output_exists(self, tmp_path: Path) -> None:
         stale = tmp_path / "beauty.0001.exr"


### PR DESCRIPTION
## Summary

- add opt-in isolated `hython` ROP render jobs plus a polling tool, so long renders do not occupy Houdini's UI event loop
- execute Solaris USD Render nodes through their `execute` contract instead of treating the LOP node like a classic ROP
- preserve `outputimage` frame tokens, prefer image output over temporary USD output, and override keyed frame-range expressions deterministically

## Validation

- `python -m pytest -q` — 412 passed, 1 skipped
- `ruff check .`
- `ruff format --check src/dcc_mcp_houdini/skills/houdini-render/scripts tests/test_render_camera_light_skills.py`
- `python tools/lint_skills.py --warnings-as-errors` — 30 skills, 0 errors, 0 warnings
- Houdini 21.0.631 / Karma live check: foreground Solaris execution wrote one 13.6 MB EXR for the requested single frame
- background live check: launch returned in 16 ms; isolated hython completed one requested frame in 23.35 s without writing adjacent frames

Related to #103. This PR covers isolated execution, polling, Solaris execution, and deterministic frame ranges; subprocess cancellation remains a follow-up.