### PR TITLE
fix: autostart when opening Houdini scenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ just say:
 
 The agent reads [`install.md`](install.md), runs the
 `dcc-mcp-houdini-setup` skill to install dependencies into Houdini's `hython`,
-generates an MCP host config, guides the Houdini package / `123.py` autostart
+generates an MCP host config, guides the Houdini package startup hooks
 step, and runs a smoke prompt to confirm the connection.
 
 ## Installation
@@ -81,8 +81,9 @@ chmod +x install.sh
 ```
 
 The package writes a Houdini package JSON into the user preferences folder.
-On startup, `scripts/123.py` extracts bundled wheels into `vendor/` and starts
-the MCP server unless `DCC_MCP_HOUDINI_AUTOSTART=0`.
+`scripts/123.py` handles an empty startup and `scripts/456.py` handles a loaded
+scene; both reuse one bootstrap that extracts bundled wheels into `vendor/` and
+starts the MCP server unless `DCC_MCP_HOUDINI_AUTOSTART=0`.
 
 Isolated background ROP workers receive `DCC_MCP_BACKGROUND_RENDER=1` in their
 child environment. Package and custom `123.py`/`456.py` startup hooks must skip

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -5,7 +5,7 @@ The output ZIP contains:
 * the built ``dcc_mcp_houdini`` wheel from ``dist/``;
 * compatible ``dcc-mcp-core`` wheels from PyPI for the requested platform;
 * a Houdini package JSON template;
-* ``scripts/123.py`` autostart bootstrap;
+* ``scripts/123.py`` and ``scripts/456.py`` autostart hooks;
 * ``toolbar/DCC-MCP.shelf`` with basic user-visible controls;
 * PowerShell and POSIX installer scripts.
 
@@ -13,9 +13,9 @@ Install flow:
 
 1. Extract the ZIP anywhere stable.
 2. Run ``install.ps1 -HoudiniVersion 20.5`` or ``./install.sh 20.5``.
-3. Start Houdini. The package adds ``scripts/`` to ``HOUDINI_PATH``; ``123.py``
-   extracts bundled wheels into ``vendor/`` and starts the MCP server when
-   ``DCC_MCP_HOUDINI_AUTOSTART`` is not disabled.
+3. Start Houdini. The package adds ``scripts/`` to ``HOUDINI_PATH``; the
+   startup hooks extract bundled wheels into ``vendor/`` and start the MCP
+   server when ``DCC_MCP_HOUDINI_AUTOSTART`` is not disabled.
 """
 
 from __future__ import annotations
@@ -268,7 +268,7 @@ def bootstrap_and_start() -> object:
 
 
 def _startup_py() -> str:
-    return r'''"""Houdini 123.py autostart hook for dcc-mcp-houdini."""
+    return r'''"""Houdini autostart hook for dcc-mcp-houdini."""
 
 from __future__ import annotations
 
@@ -446,7 +446,8 @@ Install on Linux/macOS:
 
 The installer writes a Houdini package JSON into the user Houdini preferences
 folder and points it at this extracted package directory. On Houdini startup,
-scripts/123.py extracts bundled wheels into vendor/ and starts the MCP server.
+scripts/123.py handles empty startup and scripts/456.py handles loaded scenes;
+both reuse the same bootstrap to extract bundled wheels and start the MCP server.
 The DCC-MCP shelf is loaded from toolbar/DCC-MCP.shelf.
 
 Disable autostart by setting DCC_MCP_HOUDINI_AUTOSTART=0.
@@ -474,6 +475,7 @@ def verify_quickinstall_zip(
 
     required_suffixes = [
         "/scripts/123.py",
+        "/scripts/456.py",
         "/scripts/dcc_mcp_houdini_bootstrap.py",
         "/packages/dcc_mcp_houdini.json.template",
         "/README.txt",
@@ -563,7 +565,9 @@ def assemble(platform: str, dist_dir: Path, output_dir: Path, core_version: Opti
 
         (packages_dir / "dcc_mcp_houdini.json.template").write_text(_package_json_template(), encoding="utf-8")
         (scripts_dir / "dcc_mcp_houdini_bootstrap.py").write_text(_bootstrap_py(), encoding="utf-8")
-        (scripts_dir / "123.py").write_text(_startup_py(), encoding="utf-8")
+        startup = _startup_py()
+        for hook in ("123.py", "456.py"):
+            (scripts_dir / hook).write_text(startup, encoding="utf-8")
         (toolbar_dir / "DCC-MCP.shelf").write_text(_shelf_file(), encoding="utf-8")
         (root / "install.ps1").write_text(_install_ps1(), encoding="utf-8")
         install_sh = root / "install.sh"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -21,9 +21,11 @@ def _load_packaging_script():
     return module
 
 
-def _write_quickinstall_zip(zip_path: Path, *wheel_names: str) -> None:
+def _write_quickinstall_zip(zip_path: Path, *wheel_names: str, include_scene_hook: bool = True) -> None:
     with zipfile.ZipFile(zip_path, "w") as zf:
         zf.writestr("dcc_mcp_houdini/scripts/123.py", "")
+        if include_scene_hook:
+            zf.writestr("dcc_mcp_houdini/scripts/456.py", "")
         zf.writestr("dcc_mcp_houdini/scripts/dcc_mcp_houdini_bootstrap.py", "")
         zf.writestr("dcc_mcp_houdini/packages/dcc_mcp_houdini.json.template", "")
         zf.writestr("dcc_mcp_houdini/README.txt", "")
@@ -57,10 +59,14 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
         names = set(zf.namelist())
         shelf_xml = zf.read("dcc_mcp_houdini/toolbar/DCC-MCP.shelf").decode("utf-8")
         bootstrap = zf.read("dcc_mcp_houdini/scripts/dcc_mcp_houdini_bootstrap.py").decode("utf-8")
+        startup = zf.read("dcc_mcp_houdini/scripts/123.py")
+        scene_load = zf.read("dcc_mcp_houdini/scripts/456.py")
     assert "dcc_mcp_houdini/wheels/{}".format(adapter_wheel.name) in names
     for core_wheel in core_wheels:
         assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
     assert "dcc_mcp_houdini/scripts/123.py" in names
+    assert "dcc_mcp_houdini/scripts/456.py" in names
+    assert startup == scene_load
     assert "dcc_mcp_houdini/scripts/dcc_mcp_houdini_bootstrap.py" in names
     assert "dcc_mcp_houdini/toolbar/DCC-MCP.shelf" in names
     assert "dcc_mcp_houdini/packages/dcc_mcp_houdini.json.template" in names
@@ -131,6 +137,21 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
     )
 
     with pytest.raises(RuntimeError, match="Bundled core drift"):
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
+
+
+def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
+    pkg = _load_packaging_script()
+
+    zip_path = tmp_path / "dcc_mcp_houdini_quickinstall_win64.zip"
+    _write_quickinstall_zip(
+        zip_path,
+        "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
+        "dcc_mcp_core-0.19.15-cp38-abi3-win_amd64.whl",
+        include_scene_hook=False,
+    )
+
+    with pytest.raises(RuntimeError, match="/scripts/456.py"):
         pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
 
 


### PR DESCRIPTION
## Summary
- include `scripts/456.py` in quickinstall packages so MCP autostarts when Houdini opens with an existing scene
- reuse the same thin startup hook and shared bootstrap used by `123.py`
- make quickinstall verification reject packages missing either startup path

## Validation
- `python -m pytest tests/test_packaging.py -q -o addopts=` (6 passed)
- `python -m pytest tests/test_release_workflow.py tests/test_version_consistency.py -q -o addopts=` (8 passed)
- `python -m pytest -q` (463 passed, 1 skipped)
- built wheel/sdist and passed `twine check`
- assembled and verified a Windows quickinstall ZIP with dcc-mcp-core 0.19.41; `123.py` and `456.py` were byte-identical and each delegates to the shared bootstrap

SideFX documents `456.py` as the startup hook run whenever a scene file is loaded: https://www.sidefx.com/docs/houdini/hom/locations.html#startup