### PR TITLE
feat: add cancellable background render jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ When adding or changing bundled skills, load the project skill:
 ### pipeline stage (load on demand)
 | Skill | Key tools |
 |-------|-----------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 30 skill packages, 183 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 30 skill packages, 185 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ the MCP server unless `DCC_MCP_HOUDINI_AUTOSTART=0`.
 Isolated background ROP workers receive `DCC_MCP_BACKGROUND_RENDER=1` in their
 child environment. Package and custom `123.py`/`456.py` startup hooks must skip
 MCP adapter autostart when that marker is present; the parent Houdini environment
-is not modified.
+is not modified. Background render cancellation uses only live child-process
+handles owned by the current adapter process; status-file PIDs are never used
+as process ownership evidence.
 
 ## Usage
 
@@ -147,7 +149,7 @@ manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
 PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
 available.
 
-## Bundled Skills (30 packages, 183 tools)
+## Bundled Skills (30 packages, 185 tools)
 
 Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md`
 
@@ -192,7 +194,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 ### pipeline (load on demand)
 | Skill | Tools |
 |-------|-------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |

--- a/docs/adr/0001-isolate-long-running-houdini-jobs.md
+++ b/docs/adr/0001-isolate-long-running-houdini-jobs.md
@@ -1,0 +1,52 @@
+# ADR-0001: Isolate long-running Houdini jobs
+
+## Status
+
+Accepted
+
+## Context
+
+Houdini scene APIs require host-thread coordination, while renders can run for
+hours. Keeping render execution on that thread blocks the UI. `hwebserver`
+provides HTTP ingress, but its Python handlers do not provide the host-thread
+execution guarantee needed by `hou.*` and therefore cannot replace the adapter's
+event-loop bridge.
+
+Cancellation must also avoid PID reuse hazards. A PID copied from a status file
+does not prove that a process is still the child originally launched by this
+adapter instance.
+
+## Decision
+
+- Keep the existing Houdini event-loop bridge for short scene validation and job launch.
+- Run long render work in an isolated `hython` process group.
+- Retain each launched `Popen` handle in the adapter process and cancel only through that owned handle.
+- Persist job status for observation, but never treat a persisted PID as process ownership evidence.
+- Treat `hwebserver` as optional ingress only; it does not execute `hou.*` directly for long jobs.
+
+## Consequences
+
+### Positive
+
+- Houdini remains responsive during long renders.
+- Cancellation can terminate the owned worker tree without risking an unrelated process.
+- Polling and cancellation need no Houdini main-thread affinity.
+
+### Negative
+
+- Jobs started by an adapter instance cannot be cancelled after that instance restarts.
+- Process-tree termination remains platform-specific (`taskkill /T` on Windows, process groups on POSIX).
+
+## Alternatives Considered
+
+- Run render calls on the host thread: rejected because it blocks interactive Houdini.
+- Replace the bridge with `hwebserver`: rejected because HTTP handler threads are not a `hou.*` thread-safety contract.
+- Cancel by status-file PID: rejected because persisted PIDs do not prove ownership and may be reused.
+- Use `hrpyc` or `openport` as the control plane: rejected because they do not provide this typed job lifecycle and ownership contract.
+
+## References
+
+- https://www.sidefx.com/docs/houdini/hwebserver/index.html
+- https://www.sidefx.com/docs/houdini/hwebserver/apiFunction.html
+- https://www.sidefx.com/docs/houdini/hom/hou/ui.html
+- https://www.sidefx.com/docs/houdini/hom/rpc

--- a/llms.txt
+++ b/llms.txt
@@ -65,7 +65,7 @@ server.list_skills()
 - `houdini_import_to_scene__import_to_scene`
 
 ### pipeline (load on demand)
-- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
+- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
 - `houdini_karma__configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output`
 - `houdini_husk__render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
 - `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -28,7 +28,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Three-point studio lighting | `load_skill("houdini-light-rig")` → `create_three_point_light_rig` → `aim_light_at_object` → `set_light_rig_intensity` → `get_lighting_summary` |
 | HDRI environment lighting | `load_skill("houdini-light-rig")` → `create_hdri_world` → `area_softbox` / `set_render_view_transform` → `get_lighting_summary` |
 | Light rig management | `load_skill("houdini-light-rig")` → `list_light_rigs` → `group_lights` → `set_light_rig_intensity` |
-| Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` |
+| Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` → `houdini_render__get_render_job` / `houdini_render__cancel_render_job` |
 | Texture bake (AO) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_ambient_occlusion` |
 | Texture bake (lighting) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_lighting` |
 | Transfer high→low maps | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__transfer_maps` |

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -21,7 +21,8 @@ metadata:
 
 # houdini-render
 
-Typed render and visual-verification tools. All tools are `affinity: main`.
+Typed render and visual-verification tools. Scene inspection and launch tools
+use `affinity: main`; background job polling and cancellation use `affinity: any`.
 Viewport tools are **UI-aware**: in a headless `hython` session they return a
 structured `warnings` payload with `captured: false` instead of failing, so an
 agent can detect and skip cleanly when rendering is unavailable.
@@ -32,8 +33,9 @@ agent can detect and skip cleanly when rendering is unavailable.
   clamp resolution to 4096 and return `written_files` / `skipped` / `warnings`.
 - **`render`:** `get_render_settings` (read-only), `set_render_settings`
   (reports `unsupported` fields per ROP type), `render_rop` (foreground or
-  isolated `hython` background job), `get_render_job` (polls status without
-  blocking the UI), `configure_aovs` (add/remove
+  isolated `hython` background job), `get_render_job` (polls and reconciles
+  status without blocking the UI), `cancel_render_job` (cancels only jobs
+  owned by the current adapter process), `configure_aovs` (add/remove
   AOVs with 15+ presets), `get_render_stats` (read resolution/samples/renderer/output).
 - **`render_layer`:** `create_render_layer` (Solaris RenderProduct or ROP merge),
   `manage_takes` (create/switch/delete/list takes for render layer variants).
@@ -61,8 +63,9 @@ agent can detect and skip cleanly when rendering is unavailable.
 3. `manage_takes(action="list")` → review all takes
 
 Interactive Houdini defaults to an isolated process; poll
-`get_render_job(job_id)`. Pass `background=false` only when foreground
-execution is intentional. Headless Houdini defaults to foreground execution.
+`get_render_job(job_id)` and use `cancel_render_job(job_id)` to stop a job
+started by the same adapter process. Pass `background=false` only when
+foreground execution is intentional. Headless Houdini defaults to foreground execution.
 The main thread only validates the ROP and launches the isolated process;
 Mantra/Karma work never occupies Houdini's event loop. Output-path and
 resolution parameter writes are defensive (candidate names) so Mantra, Karma,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Optional
@@ -15,11 +18,93 @@ _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
+_PROCESS_HANDLES: dict[str, Any] = {}
+_PROCESS_LOCK = threading.RLock()
+_TERMINAL_STATES = frozenset({"completed", "failed", "cancelled", "interrupted"})
+_CANCEL_GRACE_SECS = 2
+_SIGTERM = getattr(signal, "SIGTERM", 15)
+_SIGKILL = getattr(signal, "SIGKILL", 9)
+
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    pending = path.with_suffix(".tmp")
+    pending = path.with_name("{}.{}.tmp".format(path.name, os.getpid()))
     pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     os.replace(str(pending), str(path))
+
+
+def _status_path(job_id: str) -> Path:
+    if not job_id or any(char not in "0123456789abcdef" for char in job_id.lower()):
+        raise ValueError("job_id must be a hexadecimal identifier")
+    return Path(tempfile.gettempdir()) / "dcc-mcp-houdini-render-jobs" / job_id / "status.json"
+
+
+def _read_status(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError("Render job was not found")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _with_ownership(status: dict[str, Any], owned: bool) -> dict[str, Any]:
+    result = dict(status)
+    result["owned_by_current_process"] = owned
+    return result
+
+
+def _finish_status(status: dict[str, Any], state: str, return_code: int) -> dict[str, Any]:
+    finished_at = time.time()
+    status.update({"state": state, "finished_at": finished_at, "return_code": return_code})
+    if "started_at" in status:
+        status["elapsed_secs"] = round(finished_at - float(status["started_at"]), 3)
+    if state == "interrupted":
+        status["error"] = "Background render worker exited before reporting a terminal state"
+    return status
+
+
+def _reconcile_locked(
+    job_id: str,
+    status_path: Path,
+    status: dict[str, Any],
+    process: Any,
+) -> dict[str, Any]:
+    return_code = process.poll()
+    if return_code is None:
+        return _with_ownership(status, True)
+    if status.get("state") not in _TERMINAL_STATES:
+        state = "cancelled" if status.get("state") == "cancelling" else "interrupted"
+        _finish_status(status, state, return_code)
+        _write_json(status_path, status)
+    _PROCESS_HANDLES.pop(job_id, None)
+    return _with_ownership(status, False)
+
+
+def _terminate_process_tree(process: Any) -> None:
+    """Terminate one worker tree whose live Popen handle is owned here."""
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        completed = subprocess.run(  # noqa: S603
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if completed.returncode and process.poll() is None:
+            raise RuntimeError("Failed to terminate the background render process tree")
+    else:
+        killpg = getattr(os, "killpg", None)
+        if killpg is None:
+            raise RuntimeError("Process-group termination is unavailable")
+        try:
+            killpg(process.pid, _SIGTERM)
+        except ProcessLookupError:
+            return
+    try:
+        process.wait(timeout=_CANCEL_GRACE_SECS)
+    except subprocess.TimeoutExpired as exc:
+        if os.name == "nt":
+            raise RuntimeError("Background render process tree did not exit") from exc
+        killpg(process.pid, _SIGKILL)
+        process.wait(timeout=_CANCEL_GRACE_SECS)
 
 
 def launch_background_render(
@@ -67,7 +152,11 @@ def launch_background_render(
     _write_json(status_path, initial)
     child_env = dict(os.environ)
     child_env["DCC_MCP_BACKGROUND_RENDER"] = "1"
-    creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
     with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
         process = subprocess.Popen(  # noqa: S603
             command,
@@ -78,15 +167,66 @@ def launch_background_render(
             env=child_env,
             creationflags=creationflags,
             close_fds=True,
+            start_new_session=os.name != "nt",
         )
     initial.update({"pid": process.pid})
+    with _PROCESS_LOCK:
+        _PROCESS_HANDLES[job_id] = process
     return initial
 
 
 def read_render_job(job_id: str) -> dict[str, Any]:
-    if not job_id or any(char not in "0123456789abcdef" for char in job_id.lower()):
-        raise ValueError("job_id must be a hexadecimal identifier")
-    status_path = Path(tempfile.gettempdir()) / "dcc-mcp-houdini-render-jobs" / job_id / "status.json"
-    if not status_path.is_file():
-        raise FileNotFoundError("Render job was not found")
-    return json.loads(status_path.read_text(encoding="utf-8"))
+    status_path = _status_path(job_id)
+    with _PROCESS_LOCK:
+        status = _read_status(status_path)
+        process = _PROCESS_HANDLES.get(job_id)
+        if process is None:
+            return _with_ownership(status, False)
+        return _reconcile_locked(job_id, status_path, status, process)
+
+
+def cancel_render_job(job_id: str) -> dict[str, Any]:
+    """Cancel a live render only when this process owns its Popen handle."""
+    status_path = _status_path(job_id)
+    with _PROCESS_LOCK:
+        status = _read_status(status_path)
+        process = _PROCESS_HANDLES.get(job_id)
+        if status.get("state") in _TERMINAL_STATES:
+            if process is not None and process.poll() is not None:
+                _PROCESS_HANDLES.pop(job_id, None)
+                process = None
+            result = _with_ownership(status, process is not None)
+            result["cancel_requested"] = False
+            return result
+        if process is None:
+            result = _with_ownership(status, False)
+            result.update(
+                {
+                    "cancel_requested": False,
+                    "reason": "Render job is not owned by this adapter process",
+                }
+            )
+            return result
+        if process.poll() is not None:
+            result = _reconcile_locked(job_id, status_path, status, process)
+            result["cancel_requested"] = False
+            return result
+
+        status.update({"state": "cancelling", "cancel_requested_at": time.time()})
+        _write_json(status_path, status)
+        _terminate_process_tree(process)
+
+        latest = _read_status(status_path)
+        if latest.get("state") in _TERMINAL_STATES:
+            result = _with_ownership(latest, process.poll() is None)
+            result["cancel_requested"] = True
+            return result
+        return_code = process.poll()
+        if return_code is None:
+            raise RuntimeError("Background render process tree is still running")
+        _finish_status(latest, "cancelled", return_code)
+        _write_json(status_path, latest)
+        _PROCESS_HANDLES.pop(job_id, None)
+        result = _with_ownership(latest, False)
+        result["cancel_requested"] = True
+        return result

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -154,9 +154,7 @@ def launch_background_render(
     child_env["DCC_MCP_BACKGROUND_RENDER"] = "1"
     creationflags = 0
     if os.name == "nt":
-        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
-            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
-        )
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
     with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
         process = subprocess.Popen(  # noqa: S603
             command,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -13,7 +13,7 @@ from _render_common import expanded_outputs, output_snapshot, render_node, reque
 
 
 def write_status(path: Path, payload: dict) -> None:
-    pending = path.with_suffix(".tmp")
+    pending = path.with_name("{}.{}.tmp".format(path.name, os.getpid()))
     pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     os.replace(str(pending), str(path))
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/cancel_render_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/cancel_render_job.py
@@ -1,0 +1,27 @@
+"""Cancel an isolated background render owned by this adapter process."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _background_render import cancel_render_job as _cancel_render_job  # noqa: E402
+
+
+def cancel_render_job(job_id: str) -> dict:
+    try:
+        result = _cancel_render_job(job_id)
+        return skill_success("Resolved background render cancellation", **result)
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cancel background render job")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return cancel_render_job(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -170,6 +170,26 @@ tools:
       properties:
         job_id:
           type: string
+  - name: cancel_render_job
+    description: Cancel a background ROP render owned by the current adapter process. Repeated calls are safe.
+    source_file: scripts/cancel_render_job.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 10
+    group: render
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
   - name: create_render_layer
     description: >-
       Create a render layer (Render Product in Solaris /stage or merge in ROP

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -409,9 +409,7 @@ class TestRenderExecution:
         process.wait.return_value = 0
         completed = MagicMock(returncode=0)
 
-        with patch.object(mod.os, "name", "nt"), patch.object(
-            mod.subprocess, "run", return_value=completed
-        ) as run:
+        with patch.object(mod.os, "name", "nt"), patch.object(mod.subprocess, "run", return_value=completed) as run:
             mod._terminate_process_tree(process)
 
         run.assert_called_once_with(

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 _SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
 
@@ -296,6 +299,140 @@ class TestRenderExecution:
         assert popen.call_args.args[0][0] == str(hython)
         assert popen.call_args.kwargs["env"]["PARENT_ONLY"] == "keep"
         assert popen.call_args.kwargs["env"]["DCC_MCP_BACKGROUND_RENDER"] == "1"
+        assert popen.call_args.kwargs["start_new_session"] is (mod.os.name != "nt")
+        assert mod._PROCESS_HANDLES[job["job_id"]] is process
+
+    def test_cancel_background_render_is_idempotent(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "a" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        status_path = job_dir / "status.json"
+        status_path.write_text(json.dumps({"job_id": job_id, "state": "running"}), encoding="utf-8")
+        process = MagicMock(pid=4321)
+        process.poll.side_effect = [None, 0, 0]
+        mod._PROCESS_HANDLES[job_id] = process
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod, "_terminate_process_tree"
+        ) as terminate:
+            first = mod.cancel_render_job(job_id)
+            second = mod.cancel_render_job(job_id)
+
+        assert first["state"] == "cancelled"
+        assert first["cancel_requested"] is True
+        assert second["state"] == "cancelled"
+        assert second["cancel_requested"] is False
+        terminate.assert_called_once_with(process)
+
+    def test_cancel_never_uses_unowned_status_pid(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "b" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        (job_dir / "status.json").write_text(
+            json.dumps({"job_id": job_id, "state": "running", "pid": 999999}), encoding="utf-8"
+        )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod, "_terminate_process_tree"
+        ) as terminate:
+            result = mod.cancel_render_job(job_id)
+
+        assert result["state"] == "running"
+        assert result["cancel_requested"] is False
+        assert result["owned_by_current_process"] is False
+        terminate.assert_not_called()
+
+    def test_cancel_unknown_job_does_not_terminate_any_process(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod, "_terminate_process_tree"
+        ) as terminate, pytest.raises(FileNotFoundError):
+            mod.cancel_render_job("e" * 32)
+
+        terminate.assert_not_called()
+
+    def test_get_render_job_reconciles_exited_owned_worker(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "c" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        (job_dir / "status.json").write_text(
+            json.dumps({"job_id": job_id, "state": "running", "started_at": 10.0}), encoding="utf-8"
+        )
+        process = MagicMock(pid=4321)
+        process.poll.return_value = 7
+        mod._PROCESS_HANDLES[job_id] = process
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod.time, "time", return_value=15.0
+        ):
+            result = mod.read_render_job(job_id)
+
+        assert result["state"] == "interrupted"
+        assert result["return_code"] == 7
+        assert result["elapsed_secs"] == 5.0
+        assert result["owned_by_current_process"] is False
+
+    def test_cancel_complete_race_preserves_completed_state(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "d" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        status_path = job_dir / "status.json"
+        status_path.write_text(json.dumps({"job_id": job_id, "state": "running"}), encoding="utf-8")
+        process = MagicMock(pid=4321)
+        process.poll.return_value = None
+        mod._PROCESS_HANDLES[job_id] = process
+
+        def finish(_process):
+            status_path.write_text(
+                json.dumps({"job_id": job_id, "state": "completed", "written_files": ["beauty.exr"]}),
+                encoding="utf-8",
+            )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod, "_terminate_process_tree", side_effect=finish
+        ):
+            result = mod.cancel_render_job(job_id)
+
+        assert result["state"] == "completed"
+        assert result["written_files"] == ["beauty.exr"]
+        assert result["cancel_requested"] is True
+
+    def test_terminate_process_tree_uses_taskkill_on_windows(self) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        process = MagicMock(pid=4321)
+        process.poll.return_value = None
+        process.wait.return_value = 0
+        completed = MagicMock(returncode=0)
+
+        with patch.object(mod.os, "name", "nt"), patch.object(
+            mod.subprocess, "run", return_value=completed
+        ) as run:
+            mod._terminate_process_tree(process)
+
+        run.assert_called_once_with(
+            ["taskkill", "/PID", "4321", "/T", "/F"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        process.wait.assert_called_once()
+
+    def test_terminate_process_tree_uses_process_group_on_posix(self) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        process = MagicMock(pid=4321)
+        process.poll.return_value = None
+        process.wait.side_effect = [subprocess.TimeoutExpired("hython", 2), 0]
+
+        with patch.object(mod.os, "name", "posix"), patch.object(mod.os, "killpg", create=True) as killpg:
+            mod._terminate_process_tree(process)
+
+        assert killpg.call_args_list[0].args == (4321, mod._SIGTERM)
+        assert killpg.call_args_list[1].args == (4321, mod._SIGKILL)
 
     def test_background_worker_reports_only_updated_requested_outputs(self, tmp_path: Path) -> None:
         stale = tmp_path / "beauty.0001.exr"


### PR DESCRIPTION
## Summary
- retain live `Popen` handles for background ROP workers and launch POSIX process groups / Windows child trees
- add an idempotent `cancel_render_job` tool with `affinity: any`
- reconcile exited owned workers as `interrupted` and preserve terminal results during cancel/complete races
- document why hwebserver is optional ingress, not a replacement for Houdini host-thread coordination

## Safety
- cancellation only targets a worker handle created by the current adapter process
- persisted status-file PIDs are never used as ownership evidence
- unknown and non-owned jobs do not terminate any process

## Validation
- `python -m pytest -q` — 424 passed, 1 skipped, 2 deselected
- `python -m ruff check .`
- `python tools/check_py37_syntax.py`
- `python tools/lint_skills.py`

Addresses #103.