### PR TITLE
feat: report atomic node recipe outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * share owned isolated ROP jobs across renders, simulation caches, and ROP chains
 * derive bounded output progress and ETA during job polling
 * make `build_node_chain` an atomic prevalidated transaction with dry-run, one-step undo, explicit rollback, and scene readback
+* report created, connected, and parameter summaries for structured node recipes
+* replace HIP targets atomically after a successful temporary save
 
 ### Bug Fixes
 

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     dcc: houdini
     layer: pipeline
     stage: pipeline
-    version: "1.1.0"
+    version: "1.2.0"
     tags: [houdini, automation, hip, timeline, pipeline, scripts]
     search-hint: "run python file, save hip, load hip, timeline, build node chain"
     search-aliases: [run script file, save hip, open hip, load scene, set frame range, timeline, build node chain, automate houdini]
@@ -57,3 +57,30 @@ include `transaction_id`, `undo_label`, validation evidence, and post-cook
 readback fails, the tool explicitly removes created nodes and restores any
 existing input connections and existing node positions touched by layout. Check
 `rollback.complete` and `rollback.errors` before retrying a failed recipe.
+
+Successful responses expose a compact `summary` with the created nodes,
+readback-verified connections, submitted parameter values, and counts. This is
+the preferred proof for generated MaterialX networks.
+
+## MaterialX displacement acceptance
+
+For each existing MaterialX builder, use one `build_node_chain` recipe with an
+`mtlximage` feeding `mtlxrange`, then `mtlxdisplacement`. Put texture paths,
+range bounds, clamping, and displacement scale in each node's `parameters` and
+connect nodes by their recipe-local `ref` or `node_name`. Four materials need
+four such calls because they have four different parent networks; each call is
+independently prevalidated and leaves no partial network when rollback is
+complete.
+
+Use a separate atomic recipe under `/stage` for the
+`rendergeometrysettings` node and its upstream/downstream LOP connections.
+Resolve the current Houdini/Karma true-displacement and dicing parameter names
+with the parameter inspection tools, then pass those names through the same
+structured `parameters` object; no renderer-specific Python is required.
+
+Do not save between batch calls. After every material and stage response has a
+successful summary, call `save_hip_file`. It writes a sibling temporary HIP and
+uses an atomic filesystem replacement, so a save or replace failure preserves
+the prior target. If replacement fails after the temporary save, use the
+returned `recovery_file`. In-memory recipes remain separate transactions;
+reload the prior saved HIP when whole-batch rollback is required.

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/_atomic_node_chain.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/_atomic_node_chain.py
@@ -640,11 +640,30 @@ class AtomicNodeChainExecutor:
                     "warnings": list(cooked_node.warnings()) if hasattr(cooked_node, "warnings") else [],
                 }
             )
+        parameter_results = [
+            {
+                "path": created[planned.index].path(),
+                "values": dict(planned.parameters),
+            }
+            for planned in plan.nodes
+            if planned.parameters
+        ]
+        summary = {
+            "created": node_results,
+            "connected": connection_results,
+            "parameters": parameter_results,
+            "counts": {
+                "created": len(node_results),
+                "connected": len(connection_results),
+                "parameters": sum(len(entry["values"]) for entry in parameter_results),
+            },
+        }
         return {
             "performed": True,
             "nodes": node_results,
             "connections": connection_results,
             "cook": cook_result,
+            "summary": summary,
         }
 
     @staticmethod

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/build_node_chain.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/build_node_chain.py
@@ -117,6 +117,7 @@ def build_node_chain(
         parent_path=plan.parent.path(),
         affected_paths=list(execution.affected_paths),
         validated=validated,
+        summary=execution.readback["summary"],
         readback=execution.readback,
         rollback={"attempted": False, "complete": True, "errors": []},
         nodes=[node_summary(node) for node in execution.nodes],

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/save_hip_file.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/save_hip_file.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import sys
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -16,25 +18,43 @@ from _automation_common import hou_import_error
 
 
 def save_hip_file(file_path: Optional[str] = None) -> dict:
-    """Save the current Houdini hip file."""
+    """Save through a sibling temporary file, then atomically replace the target."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
         return hou_import_error()
 
+    temporary = None
+    temporary_saved = False
+    previous_name = None
     try:
-        resolved = None
-        if file_path:
-            resolved_path = Path(file_path).expanduser()
-            resolved_path.parent.mkdir(parents=True, exist_ok=True)
-            resolved = str(resolved_path)
-            hou.hipFile.save(file_name=resolved)
-        else:
-            hou.hipFile.save()
-            resolved = hou.hipFile.name() if not hou.hipFile.isNewFile() else None
-        return skill_success("Saved Houdini hip file", hip_file=resolved)
+        previous_name = hou.hipFile.name()
+        target = Path(file_path or hou.hipFile.path()).expanduser().resolve()
+        if target.suffix.lower() not in {".hip", ".hiplc", ".hipnc"}:
+            raise ValueError("Houdini scene path must end in .hip, .hiplc, or .hipnc")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temporary = target.with_name(".{}.{}.tmp{}".format(target.stem, uuid.uuid4().hex, target.suffix))
+        hou.hipFile.save(file_name=str(temporary), save_to_recent_files=False)
+        temporary_saved = True
+        hou.hipFile.setName(str(target))
+        os.replace(str(temporary), str(target))
+        return skill_success("Saved Houdini hip file", hip_file=str(target), atomic_replace=True)
     except Exception as exc:
-        return skill_exception(exc, message="Failed to save Houdini hip file")
+        recovery_file = str(temporary) if temporary_saved and temporary is not None and temporary.exists() else None
+        try:
+            hou.hipFile.setName(recovery_file or previous_name)
+        except Exception:
+            pass
+        if not temporary_saved and temporary is not None and temporary.exists():
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+        return skill_exception(
+            exc,
+            message="Failed to save Houdini hip file",
+            recovery_file=recovery_file,
+        )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
@@ -72,7 +72,9 @@ tools:
       idempotent_hint: true
 
   - name: save_hip_file
-    description: "Save the current Houdini hip file, optionally to a new path."
+    description: >-
+      Save the current Houdini hip file, optionally to a new path, through a
+      sibling temporary file and atomic target replacement.
     input_schema:
       type: object
       properties:
@@ -88,7 +90,7 @@ tools:
     source_file: scripts/save_hip_file.py
     tool_role: action
     risk: medium
-    search_aliases: [save hip, save scene, write hip file, save as]
+    search_aliases: [save hip, atomic save hip, save scene, write hip file, save as]
     produces: ["file:hip"]
     annotations:
       read_only_hint: false
@@ -127,7 +129,8 @@ tools:
     description: >-
       Prevalidate and atomically build a small Houdini node chain from
       structured node specs and connections. Supports dry-run, one-step undo,
-      explicit rollback evidence, and post-cook scene readback.
+      explicit rollback evidence, post-cook scene readback, and compact
+      created/connected/parameter summaries.
     input_schema:
       type: object
       required: [parent_path, nodes]

--- a/tests/test_atomic_node_chain.py
+++ b/tests/test_atomic_node_chain.py
@@ -194,7 +194,11 @@ class FakeParent:
         self.editable = True
         self.types = {
             "box": FakeNodeType("box", 0, 1),
+            "mtlxdisplacement": FakeNodeType("mtlxdisplacement", 1, 1),
+            "mtlximage": FakeNodeType("mtlximage", 0, 1),
+            "mtlxrange": FakeNodeType("mtlxrange", 1, 1),
             "null": FakeNodeType("null", 4, 1),
+            "rendergeometrysettings": FakeNodeType("rendergeometrysettings", 1, 1),
         }
         self._children: List[FakeNode] = []
         self.create_count = 0
@@ -646,3 +650,119 @@ def test_success_uses_one_named_undo_group_and_returns_scene_readback() -> None:
     assert readback["cook"]["node"]["path"] == "/obj/geo1/OUT"
     assert parent.node("OUT").cooked is True
     assert context["rollback"] == {"attempted": False, "complete": True, "errors": []}
+
+
+def _materialx_displacement_recipe() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    nodes = []
+    connections = []
+    for index in range(4):
+        prefix = "surface_{}".format(index)
+        nodes.extend(
+            [
+                {
+                    "node_type": "mtlximage",
+                    "node_name": "{}_image".format(prefix),
+                    "parameters": {"signature": "default", "file": "/assets/{}_height.exr".format(prefix)},
+                },
+                {
+                    "node_type": "mtlxrange",
+                    "node_name": "{}_range".format(prefix),
+                    "parameters": {
+                        "signature": "default",
+                        "inlow": 0.1,
+                        "inhigh": 0.9,
+                        "outlow": -1.0,
+                        "outhigh": 1.0,
+                        "doclamp": 1,
+                    },
+                },
+                {
+                    "node_type": "mtlxdisplacement",
+                    "node_name": "{}_displacement".format(prefix),
+                    "parameters": {"signature": "default", "scale": 0.01},
+                },
+            ]
+        )
+        connections.extend(
+            [
+                {"input": "{}_range".format(prefix), "output": "{}_image".format(prefix)},
+                {"input": "{}_displacement".format(prefix), "output": "{}_range".format(prefix)},
+            ]
+        )
+    return nodes, connections
+
+
+def test_materialx_displacement_batch_and_stage_settings_return_summaries() -> None:
+    module = _load_script()
+    nodes, connections = _materialx_displacement_recipe()
+    material_parent = FakeParent("/mat/displacement_batch")
+
+    with patch.dict(sys.modules, {"hou": FakeHou(material_parent)}):
+        material_result = module.build_node_chain(
+            material_parent.path(),
+            nodes,
+            connections,
+            layout=False,
+            cook_last=False,
+        )
+
+    material_summary = material_result["context"]["summary"]
+    assert material_summary["counts"] == {"created": 12, "connected": 8, "parameters": 40}
+    assert all(connection["matches"] for connection in material_summary["connected"])
+    assert len(material_summary["parameters"]) == 12
+
+    stage_parent = FakeParent("/stage")
+    upstream = stage_parent.add_existing("null", "upstream", (0.0, 0.0))
+    downstream = stage_parent.add_existing("null", "downstream", (1.0, 0.0))
+    with patch.dict(sys.modules, {"hou": FakeHou(stage_parent)}):
+        settings_result = module.build_node_chain(
+            stage_parent.path(),
+            [
+                {
+                    "node_type": "rendergeometrysettings",
+                    "node_name": "displacement_settings",
+                    "parameters": {
+                        "primpattern": "/asset/*",
+                        "xn__primvarskarmaobjecttruedisplace_control_n4bfg": "set",
+                        "xn__primvarskarmaobjecttruedisplace_mrbfg": "True Displacement",
+                        "xn__primvarskarmaobjectdicingquality_control_95bfg": "set",
+                        "xn__primvarskarmaobjectdicingquality_8sbfg": 1.25,
+                    },
+                }
+            ],
+            [
+                {"input": "displacement_settings", "output": upstream.path()},
+                {"input": downstream.path(), "output": "displacement_settings"},
+            ],
+            layout=False,
+            cook_last=False,
+        )
+
+    assert settings_result["context"]["summary"]["counts"] == {
+        "created": 1,
+        "connected": 2,
+        "parameters": 5,
+    }
+
+
+def test_materialx_batch_failure_leaves_no_partial_network() -> None:
+    module = _load_script()
+    nodes, connections = _materialx_displacement_recipe()
+    parent = FakeParent("/mat/displacement_batch")
+    parent.cook_fail_names.add("surface_3_displacement")
+
+    with patch.dict(sys.modules, {"hou": FakeHou(parent)}):
+        result = module.build_node_chain(
+            parent.path(),
+            nodes,
+            connections,
+            layout=False,
+            cook_last=True,
+        )
+
+    assert result["success"] is False
+    assert parent.children() == ()
+    rollback = result["context"]["rollback"]
+    assert rollback["complete"] is True
+    assert len(rollback["created_paths"]) == 12
+    assert set(rollback["deleted_paths"]) == set(rollback["created_paths"])

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -391,6 +391,55 @@ class TestAutomationSkills:
         assert "hello" in result["context"]["stdout"]
         assert result["context"]["result"] == "42"
 
+    def test_save_hip_file_atomically_replaces_target(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "save_hip_file.py")
+        target = tmp_path / "scene.hip"
+        target.write_bytes(b"old")
+        hip_file = MagicMock()
+        hip_file.name.return_value = str(target)
+        hip_file.path.return_value = str(target)
+
+        def save(file_name: str, save_to_recent_files: bool) -> None:
+            assert save_to_recent_files is False
+            Path(file_name).write_bytes(b"new")
+
+        hip_file.save.side_effect = save
+        mock_hou = MagicMock(hipFile=hip_file)
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.save_hip_file(str(target))
+
+        resolved = str(target.resolve())
+        assert result["success"] is True
+        assert result["context"] == {"hip_file": resolved, "atomic_replace": True}
+        assert target.read_bytes() == b"new"
+        hip_file.setName.assert_called_once_with(resolved)
+        assert list(tmp_path.iterdir()) == [target]
+
+    def test_save_hip_file_preserves_target_when_replace_fails(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "save_hip_file.py")
+        previous = tmp_path / "previous.hip"
+        target = tmp_path / "scene.hip"
+        target.write_bytes(b"old")
+        hip_file = MagicMock()
+        hip_file.name.return_value = str(previous)
+        hip_file.path.return_value = str(previous)
+        hip_file.save.side_effect = lambda file_name, save_to_recent_files: Path(file_name).write_bytes(b"new")
+        mock_hou = MagicMock(hipFile=hip_file)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(
+            mod.os,
+            "replace",
+            side_effect=OSError("replace failed"),
+        ):
+            result = mod.save_hip_file(str(target))
+
+        assert result["success"] is False
+        assert target.read_bytes() == b"old"
+        recovery = Path(result["context"]["recovery_file"])
+        assert recovery.read_bytes() == b"new"
+        assert hip_file.setName.call_args_list[-1] == call(str(recovery))
+        assert sorted(path.name for path in tmp_path.iterdir()) == sorted([target.name, recovery.name])
+
     def test_build_node_chain_with_mock_hou(self) -> None:
         mod = _load_script("houdini-automation", "build_node_chain.py")
         box_type = MagicMock()


### PR DESCRIPTION
## Summary
- expose compact created, connected, parameter, and count summaries after atomic node-chain readback
- cover a four-network MaterialX image-to-range-to-displacement recipe plus Karma geometry settings without renderer-specific adapter logic
- prove a post-connection failure removes the complete generated network
- save HIP files through a same-directory temporary file and atomic target replacement, retaining a recovery file if replacement fails
- document the per-network transaction and final-save boundary for batch authoring

## Validation
- `python -m pytest -q` (462 passed, 1 skipped, 2 deselected)
- focused atomic recipe and HIP replacement tests (17 passed)
- `python -m ruff check` on changed Python files
- `python -m ruff format --check` on changed Python files
- `git diff --check`