### PR TITLE
fix: keep interactive ROP renders off the UI thread

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -46,7 +46,7 @@ agent can detect and skip cleanly when rendering is unavailable.
 2. `set_render_settings(rop_path="/out/mantra1", camera="/obj/rendercam", resolution=[1280,720], output_path="/tmp/beauty.exr")`
 3. `get_render_settings("/out/mantra1")` → verify
 4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only)
-5. `render_rop("/out/mantra1", frame_range=[1,1])` → `written_files`, `elapsed_secs`
+5. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive Houdini; foreground results in headless Houdini
 
 ### Render Layers & AOVs
 
@@ -60,9 +60,10 @@ agent can detect and skip cleanly when rendering is unavailable.
 2. `manage_takes(action="switch", take_name="lighting_variant_a")`
 3. `manage_takes(action="list")` → review all takes
 
-Use `render_rop(..., background=true)` for production renders, then poll
-`get_render_job(job_id)`. The main thread only validates the ROP and launches
-the isolated process; Mantra/Karma work never occupies Houdini's event loop.
-Foreground `render_rop` retains the 30-minute timeout hint; output-path and
+Interactive Houdini defaults to an isolated process; poll
+`get_render_job(job_id)`. Pass `background=false` only when foreground
+execution is intentional. Headless Houdini defaults to foreground execution.
+The main thread only validates the ROP and launches the isolated process;
+Mantra/Karma work never occupies Houdini's event loop. Output-path and
 resolution parameter writes are defensive (candidate names) so Mantra, Karma,
 and ROP geometry/USD drivers are all tolerated.

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -15,8 +15,6 @@ _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
-from _render_common import output_snapshot, requested_outputs
-
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     pending = path.with_suffix(".tmp")
@@ -56,7 +54,6 @@ def launch_background_render(
         str(status_path),
         json.dumps(output_pattern),
     ]
-    expected_outputs = requested_outputs(hou, output_pattern, frame_range)
     initial = {
         "job_id": job_id,
         "state": "queued",
@@ -67,14 +64,7 @@ def launch_background_render(
         "stdout_path": str(stdout_path),
         "stderr_path": str(stderr_path),
     }
-    status = dict(initial)
-    status.update(
-        {
-            "expected_outputs": expected_outputs,
-            "output_snapshot": output_snapshot(expected_outputs),
-        }
-    )
-    _write_json(status_path, status)
+    _write_json(status_path, initial)
     child_env = dict(os.environ)
     child_env["DCC_MCP_BACKGROUND_RENDER"] = "1"
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -22,7 +22,7 @@ _OUTPUT_PARMS = ("outputimage", "picture", "vm_picture", "sopoutput", "filename"
 def render_rop(
     rop_path: str,
     frame_range: Optional[List[float]] = None,
-    background: bool = False,
+    background: Optional[bool] = None,
 ) -> dict:
     """Render the ROP at *rop_path*, returning written files and elapsed time."""
     try:
@@ -42,7 +42,8 @@ def render_rop(
                 node_path=rop.path(),
             )
         output_pattern = eval_first_parm(rop, _OUTPUT_PARMS, preserve_string=True)
-        if background:
+        use_background = bool(hou.isUIAvailable()) if background is None else background
+        if use_background:
             job = launch_background_render(hou, rop.path(), frame_range, output_pattern)
             return skill_success(
                 "Started background ROP render",

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -123,7 +123,8 @@ tools:
   - name: render_rop
     description: >-
       Render a ROP/output driver and report written files, elapsed time,
-      warnings/errors. Async with a long timeout hint to avoid hanging the host.
+      warnings/errors. Interactive Houdini defaults to an isolated job so the
+      UI stays responsive; headless Houdini defaults to foreground execution.
     source_file: scripts/render_rop.py
     execution: async
     affinity: main
@@ -149,8 +150,7 @@ tools:
           maxItems: 3
         background:
           type: boolean
-          default: false
-          description: Launch an isolated hython job and return immediately, keeping the Houdini UI responsive.
+          description: Explicitly select isolated hython (true) or foreground (false) execution. When omitted, interactive Houdini uses an isolated job and headless Houdini renders in the foreground.
   - name: get_render_job
     description: Read status, elapsed time, and written files for a background ROP render job.
     source_file: scripts/get_render_job.py

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -266,16 +266,10 @@ class TestRenderExecution:
         mod = _load_script("houdini-render", "_background_render.py")
         hip = tmp_path / "scene.hip"
         hip.write_bytes(b"hip")
-        requested = tmp_path / "beauty.0001.exr"
-        requested.write_bytes(b"old")
-        (tmp_path / "beauty.0002.exr").write_bytes(b"outside requested range")
         hython = tmp_path / ("hython.exe" if mod.os.name == "nt" else "hython")
         hython.write_bytes(b"exe")
         mock_hou = MagicMock()
         mock_hou.hipFile.path.return_value = str(hip)
-        mock_hou.text.expandStringAtFrame.side_effect = lambda pattern, frame: pattern.replace(
-            "$F4", "{:04d}".format(int(frame))
-        )
         process = MagicMock(pid=4321)
 
         with patch.dict(mod.os.environ, {"PARENT_ONLY": "keep"}, clear=True), patch.object(
@@ -286,7 +280,7 @@ class TestRenderExecution:
             job = mod.launch_background_render(
                 mock_hou,
                 "/stage/karma",
-                [1, 9, 4],
+                [1, 100000, 1],
                 str(tmp_path / "beauty.$F4.exr"),
             )
             assert "DCC_MCP_BACKGROUND_RENDER" not in mod.os.environ
@@ -295,9 +289,9 @@ class TestRenderExecution:
         assert job["pid"] == 4321
         assert status["state"] == "queued"
         assert "pid" not in status
-        assert status["output_snapshot"] == {
-            str(requested): {"mtime_ns": requested.stat().st_mtime_ns, "size": requested.stat().st_size}
-        }
+        assert "expected_outputs" not in status
+        assert "output_snapshot" not in status
+        mock_hou.text.expandStringAtFrame.assert_not_called()
         assert popen.call_args.kwargs["cwd"].endswith(job["job_id"])
         assert popen.call_args.args[0][0] == str(hython)
         assert popen.call_args.kwargs["env"]["PARENT_ONLY"] == "keep"
@@ -393,6 +387,27 @@ class TestRenderExecution:
         launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 9, 4], str(tmp_path / "beauty.$F4.exr"))
         rop.render.assert_not_called()
 
+    def test_render_rop_defaults_to_background_in_ui(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        picture = _scalar_parm(str(tmp_path / "beauty.$F4.exr"))
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = True
+        job = {"job_id": "a" * 32, "state": "queued", "pid": 1234}
+
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(
+            mod, "launch_background_render", return_value=job
+        ) as launch:
+            result = mod.render_rop("/out/mantra1", frame_range=[1, 100000, 1])
+
+        assert result["success"] is True
+        assert result["context"]["background"] is True
+        launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 100000, 1], str(tmp_path / "beauty.$F4.exr"))
+        rop.render.assert_not_called()
+
     def test_render_rop_reports_written_and_elapsed(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
         out = tmp_path / "beauty.exr"
@@ -404,6 +419,7 @@ class TestRenderExecution:
         rop.errors.return_value = []
         mock_hou = MagicMock()
         mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = False
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.render_rop("/out/mantra1")
@@ -431,6 +447,7 @@ class TestRenderExecution:
         rop.errors.return_value = []
         mock_hou = MagicMock()
         mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = True
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.render_rop("/stage/karma_rop", frame_range=[1, 1], background=False)


### PR DESCRIPTION
## Summary
- default omitted `background` to an isolated hython render job in interactive Houdini
- preserve foreground execution for headless Houdini and explicit `background=false`
- move frame-range output expansion and file snapshots from the Houdini UI thread into the render worker

## Validation
- 417 tests passed, 1 skipped
- Ruff check and format passed
- skill metadata validation passed with no warnings
- Python 3.7 syntax validation passed