### PR TITLE
feat: make node-chain builds atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * share owned isolated ROP jobs across renders, simulation caches, and ROP chains
 * derive bounded output progress and ETA during job polling
+* make `build_node_chain` an atomic prevalidated transaction with dry-run, one-step undo, explicit rollback, and scene readback
 
 ### Bug Fixes
 
@@ -19,7 +20,6 @@
 ### Features
 
 * isolate long-running ROP jobs ([#109](https://github.com/dcc-mcp/dcc-mcp-houdini/issues/109)) ([08f7ab3](https://github.com/dcc-mcp/dcc-mcp-houdini/commit/08f7ab30eb8bb593deab09586e4d36ae62a04dfb))
-
 ## [0.13.0](https://github.com/dcc-mcp/dcc-mcp-houdini/compare/v0.12.0...v0.13.0) (2026-07-16)
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     dcc: houdini
     layer: pipeline
     stage: pipeline
-    version: "1.0.0"
+    version: "1.1.0"
     tags: [houdini, automation, hip, timeline, pipeline, scripts]
     search-hint: "run python file, save hip, load hip, timeline, build node chain"
     search-aliases: [run script file, save hip, open hip, load scene, set frame range, timeline, build node chain, automate houdini]
@@ -44,3 +44,16 @@ metadata:
 
 Higher-level repeatable automation for Houdini sessions. Prefer `run_python_file`
 for reviewed scripts on disk, and `build_node_chain` for compact graph recipes.
+
+`build_node_chain` is a structured atomic mutation surface, not an arbitrary
+code executor. It validates the parent, every node type/name/reference, and all
+connection references/port indices before opening an undo group. Use
+`dry_run=true` to inspect `validated` and predicted `affected_paths` with zero
+scene mutation.
+
+On execution, the complete recipe uses one named Houdini undo group. Results
+include `transaction_id`, `undo_label`, validation evidence, and post-cook
+`readback`. If creation, parameter assignment, connection, layout, cook, or
+readback fails, the tool explicitly removes created nodes and restores any
+existing input connections and existing node positions touched by layout. Check
+`rollback.complete` and `rollback.errors` before retrying a failed recipe.

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/_atomic_node_chain.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/_atomic_node_chain.py
@@ -1,0 +1,807 @@
+"""Validation and transaction data for structured node-chain builds.
+
+This module deliberately contains no MCP response formatting.  It models and
+validates a recipe against the live parent network before the caller is allowed
+to mutate Houdini.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+
+class NodeChainValidationError(ValueError):
+    """Raised when a recipe cannot be executed without partial mutation."""
+
+    def __init__(self, errors: Sequence[Dict[str, Any]]) -> None:
+        super().__init__("Node-chain validation failed")
+        self.errors = list(errors)
+
+
+class NodeChainExecutionError(RuntimeError):
+    """Execution failed after mutation began and an explicit rollback ran."""
+
+    def __init__(
+        self,
+        cause: BaseException,
+        rollback: Dict[str, Any],
+        affected_paths: Sequence[str],
+    ) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+        self.rollback = rollback
+        self.affected_paths = list(affected_paths)
+
+
+@dataclass(frozen=True)
+class PlannedNode:
+    index: int
+    node_type: str
+    node_type_object: Any
+    node_name: Optional[str]
+    reference: str
+    parameters: Dict[str, Any]
+    aliases: Tuple[str, ...]
+    predicted_path: str
+
+
+@dataclass(frozen=True)
+class NodeReference:
+    value: str
+    planned_index: Optional[int] = None
+    existing_node: Any = None
+
+    @property
+    def is_planned(self) -> bool:
+        return self.planned_index is not None
+
+    def identity(self) -> Tuple[str, Any]:
+        if self.is_planned:
+            return ("planned", self.planned_index)
+        return ("existing", self.existing_node.path())
+
+
+@dataclass(frozen=True)
+class PlannedConnection:
+    index: int
+    input_ref: NodeReference
+    output_ref: NodeReference
+    input_index: int
+    output_index: int
+
+
+@dataclass(frozen=True)
+class NodeChainPlan:
+    parent: Any
+    nodes: Tuple[PlannedNode, ...]
+    connections: Tuple[PlannedConnection, ...]
+    layout: bool
+    cook_last: bool
+    existing_children: Tuple[Any, ...]
+
+    def validated_summary(self) -> Dict[str, Any]:
+        return {
+            "valid": True,
+            "parent_path": self.parent.path(),
+            "node_count": len(self.nodes),
+            "connection_count": len(self.connections),
+            "node_types": sorted({node.node_type for node in self.nodes}),
+            "references": [node.reference for node in self.nodes],
+            "checks": [
+                "parent_network",
+                "parent_editable",
+                "node_specs",
+                "node_types",
+                "unique_names_and_references",
+                "connection_references_and_indices",
+            ],
+        }
+
+    def predicted_affected_paths(self) -> List[str]:
+        paths = [node.predicted_path for node in self.nodes]
+        for connection in self.connections:
+            if not connection.input_ref.is_planned:
+                paths.append(connection.input_ref.existing_node.path())
+        if self.layout:
+            paths.extend(node.path() for node in self.existing_children)
+        return sorted(set(paths))
+
+
+class NodeChainValidator:
+    """Compile an untrusted recipe into an immutable, executable plan."""
+
+    def __init__(self, hou: Any) -> None:
+        self._hou = hou
+        self._errors: List[Dict[str, Any]] = []
+
+    def validate(
+        self,
+        parent_path: str,
+        nodes: Any,
+        connections: Any,
+        *,
+        layout: bool,
+        cook_last: bool,
+    ) -> NodeChainPlan:
+        self._errors = []
+        parent = self._validate_parent(parent_path)
+        if parent is None:
+            raise NodeChainValidationError(self._errors)
+
+        existing_children = tuple(parent.children())
+        node_types = self._available_node_types(parent)
+        planned_nodes, aliases = self._validate_nodes(
+            parent,
+            parent_path,
+            nodes,
+            node_types,
+            existing_children,
+        )
+        planned_connections = self._validate_connections(
+            parent,
+            connections,
+            planned_nodes,
+            aliases,
+        )
+        if self._errors:
+            raise NodeChainValidationError(self._errors)
+        return NodeChainPlan(
+            parent=parent,
+            nodes=tuple(planned_nodes),
+            connections=tuple(planned_connections),
+            layout=bool(layout),
+            cook_last=bool(cook_last),
+            existing_children=existing_children,
+        )
+
+    def _validate_parent(self, parent_path: Any) -> Any:
+        if not isinstance(parent_path, str) or not parent_path.strip():
+            self._add_error("parent_path", "must be a non-empty string")
+            return None
+        parent = self._hou.node(parent_path)
+        if parent is None:
+            self._add_error("parent_path", "parent network does not exist", value=parent_path)
+            return None
+        try:
+            if not parent.isNetwork():
+                self._add_error("parent_path", "node is not a parent network", value=parent_path)
+                return None
+            if not parent.isEditable():
+                self._add_error("parent_path", "parent network is not editable", value=parent_path)
+                return None
+        except Exception as exc:  # noqa: BLE001
+            self._add_error("parent_path", "failed to inspect parent network", value=parent_path, detail=str(exc))
+            return None
+        return parent
+
+    def _available_node_types(self, parent: Any) -> Dict[str, Any]:
+        try:
+            category = parent.childTypeCategory()
+            node_types = category.nodeTypes() if category is not None else {}
+        except Exception as exc:  # noqa: BLE001
+            self._add_error("parent_path", "failed to inspect child node types", detail=str(exc))
+            return {}
+        if not isinstance(node_types, dict):
+            self._add_error("parent_path", "child node type catalog is unavailable")
+            return {}
+        return node_types
+
+    def _validate_nodes(
+        self,
+        parent: Any,
+        parent_path: str,
+        raw_nodes: Any,
+        node_types: Dict[str, Any],
+        existing_children: Tuple[Any, ...],
+    ) -> Tuple[List[PlannedNode], Dict[str, int]]:
+        if not isinstance(raw_nodes, list) or not raw_nodes:
+            self._add_error("nodes", "must be a non-empty array")
+            return [], {}
+
+        existing_names = {node.name() for node in existing_children}
+        existing_paths = {node.path() for node in existing_children}
+        aliases: Dict[str, int] = {}
+        names: Dict[str, int] = {}
+        planned: List[PlannedNode] = []
+
+        for index, raw in enumerate(raw_nodes):
+            field = "nodes[{}]".format(index)
+            if not isinstance(raw, dict):
+                self._add_error(field, "must be an object")
+                continue
+            node_type = raw.get("node_type")
+            if not isinstance(node_type, str) or not node_type.strip():
+                self._add_error("{}.node_type".format(field), "must be a non-empty string")
+                continue
+            node_type = node_type.strip()
+            type_object = node_types.get(node_type)
+            if type_object is None:
+                self._add_error(
+                    "{}.node_type".format(field),
+                    "node type is not available in the parent network",
+                    value=node_type,
+                )
+
+            node_name = raw.get("node_name")
+            if node_name is not None:
+                if not isinstance(node_name, str) or not node_name.strip():
+                    self._add_error("{}.node_name".format(field), "must be a non-empty string")
+                    node_name = None
+                else:
+                    node_name = node_name.strip()
+                    self._validate_node_name(node_name, "{}.node_name".format(field))
+                    if node_name in names:
+                        self._add_error(
+                            "{}.node_name".format(field),
+                            "node name duplicates another planned node",
+                            value=node_name,
+                        )
+                    if node_name in existing_names:
+                        self._add_error(
+                            "{}.node_name".format(field),
+                            "node name already exists in the parent network",
+                            value=node_name,
+                        )
+                    names[node_name] = index
+
+            explicit_ref = raw.get("ref")
+            if explicit_ref is not None and (not isinstance(explicit_ref, str) or not explicit_ref.strip()):
+                self._add_error("{}.ref".format(field), "must be a non-empty string")
+                explicit_ref = None
+            reference = explicit_ref.strip() if isinstance(explicit_ref, str) else node_name
+            if not reference:
+                reference = "node_{}".format(index)
+
+            parameters = raw.get("parameters") or {}
+            if not isinstance(parameters, dict):
+                self._add_error("{}.parameters".format(field), "must be an object")
+                parameters = {}
+
+            predicted_path = (
+                "{}/{}".format(parent_path.rstrip("/"), node_name) if node_name else "planned:{}".format(reference)
+            )
+            node_aliases = tuple(dict.fromkeys(alias for alias in (reference, node_name, predicted_path) if alias))
+            for alias in node_aliases:
+                previous = aliases.get(alias)
+                if previous is not None and previous != index:
+                    self._add_error(
+                        "{}.ref".format(field),
+                        "reference is not unique",
+                        value=alias,
+                    )
+                elif alias in existing_names or alias in existing_paths:
+                    self._add_error(
+                        "{}.ref".format(field),
+                        "reference collides with an existing node",
+                        value=alias,
+                    )
+                else:
+                    aliases[alias] = index
+
+            planned.append(
+                PlannedNode(
+                    index=index,
+                    node_type=node_type,
+                    node_type_object=type_object,
+                    node_name=node_name,
+                    reference=reference,
+                    parameters=dict(parameters),
+                    aliases=node_aliases,
+                    predicted_path=predicted_path,
+                )
+            )
+        return planned, aliases
+
+    def _validate_node_name(self, node_name: str, field: str) -> None:
+        text_api = getattr(self._hou, "text", None)
+        variable_name = getattr(text_api, "variableName", None)
+        if not callable(variable_name):
+            self._add_error(
+                field,
+                "Houdini runtime does not expose hou.text.variableName for node-name validation",
+            )
+            return
+        try:
+            normalized = variable_name(node_name, ".-")
+        except Exception as exc:  # noqa: BLE001
+            self._add_error(field, "failed to validate Houdini node name", detail=str(exc))
+            return
+        if normalized != node_name:
+            self._add_error(
+                field,
+                "node name is not valid in Houdini",
+                value=node_name,
+                normalized=normalized,
+            )
+
+    def _validate_connections(
+        self,
+        parent: Any,
+        raw_connections: Any,
+        planned_nodes: List[PlannedNode],
+        aliases: Dict[str, int],
+    ) -> List[PlannedConnection]:
+        if raw_connections is None:
+            raw_connections = []
+        if not isinstance(raw_connections, list):
+            self._add_error("connections", "must be an array")
+            return []
+
+        planned_by_index = {node.index: node for node in planned_nodes}
+        occupied_targets = set()
+        planned_connections: List[PlannedConnection] = []
+        for index, raw in enumerate(raw_connections):
+            field = "connections[{}]".format(index)
+            if not isinstance(raw, dict):
+                self._add_error(field, "must be an object")
+                continue
+            input_ref = self._resolve_reference(parent, raw.get("input"), aliases, "{}.input".format(field))
+            output_ref = self._resolve_reference(
+                parent,
+                raw.get("output"),
+                aliases,
+                "{}.output".format(field),
+            )
+            input_index = self._validate_index(raw.get("input_index", 0), "{}.input_index".format(field))
+            output_index = self._validate_index(
+                raw.get("output_index", 0),
+                "{}.output_index".format(field),
+            )
+            if input_ref is None or output_ref is None or input_index is None or output_index is None:
+                continue
+
+            target_key = (input_ref.identity(), input_index)
+            if target_key in occupied_targets:
+                self._add_error(
+                    "{}.input_index".format(field),
+                    "multiple connections target the same input slot",
+                    value=input_index,
+                )
+            occupied_targets.add(target_key)
+            if input_ref.identity() == output_ref.identity():
+                self._add_error(field, "self-connections are not allowed")
+
+            input_type = self._reference_type(input_ref, planned_by_index)
+            output_type = self._reference_type(output_ref, planned_by_index)
+            self._validate_port_range(input_type, input_index, True, "{}.input_index".format(field))
+            self._validate_port_range(output_type, output_index, False, "{}.output_index".format(field))
+            planned_connections.append(
+                PlannedConnection(
+                    index=index,
+                    input_ref=input_ref,
+                    output_ref=output_ref,
+                    input_index=input_index,
+                    output_index=output_index,
+                )
+            )
+        return planned_connections
+
+    def _resolve_reference(
+        self,
+        parent: Any,
+        value: Any,
+        aliases: Dict[str, int],
+        field: str,
+    ) -> Optional[NodeReference]:
+        if not isinstance(value, str) or not value.strip():
+            self._add_error(field, "must be a non-empty node reference")
+            return None
+        value = value.strip()
+        if value in aliases:
+            return NodeReference(value=value, planned_index=aliases[value])
+        try:
+            existing = parent.node(value)
+            if existing is None and value.startswith("/"):
+                existing = self._hou.node(value)
+        except Exception as exc:  # noqa: BLE001
+            self._add_error(field, "failed to resolve node reference", value=value, detail=str(exc))
+            return None
+        if existing is None:
+            self._add_error(field, "node reference does not exist", value=value)
+            return None
+        try:
+            existing_parent = existing.parent()
+            parent_path = parent.path()
+            existing_parent_path = existing_parent.path() if existing_parent is not None else None
+        except Exception as exc:  # noqa: BLE001
+            self._add_error(
+                field,
+                "failed to inspect node reference network",
+                value=value,
+                detail=str(exc),
+            )
+            return None
+        if existing_parent_path != parent_path:
+            self._add_error(
+                field,
+                "existing node is not a child of the parent network",
+                value=value,
+                parent_path=parent_path,
+            )
+            return None
+        return NodeReference(value=value, existing_node=existing)
+
+    def _validate_index(self, value: Any, field: str) -> Optional[int]:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            self._add_error(field, "must be a non-negative integer", value=value)
+            return None
+        return value
+
+    def _reference_type(self, ref: NodeReference, planned: Dict[int, PlannedNode]) -> Any:
+        if ref.is_planned:
+            return planned[ref.planned_index].node_type_object
+        return ref.existing_node.type()
+
+    def _validate_port_range(self, type_object: Any, index: int, is_input: bool, field: str) -> None:
+        if type_object is None:
+            return
+        method_name = "maxNumInputs" if is_input else "maxNumOutputs"
+        method = getattr(type_object, method_name, None)
+        try:
+            maximum = int(method()) if callable(method) else None
+        except Exception as exc:  # noqa: BLE001
+            self._add_error(field, "failed to inspect node port range", detail=str(exc))
+            return
+        if maximum is None:
+            self._add_error(field, "node type does not expose a port range")
+        elif index >= maximum:
+            self._add_error(
+                field,
+                "index is outside the node type port range",
+                value=index,
+                maximum=maximum,
+            )
+
+    def _add_error(self, field: str, message: str, **details: Any) -> None:
+        error = {"field": field, "message": message}
+        error.update(details)
+        self._errors.append(error)
+
+
+@dataclass(frozen=True)
+class InputSnapshot:
+    node: Any
+    input_index: int
+    source_item: Any
+    output_index: int
+
+
+@dataclass(frozen=True)
+class PositionSnapshot:
+    node: Any
+    position: Any
+
+
+@dataclass(frozen=True)
+class NodeChainExecutionResult:
+    nodes: Tuple[Any, ...]
+    cooked_node: Any
+    affected_paths: Tuple[str, ...]
+    readback: Dict[str, Any]
+
+
+class AtomicNodeChainExecutor:
+    """Apply one validated plan, or explicitly restore its complete pre-state."""
+
+    def __init__(
+        self,
+        hou: Any,
+        parameter_setter: Callable[[Any, str, Any], None],
+        node_summarizer: Callable[[Any], Dict[str, Any]],
+    ) -> None:
+        self._hou = hou
+        self._set_parameter = parameter_setter
+        self._summarize_node = node_summarizer
+
+    def execute(self, plan: NodeChainPlan, undo_label: str) -> NodeChainExecutionResult:
+        input_snapshots = self._capture_input_snapshots(plan)
+        position_snapshots = self._capture_position_snapshots(plan)
+        created: Dict[int, Any] = {}
+        ordered: List[Any] = []
+        created_paths: List[str] = []
+        try:
+            with self._hou.undos.group(undo_label):
+                try:
+                    for planned in plan.nodes:
+                        node = plan.parent.createNode(
+                            planned.node_type,
+                            node_name=planned.node_name,
+                            exact_type_name=True,
+                        )
+                        created[planned.index] = node
+                        ordered.append(node)
+                        created_paths.append(node.path())
+                        for parm_name, value in planned.parameters.items():
+                            self._set_parameter(node, parm_name, value)
+
+                    for connection in plan.connections:
+                        input_node = self._resolve(connection.input_ref, created)
+                        output_node = self._resolve(connection.output_ref, created)
+                        input_node.setInput(
+                            connection.input_index,
+                            output_node,
+                            connection.output_index,
+                        )
+
+                    if plan.layout:
+                        plan.parent.layoutChildren()
+
+                    cooked_node = ordered[-1] if plan.cook_last and ordered else None
+                    if cooked_node is not None:
+                        cooked_node.cook(force=False)
+
+                    readback = self._readback(plan, created, ordered, cooked_node)
+                except Exception as exc:
+                    rollback = self._rollback(
+                        created=ordered,
+                        created_paths=created_paths,
+                        input_snapshots=input_snapshots,
+                        position_snapshots=position_snapshots,
+                    )
+                    affected_paths = self._affected_paths(plan, created_paths)
+                    raise NodeChainExecutionError(exc, rollback, affected_paths) from exc
+        except NodeChainExecutionError:
+            raise
+        except Exception as exc:
+            # Entering or leaving the undo group can itself fail.  No mutation
+            # is expected on enter failure; on exit failure this second,
+            # idempotent restoration is the safest available recovery path.
+            rollback = self._rollback(
+                created=ordered,
+                created_paths=created_paths,
+                input_snapshots=input_snapshots,
+                position_snapshots=position_snapshots,
+            )
+            affected_paths = self._affected_paths(plan, created_paths)
+            raise NodeChainExecutionError(exc, rollback, affected_paths) from exc
+
+        return NodeChainExecutionResult(
+            nodes=tuple(ordered),
+            cooked_node=cooked_node,
+            affected_paths=tuple(self._affected_paths(plan, created_paths)),
+            readback=readback,
+        )
+
+    def _capture_input_snapshots(self, plan: NodeChainPlan) -> List[InputSnapshot]:
+        snapshots: List[InputSnapshot] = []
+        seen = set()
+        for connection in plan.connections:
+            if connection.input_ref.is_planned:
+                continue
+            node = connection.input_ref.existing_node
+            key = (node.path(), connection.input_index)
+            if key in seen:
+                continue
+            seen.add(key)
+            current = self._connection_at(node, connection.input_index)
+            snapshots.append(
+                InputSnapshot(
+                    node=node,
+                    input_index=connection.input_index,
+                    source_item=current.inputItem() if current is not None else None,
+                    output_index=current.inputItemOutputIndex() if current is not None else 0,
+                )
+            )
+        return snapshots
+
+    def _capture_position_snapshots(self, plan: NodeChainPlan) -> List[PositionSnapshot]:
+        if not plan.layout:
+            return []
+        return [PositionSnapshot(node=node, position=node.position()) for node in plan.existing_children]
+
+    @staticmethod
+    def _resolve(ref: NodeReference, created: Dict[int, Any]) -> Any:
+        if ref.is_planned:
+            return created[ref.planned_index]
+        return ref.existing_node
+
+    def _readback(
+        self,
+        plan: NodeChainPlan,
+        created: Dict[int, Any],
+        ordered: List[Any],
+        cooked_node: Any,
+    ) -> Dict[str, Any]:
+        node_results = []
+        for node in ordered:
+            scene_node = plan.parent.node(node.name())
+            if scene_node is None or scene_node.path() != node.path():
+                raise RuntimeError("Created node failed scene readback: {}".format(node.path()))
+            node_results.append(self._summarize_node(scene_node))
+
+        connection_results = []
+        for planned in plan.connections:
+            input_node = self._resolve(planned.input_ref, created)
+            output_node = self._resolve(planned.output_ref, created)
+            actual = self._connection_at(input_node, planned.input_index)
+            matches = bool(
+                actual is not None
+                and actual.inputItem() == output_node
+                and actual.inputItemOutputIndex() == planned.output_index
+            )
+            entry = {
+                "input_path": input_node.path(),
+                "input_index": planned.input_index,
+                "output_path": output_node.path(),
+                "output_index": planned.output_index,
+                "matches": matches,
+            }
+            connection_results.append(entry)
+            if not matches:
+                raise RuntimeError("Connection failed scene readback: {}".format(entry))
+
+        cook_result = {"performed": cooked_node is not None}
+        if cooked_node is not None:
+            cook_result.update(
+                {
+                    "node": self._summarize_node(cooked_node),
+                    "errors": list(cooked_node.errors()) if hasattr(cooked_node, "errors") else [],
+                    "warnings": list(cooked_node.warnings()) if hasattr(cooked_node, "warnings") else [],
+                }
+            )
+        return {
+            "performed": True,
+            "nodes": node_results,
+            "connections": connection_results,
+            "cook": cook_result,
+        }
+
+    @staticmethod
+    def _connection_at(node: Any, input_index: int) -> Any:
+        for connection in node.inputConnections():
+            if connection.inputIndex() == input_index:
+                return connection
+        return None
+
+    def _rollback(
+        self,
+        *,
+        created: List[Any],
+        created_paths: List[str],
+        input_snapshots: List[InputSnapshot],
+        position_snapshots: List[PositionSnapshot],
+    ) -> Dict[str, Any]:
+        evidence: Dict[str, Any] = {
+            "attempted": True,
+            "complete": True,
+            "created_paths": list(created_paths),
+            "deleted_paths": [],
+            "restored_connections": [],
+            "restored_positions": [],
+            "errors": [],
+        }
+        for snapshot in input_snapshots:
+            try:
+                snapshot.node.setInput(
+                    snapshot.input_index,
+                    snapshot.source_item,
+                    snapshot.output_index,
+                )
+                evidence["restored_connections"].append(
+                    {
+                        "input_path": snapshot.node.path(),
+                        "input_index": snapshot.input_index,
+                        "output_path": snapshot.source_item.path() if snapshot.source_item is not None else None,
+                        "output_index": snapshot.output_index,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append(
+                    "restore connection {}[{}]: {}".format(
+                        self._safe_node_path(snapshot.node),
+                        snapshot.input_index,
+                        exc,
+                    )
+                )
+
+        for snapshot in position_snapshots:
+            try:
+                snapshot.node.setPosition(snapshot.position)
+                evidence["restored_positions"].append(
+                    {
+                        "path": snapshot.node.path(),
+                        "position": self._position_value(snapshot.position),
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append("restore position {}: {}".format(self._safe_node_path(snapshot.node), exc))
+
+        for index in reversed(range(len(created))):
+            node = created[index]
+            path = created_paths[index] if index < len(created_paths) else None
+            try:
+                path = node.path()
+            except Exception as exc:  # noqa: BLE001
+                if path is None:
+                    evidence["errors"].append("resolve created node path at index {}: {}".format(index, exc))
+                    continue
+            try:
+                live_node = self._hou.node(path)
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append("resolve created node {}: {}".format(path, exc))
+                continue
+            if live_node is None:
+                evidence["deleted_paths"].append(path)
+                continue
+            try:
+                live_node.destroy()
+                evidence["deleted_paths"].append(path)
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append("delete {}: {}".format(path, exc))
+
+        self._verify_rollback(
+            evidence,
+            created_paths=created_paths,
+            input_snapshots=input_snapshots,
+            position_snapshots=position_snapshots,
+        )
+        evidence["complete"] = not evidence["errors"]
+        return evidence
+
+    def _verify_rollback(
+        self,
+        evidence: Dict[str, Any],
+        *,
+        created_paths: List[str],
+        input_snapshots: List[InputSnapshot],
+        position_snapshots: List[PositionSnapshot],
+    ) -> None:
+        for path in created_paths:
+            try:
+                if self._hou.node(path) is not None:
+                    evidence["errors"].append("created node still exists after rollback: {}".format(path))
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append("verify deleted node {}: {}".format(path, exc))
+
+        for snapshot in input_snapshots:
+            try:
+                actual = self._connection_at(snapshot.node, snapshot.input_index)
+                actual_source_item = actual.inputItem() if actual is not None else None
+                actual_output_index = actual.inputItemOutputIndex() if actual is not None else 0
+                if actual_source_item != snapshot.source_item or actual_output_index != snapshot.output_index:
+                    evidence["errors"].append(
+                        "connection rollback verification failed: {}[{}]".format(
+                            snapshot.node.path(),
+                            snapshot.input_index,
+                        )
+                    )
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append(
+                    "verify connection {}[{}]: {}".format(
+                        self._safe_node_path(snapshot.node),
+                        snapshot.input_index,
+                        exc,
+                    )
+                )
+
+        for snapshot in position_snapshots:
+            try:
+                if snapshot.node.position() != snapshot.position:
+                    evidence["errors"].append("position rollback verification failed: {}".format(snapshot.node.path()))
+            except Exception as exc:  # noqa: BLE001
+                evidence["errors"].append("verify position {}: {}".format(self._safe_node_path(snapshot.node), exc))
+
+    @staticmethod
+    def _safe_node_path(node: Any) -> str:
+        try:
+            return str(node.path())
+        except Exception:  # noqa: BLE001
+            return "<deleted-or-unavailable-node>"
+
+    @staticmethod
+    def _position_value(position: Any) -> Any:
+        try:
+            return [float(position[0]), float(position[1])]
+        except (IndexError, TypeError, ValueError):
+            return str(position)
+
+    @staticmethod
+    def _affected_paths(plan: NodeChainPlan, created_paths: List[str]) -> List[str]:
+        paths = list(created_paths)
+        for connection in plan.connections:
+            if not connection.input_ref.is_planned:
+                paths.append(connection.input_ref.existing_node.path())
+        if plan.layout:
+            paths.extend(node.path() for node in plan.existing_children)
+        return sorted(set(paths))

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/build_node_chain.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/build_node_chain.py
@@ -3,25 +3,23 @@
 from __future__ import annotations
 
 import sys
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
+from _atomic_node_chain import (
+    AtomicNodeChainExecutor,
+    NodeChainExecutionError,
+    NodeChainValidationError,
+    NodeChainValidator,
+)
 from _automation_common import hou_import_error, node_summary, set_parm_value
-
-
-def _resolve_created(parent, created: Dict[str, Any], ref: str):
-    if ref in created:
-        return created[ref]
-    node = parent.node(ref)
-    if node is not None:
-        return node
-    return None
 
 
 def build_node_chain(
@@ -30,56 +28,100 @@ def build_node_chain(
     connections: Optional[List[Dict[str, Any]]] = None,
     layout: bool = True,
     cook_last: bool = True,
+    dry_run: bool = False,
 ) -> dict:
-    """Create nodes, wire them, layout, and optionally cook the last node."""
+    """Validate and atomically build a node recipe with readback evidence."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
         return hou_import_error()
 
+    transaction_id = uuid.uuid4().hex
+    undo_label = "DCC MCP: build_node_chain {}".format(transaction_id)
     try:
-        parent = hou.node(parent_path)
-        if parent is None:
-            raise ValueError("Parent node not found: {}".format(parent_path))
-
-        created: Dict[str, Any] = {}
-        ordered = []
-        for spec in nodes:
-            node_type = spec["node_type"]
-            node_name = spec.get("node_name")
-            node = parent.createNode(node_type, node_name=node_name)
-            for parm_name, value in (spec.get("parameters") or {}).items():
-                set_parm_value(node, parm_name, value)
-            created[node.name()] = node
-            created[node.path()] = node
-            ordered.append(node)
-
-        for conn in connections or []:
-            input_node = _resolve_created(parent, created, conn["input"])
-            output_node = _resolve_created(parent, created, conn["output"])
-            if input_node is None or output_node is None:
-                raise ValueError("Connection references unknown node: {}".format(conn))
-            input_node.setInput(
-                int(conn.get("input_index", 0)),
-                output_node,
-                int(conn.get("output_index", 0)),
-            )
-
-        if layout:
-            parent.layoutChildren()
-        cooked = None
-        if cook_last and ordered:
-            cooked = ordered[-1]
-            cooked.cook(force=False)
-
-        return skill_success(
-            "Built Houdini node chain",
-            parent_path=parent.path(),
-            nodes=[node_summary(node) for node in ordered],
-            cooked_node=node_summary(cooked) if cooked is not None else None,
+        plan = NodeChainValidator(hou).validate(
+            parent_path,
+            nodes,
+            connections,
+            layout=layout,
+            cook_last=cook_last,
+        )
+    except NodeChainValidationError as exc:
+        return skill_error(
+            "Invalid Houdini node chain",
+            str(exc),
+            transaction_id=transaction_id,
+            undo_label=undo_label,
+            dry_run=bool(dry_run),
+            affected_paths=[],
+            validated={"valid": False, "errors": exc.errors},
+            readback={"performed": False},
+            rollback={"attempted": False, "complete": True, "errors": []},
         )
     except Exception as exc:
-        return skill_exception(exc, message="Failed to build Houdini node chain")
+        return skill_exception(
+            exc,
+            message="Failed to validate Houdini node chain",
+            transaction_id=transaction_id,
+            undo_label=undo_label,
+            dry_run=bool(dry_run),
+        )
+
+    validated = plan.validated_summary()
+    affected_paths = plan.predicted_affected_paths()
+    if dry_run:
+        return skill_success(
+            "Validated Houdini node chain",
+            transaction_id=transaction_id,
+            undo_label=undo_label,
+            dry_run=True,
+            affected_paths=affected_paths,
+            validated=validated,
+            readback={"performed": False},
+            rollback={"attempted": False, "complete": True, "errors": []},
+        )
+
+    try:
+        execution = AtomicNodeChainExecutor(hou, set_parm_value, node_summary).execute(
+            plan,
+            undo_label,
+        )
+    except NodeChainExecutionError as exc:
+        return skill_error(
+            "Failed to build Houdini node chain",
+            "{}: {}".format(type(exc.cause).__name__, exc.cause),
+            transaction_id=transaction_id,
+            undo_label=undo_label,
+            dry_run=False,
+            affected_paths=exc.affected_paths,
+            validated=validated,
+            readback={"performed": False},
+            rollback=exc.rollback,
+        )
+    except Exception as exc:
+        return skill_exception(
+            exc,
+            message="Failed to build Houdini node chain",
+            transaction_id=transaction_id,
+            undo_label=undo_label,
+            dry_run=False,
+            affected_paths=affected_paths,
+            validated=validated,
+        )
+
+    return skill_success(
+        "Built Houdini node chain",
+        transaction_id=transaction_id,
+        undo_label=undo_label,
+        dry_run=False,
+        parent_path=plan.parent.path(),
+        affected_paths=list(execution.affected_paths),
+        validated=validated,
+        readback=execution.readback,
+        rollback={"attempted": False, "complete": True, "errors": []},
+        nodes=[node_summary(node) for node in execution.nodes],
+        cooked_node=(node_summary(execution.cooked_node) if execution.cooked_node is not None else None),
+    )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
@@ -125,8 +125,9 @@ tools:
 
   - name: build_node_chain
     description: >-
-      Build a small Houdini node chain from structured node specs and
-      connections. Mutates the scene and can cook the last created node.
+      Prevalidate and atomically build a small Houdini node chain from
+      structured node specs and connections. Supports dry-run, one-step undo,
+      explicit rollback evidence, and post-cook scene readback.
     input_schema:
       type: object
       required: [parent_path, nodes]
@@ -145,6 +146,12 @@ tools:
                 type: string
               node_name:
                 type: string
+                description: "Optional unique Houdini node name. Must not already exist under the parent."
+              ref:
+                type: string
+                description: >-
+                  Optional recipe-local unique reference for connections. Uses
+                  node_name when omitted, or node_<index> when both are omitted.
               parameters:
                 type: object
                 additionalProperties: true
@@ -156,10 +163,10 @@ tools:
             properties:
               input:
                 type: string
-                description: "Node name/path receiving the connection."
+                description: "Planned ref/name/path or existing node name/path receiving the connection."
               output:
                 type: string
-                description: "Node name/path providing the connection."
+                description: "Planned ref/name/path or existing node name/path providing the connection."
               input_index:
                 type: integer
                 minimum: 0
@@ -174,6 +181,12 @@ tools:
         cook_last:
           type: boolean
           default: true
+        dry_run:
+          type: boolean
+          default: false
+          description: >-
+            Validate the complete recipe and return predicted affected paths
+            without creating nodes, opening an undo group, laying out, or cooking.
     read_only: false
     destructive: false
     idempotent: false
@@ -183,7 +196,7 @@ tools:
     source_file: scripts/build_node_chain.py
     tool_role: action
     risk: medium
-    search_aliases: [build node chain, create network, node recipe, chain nodes]
+    search_aliases: [build node chain, atomic network, dry run node recipe, create network, node recipe, chain nodes]
     produces: [node_network]
     annotations:
       read_only_hint: false

--- a/tests/test_atomic_node_chain.py
+++ b/tests/test_atomic_node_chain.py
@@ -1,0 +1,648 @@
+"""Behaviour tests for atomic structured Houdini node-chain builds."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).parent.parent
+    / "src"
+    / "dcc_mcp_houdini"
+    / "skills"
+    / "houdini-automation"
+    / "scripts"
+    / "build_node_chain.py"
+)
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("skill_atomic_build_node_chain", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeNodeType:
+    def __init__(self, name: str, max_inputs: int, max_outputs: int) -> None:
+        self._name = name
+        self._max_inputs = max_inputs
+        self._max_outputs = max_outputs
+
+    def name(self) -> str:
+        return self._name
+
+    def maxNumInputs(self) -> int:
+        return self._max_inputs
+
+    def maxNumOutputs(self) -> int:
+        return self._max_outputs
+
+
+class FakeCategory:
+    def __init__(self, node_types: Dict[str, FakeNodeType]) -> None:
+        self._node_types = node_types
+
+    def nodeTypes(self) -> Dict[str, FakeNodeType]:
+        return dict(self._node_types)
+
+
+class FakeParm:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.value: Any = None
+
+    def set(self, value: Any) -> None:
+        if self.fail:
+            raise RuntimeError("parameter write failed")
+        self.value = value
+
+
+class FakeConnection:
+    def __init__(
+        self,
+        input_index: int,
+        source: "FakeNode",
+        destination: "FakeNode",
+        output_index: int,
+    ) -> None:
+        self._input_index = input_index
+        self._source = source
+        self._destination = destination
+        self._output_index = output_index
+
+    def inputIndex(self) -> int:
+        return self._input_index
+
+    def inputNode(self) -> "FakeNode":
+        if isinstance(self._source, FakeIndirectInput):
+            return self._source.upstream
+        return self._source
+
+    def inputItem(self) -> Any:
+        return self._source
+
+    def inputItemOutputIndex(self) -> int:
+        return self._output_index
+
+    def outputNode(self) -> "FakeNode":
+        return self._destination
+
+    def outputIndex(self) -> int:
+        return self._output_index
+
+
+class FakeIndirectInput:
+    def __init__(self, path: str, upstream: Optional["FakeNode"] = None) -> None:
+        self._path = path
+        self.upstream = upstream
+
+    def path(self) -> str:
+        return self._path
+
+
+class FakeNode:
+    def __init__(
+        self,
+        parent: "FakeParent",
+        node_type: FakeNodeType,
+        name: str,
+        *,
+        position: Tuple[float, float] = (0.0, 0.0),
+        failing_parms: Optional[List[str]] = None,
+        cook_fails: bool = False,
+    ) -> None:
+        self._parent = parent
+        self._type = node_type
+        self._name = name
+        self._position = position
+        self._inputs: Dict[int, Tuple[FakeNode, int]] = {}
+        self._parms: Dict[str, FakeParm] = {}
+        self._failing_parms = set(failing_parms or [])
+        self._cook_fails = cook_fails
+        self.cooked = False
+        self.destroyed = False
+
+    def name(self) -> str:
+        return self._name
+
+    def path(self) -> str:
+        if self.destroyed:
+            raise RuntimeError("ObjectWasDeleted")
+        return "{}/{}".format(self._parent.path().rstrip("/"), self._name)
+
+    def parent(self) -> "FakeParent":
+        return self._parent
+
+    def type(self) -> FakeNodeType:
+        return self._type
+
+    def parm(self, name: str) -> FakeParm:
+        if name not in self._parms:
+            self._parms[name] = FakeParm(fail=name in self._failing_parms)
+        return self._parms[name]
+
+    def parmTuple(self, name: str) -> None:
+        return None
+
+    def setInput(self, input_index: int, source: Optional["FakeNode"], output_index: int = 0) -> None:
+        if source is None:
+            self._inputs.pop(input_index, None)
+        else:
+            self._inputs[input_index] = (source, output_index)
+
+    def inputConnections(self) -> Tuple[FakeConnection, ...]:
+        return tuple(
+            FakeConnection(input_index, source, self, output_index)
+            for input_index, (source, output_index) in sorted(self._inputs.items())
+        )
+
+    def position(self) -> Tuple[float, float]:
+        return self._position
+
+    def setPosition(self, position: Tuple[float, float]) -> None:
+        self._position = position
+
+    def cook(self, force: bool = False) -> None:
+        del force
+        if self._cook_fails:
+            raise RuntimeError("cook failed")
+        self.cooked = True
+
+    def errors(self) -> Tuple[str, ...]:
+        return ()
+
+    def warnings(self) -> Tuple[str, ...]:
+        return ()
+
+    def destroy(self) -> None:
+        self.destroyed = True
+        self._parent.remove(self)
+
+
+class FakeParent:
+    def __init__(self, path: str = "/obj/geo1") -> None:
+        self._path = path
+        self.editable = True
+        self.types = {
+            "box": FakeNodeType("box", 0, 1),
+            "null": FakeNodeType("null", 4, 1),
+        }
+        self._children: List[FakeNode] = []
+        self.create_count = 0
+        self.exact_type_name_values: List[bool] = []
+        self.layout_count = 0
+        self.failing_parms: Dict[str, List[str]] = {}
+        self.cook_fail_names: set = set()
+        self.external_nodes: Dict[str, FakeNode] = {}
+
+    def path(self) -> str:
+        return self._path
+
+    def isNetwork(self) -> bool:
+        return True
+
+    def isEditable(self) -> bool:
+        return self.editable
+
+    def childTypeCategory(self) -> FakeCategory:
+        return FakeCategory(self.types)
+
+    def children(self) -> Tuple[FakeNode, ...]:
+        return tuple(self._children)
+
+    def createNode(
+        self,
+        node_type: str,
+        node_name: Optional[str] = None,
+        exact_type_name: bool = False,
+    ) -> FakeNode:
+        self.create_count += 1
+        self.exact_type_name_values.append(exact_type_name)
+        name = node_name or "{}{}".format(node_type, self.create_count)
+        node = FakeNode(
+            self,
+            self.types[node_type],
+            name,
+            failing_parms=self.failing_parms.get(name),
+            cook_fails=name in self.cook_fail_names,
+        )
+        self._children.append(node)
+        return node
+
+    def add_existing(
+        self,
+        node_type: str,
+        name: str,
+        position: Tuple[float, float],
+    ) -> FakeNode:
+        node = FakeNode(self, self.types[node_type], name, position=position)
+        self._children.append(node)
+        return node
+
+    def remove(self, node: FakeNode) -> None:
+        self._children.remove(node)
+
+    def node(self, ref: str) -> Optional[FakeNode]:
+        if ref in self.external_nodes:
+            return self.external_nodes[ref]
+        normalized = ref.rsplit("/", 1)[-1]
+        return next((child for child in self._children if child.name() == normalized), None)
+
+    def layoutChildren(self) -> None:
+        self.layout_count += 1
+        for index, child in enumerate(self._children):
+            child.setPosition((100.0 + index, 200.0))
+
+
+class FakeUndoGroup:
+    def __init__(self, owner: "FakeUndos", label: str) -> None:
+        self.owner = owner
+        self.label = label
+
+    def __enter__(self) -> "FakeUndoGroup":
+        self.owner.entered.append(self.label)
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+        del exc_type, exc, traceback
+        self.owner.exited.append(self.label)
+        if self.owner.raise_on_exit:
+            raise RuntimeError("undo group exit failed")
+        return False
+
+
+class FakeUndos:
+    def __init__(self) -> None:
+        self.entered: List[str] = []
+        self.exited: List[str] = []
+        self.raise_on_exit = False
+
+    def group(self, label: str) -> FakeUndoGroup:
+        return FakeUndoGroup(self, label)
+
+
+class FakeText:
+    @staticmethod
+    def variableName(value: str, safe_chars: str = "") -> str:
+        normalized = "".join(
+            character
+            if character.isascii() and (character.isalnum() or character == "_" or character in safe_chars)
+            else "_"
+            for character in value
+        )
+        if normalized and (normalized[0].isdigit() or normalized[0] in safe_chars):
+            normalized = "_" + normalized
+        return normalized
+
+
+class FakeHou:
+    def __init__(self, parent: FakeParent) -> None:
+        self.parent = parent
+        self.undos = FakeUndos()
+        self.text = FakeText()
+
+    def node(self, path: str) -> Optional[Any]:
+        if path == self.parent.path():
+            return self.parent
+        return self.parent.node(path)
+
+
+def test_dry_run_validates_without_mutating_or_opening_undo_group() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            "/obj/geo1",
+            [
+                {"node_type": "box", "node_name": "box1"},
+                {"node_type": "null", "node_name": "OUT"},
+            ],
+            [{"input": "OUT", "output": "box1"}],
+            dry_run=True,
+        )
+
+    assert result["success"] is True
+    assert result["context"]["dry_run"] is True
+    assert result["context"]["validated"]["valid"] is True
+    assert result["context"]["validated"]["node_count"] == 2
+    assert result["context"]["validated"]["connection_count"] == 1
+    assert result["context"]["readback"] == {"performed": False}
+    assert result["context"]["transaction_id"]
+    assert result["context"]["undo_label"].startswith("DCC MCP: build_node_chain ")
+    assert parent.create_count == 0
+    assert hou.undos.entered == []
+
+
+def test_prevalidation_reports_all_recipe_errors_with_zero_scene_changes() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    parent.add_existing("null", "taken", (1.0, 2.0))
+    hou = FakeHou(parent)
+    before = tuple(parent.children())
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            "/obj/geo1",
+            [
+                {"node_type": "missing", "node_name": "taken"},
+                {"node_type": "null", "node_name": "dup", "ref": "same"},
+                {"node_type": "null", "node_name": "dup2", "ref": "same"},
+            ],
+            [
+                {"input": "unknown", "output": "same"},
+                {"input": "dup", "output": "same", "input_index": 99},
+            ],
+        )
+
+    assert result["success"] is False
+    validated = result["context"]["validated"]
+    assert validated["valid"] is False
+    fields = {error["field"] for error in validated["errors"]}
+    assert "nodes[0].node_type" in fields
+    assert "nodes[0].node_name" in fields
+    assert "nodes[2].ref" in fields
+    assert "connections[0].input" in fields
+    assert "connections[1].input_index" in fields
+    assert tuple(parent.children()) == before
+    assert parent.create_count == 0
+    assert parent.layout_count == 0
+    assert hou.undos.entered == []
+    assert result["context"]["rollback"]["attempted"] is False
+
+
+def test_prevalidation_rejects_existing_nodes_from_another_network() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    other_parent = FakeParent("/obj/geo2")
+    external_target = other_parent.add_existing("null", "target", (0.0, 0.0))
+    parent.external_nodes[external_target.path()] = external_target
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            parent.path(),
+            [{"node_type": "box", "node_name": "source"}],
+            [{"input": external_target.path(), "output": "source"}],
+            dry_run=True,
+        )
+
+    assert result["success"] is False
+    errors = result["context"]["validated"]["errors"]
+    assert any(error["field"] == "connections[0].input" for error in errors)
+    assert parent.create_count == 0
+    assert hou.undos.entered == []
+
+
+def test_prevalidation_rejects_node_names_houdini_would_normalize() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            parent.path(),
+            [{"node_type": "box", "node_name": "bad name"}],
+            dry_run=True,
+        )
+
+    assert result["success"] is False
+    errors = result["context"]["validated"]["errors"]
+    assert any(error["field"] == "nodes[0].node_name" for error in errors)
+    assert parent.create_count == 0
+    assert hou.undos.entered == []
+
+
+def test_prevalidation_refuses_explicit_names_without_hom_name_validator() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    hou = FakeHou(parent)
+    hou.text = None
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            parent.path(),
+            [{"node_type": "box", "node_name": "box1"}],
+            dry_run=True,
+        )
+
+    assert result["success"] is False
+    errors = result["context"]["validated"]["errors"]
+    assert any(
+        error["field"] == "nodes[0].node_name" and "hou.text.variableName" in error["message"] for error in errors
+    )
+    assert parent.create_count == 0
+
+
+def test_prevalidation_rejects_uneditable_parent_network() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    parent.editable = False
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            parent.path(),
+            [{"node_type": "box", "node_name": "box1"}],
+            dry_run=True,
+        )
+
+    assert result["success"] is False
+    errors = result["context"]["validated"]["errors"]
+    assert any(error["field"] == "parent_path" and "editable" in error["message"] for error in errors)
+    assert parent.create_count == 0
+    assert hou.undos.entered == []
+
+
+def test_parameter_failure_deletes_every_created_node_and_reports_rollback() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    parent.failing_parms["bad"] = ["explode"]
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            "/obj/geo1",
+            [
+                {"node_type": "box", "node_name": "good"},
+                {
+                    "node_type": "null",
+                    "node_name": "bad",
+                    "parameters": {"explode": 1},
+                },
+            ],
+            layout=False,
+            cook_last=False,
+        )
+
+    assert result["success"] is False
+    assert parent.children() == ()
+    assert len(hou.undos.entered) == 1
+    assert hou.undos.entered == hou.undos.exited
+    rollback = result["context"]["rollback"]
+    assert rollback["attempted"] is True
+    assert rollback["complete"] is True
+    assert rollback["created_paths"] == ["/obj/geo1/good", "/obj/geo1/bad"]
+    assert rollback["deleted_paths"] == ["/obj/geo1/bad", "/obj/geo1/good"]
+    assert rollback["restored_connections"] == []
+    assert rollback["restored_positions"] == []
+    assert rollback["errors"] == []
+
+
+def test_undo_exit_failure_can_repeat_rollback_after_nodes_were_destroyed() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    parent.failing_parms["bad"] = ["explode"]
+    hou = FakeHou(parent)
+    hou.undos.raise_on_exit = True
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            parent.path(),
+            [{"node_type": "box", "node_name": "bad", "parameters": {"explode": 1}}],
+            layout=False,
+            cook_last=False,
+        )
+
+    assert result["success"] is False
+    assert parent.children() == ()
+    rollback = result["context"]["rollback"]
+    assert rollback["attempted"] is True
+    assert rollback["complete"] is True
+    assert rollback["deleted_paths"] == ["/obj/geo1/bad"]
+    assert rollback["errors"] == []
+
+
+def test_cook_failure_restores_existing_connection_and_layout_positions() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    old_source = parent.add_existing("box", "old_source", (3.0, 4.0))
+    target = parent.add_existing("null", "target", (8.0, 9.0))
+    target.setInput(0, old_source, 0)
+    parent.cook_fail_names.add("new_source")
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            "/obj/geo1",
+            [{"node_type": "box", "node_name": "new_source"}],
+            [{"input": "target", "output": "new_source", "input_index": 0}],
+            layout=True,
+            cook_last=True,
+        )
+
+    assert result["success"] is False
+    assert tuple(node.name() for node in parent.children()) == ("old_source", "target")
+    restored = target.inputConnections()
+    assert len(restored) == 1
+    assert restored[0].inputNode() is old_source
+    assert restored[0].outputNode() is target
+    assert restored[0].outputIndex() == 0
+    assert old_source.position() == (3.0, 4.0)
+    assert target.position() == (8.0, 9.0)
+    rollback = result["context"]["rollback"]
+    assert rollback["complete"] is True
+    assert rollback["deleted_paths"] == ["/obj/geo1/new_source"]
+    assert rollback["restored_connections"] == [
+        {
+            "input_path": "/obj/geo1/target",
+            "input_index": 0,
+            "output_path": "/obj/geo1/old_source",
+            "output_index": 0,
+        }
+    ]
+    assert {entry["path"] for entry in rollback["restored_positions"]} == {
+        "/obj/geo1/old_source",
+        "/obj/geo1/target",
+    }
+
+
+@pytest.mark.parametrize("upstream_connected", [False, True])
+def test_cook_failure_restores_subnet_indirect_input(upstream_connected: bool) -> None:
+    module = _load_script()
+    parent = FakeParent()
+    target = parent.add_existing("null", "target", (0.0, 0.0))
+    outer_parent = FakeParent("/obj/outer")
+    upstream = outer_parent.add_existing("box", "upstream", (0.0, 0.0)) if upstream_connected else None
+    indirect = FakeIndirectInput("/obj/geo1/1", upstream=upstream)
+    target.setInput(0, indirect, 0)
+    parent.cook_fail_names.add("bad_cook")
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            parent.path(),
+            [
+                {"node_type": "box", "node_name": "new_source"},
+                {"node_type": "null", "node_name": "bad_cook"},
+            ],
+            [{"input": "target", "output": "new_source", "input_index": 0}],
+            layout=False,
+            cook_last=True,
+        )
+
+    assert result["success"] is False
+    restored = target.inputConnections()
+    assert len(restored) == 1
+    assert restored[0].inputItem() is indirect
+    assert result["context"]["rollback"]["complete"] is True
+
+
+def test_success_uses_one_named_undo_group_and_returns_scene_readback() -> None:
+    module = _load_script()
+    parent = FakeParent()
+    hou = FakeHou(parent)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.build_node_chain(
+            "/obj/geo1",
+            [
+                {"node_type": "box", "node_name": "box1", "parameters": {"size": 2.0}},
+                {"node_type": "null", "node_name": "OUT"},
+            ],
+            [{"input": "OUT", "output": "box1", "input_index": 0, "output_index": 0}],
+            layout=True,
+            cook_last=True,
+        )
+
+    assert result["success"] is True
+    assert parent.exact_type_name_values == [True, True]
+    context = result["context"]
+    assert context["transaction_id"]
+    assert context["undo_label"] == hou.undos.entered[0]
+    assert hou.undos.entered == [context["undo_label"]]
+    assert hou.undos.exited == [context["undo_label"]]
+    assert context["validated"]["valid"] is True
+    assert context["affected_paths"] == ["/obj/geo1/OUT", "/obj/geo1/box1"]
+    readback = context["readback"]
+    assert readback["performed"] is True
+    assert [node["path"] for node in readback["nodes"]] == [
+        "/obj/geo1/box1",
+        "/obj/geo1/OUT",
+    ]
+    assert readback["connections"] == [
+        {
+            "input_path": "/obj/geo1/OUT",
+            "input_index": 0,
+            "output_path": "/obj/geo1/box1",
+            "output_index": 0,
+            "matches": True,
+        }
+    ]
+    connection = parent.node("OUT").inputConnections()[0]
+    assert connection.inputNode() is parent.node("box1")
+    assert connection.outputNode() is parent.node("OUT")
+    assert readback["cook"]["performed"] is True
+    assert readback["cook"]["node"]["path"] == "/obj/geo1/OUT"
+    assert parent.node("OUT").cooked is True
+    assert context["rollback"] == {"attempted": False, "complete": True, "errors": []}

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -6,7 +6,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import yaml
@@ -393,20 +393,41 @@ class TestAutomationSkills:
 
     def test_build_node_chain_with_mock_hou(self) -> None:
         mod = _load_script("houdini-automation", "build_node_chain.py")
+        box_type = MagicMock()
+        box_type.name.return_value = "box"
+        box_type.maxNumInputs.return_value = 0
+        box_type.maxNumOutputs.return_value = 1
+        null_type = MagicMock()
+        null_type.name.return_value = "null"
+        null_type.maxNumInputs.return_value = 4
+        null_type.maxNumOutputs.return_value = 1
         box = MagicMock()
         box.name.return_value = "box1"
         box.path.return_value = "/obj/geo1/box1"
-        box.type.return_value.name.return_value = "box"
+        box.type.return_value = box_type
         null = MagicMock()
         null.name.return_value = "OUT"
         null.path.return_value = "/obj/geo1/OUT"
-        null.type.return_value.name.return_value = "null"
+        null.type.return_value = null_type
+        connection = MagicMock()
+        connection.inputIndex.return_value = 0
+        connection.inputItem.return_value = box
+        connection.inputItemOutputIndex.return_value = 0
+        null.inputConnections.return_value = [connection]
         parent = MagicMock()
         parent.path.return_value = "/obj/geo1"
+        parent.isNetwork.return_value = True
+        parent.isEditable.return_value = True
+        parent.children.return_value = []
+        parent.childTypeCategory.return_value.nodeTypes.return_value = {
+            "box": box_type,
+            "null": null_type,
+        }
         parent.createNode.side_effect = [box, null]
         parent.node.side_effect = lambda name: {"box1": box, "OUT": null}.get(name)
         mock_hou = MagicMock()
         mock_hou.node.return_value = parent
+        mock_hou.text.variableName.side_effect = lambda value, safe_chars: value
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.build_node_chain(
@@ -416,5 +437,9 @@ class TestAutomationSkills:
             )
 
         assert result["success"] is True
+        assert parent.createNode.call_args_list == [
+            call("box", node_name="box1", exact_type_name=True),
+            call("null", node_name="OUT", exact_type_name=True),
+        ]
         null.setInput.assert_called_once_with(0, box, 0)
         null.cook.assert_called_once_with(force=False)


### PR DESCRIPTION
## Summary
- prevalidate the complete structured node recipe before changing the Houdini scene
- add dry-run planning, recipe-local references, and one named undo group
- restore touched node-graph connections and positions when execution or readback fails
- return transaction, validation, rollback, and post-cook readback evidence

## Validation
- `python -m pytest -q tests/test_atomic_node_chain.py tests/test_skills.py::TestAutomationSkills::test_build_node_chain_with_mock_hou` (13 passed)
- `python -m ruff check` on changed Python files
- `python -m ruff format --check` on changed Python files
- `git diff --check`