### PR TITLE
fix: write Houdini package JSON without UTF-8 BOM

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -394,7 +394,7 @@ New-Item -ItemType Directory -Force -Path $packagesDir | Out-Null
 $template = Get-Content -LiteralPath (Join-Path $PSScriptRoot "packages/dcc_mcp_houdini.json.template") -Raw
 $json = $template.Replace("__PACKAGE_ROOT__", $resolvedRoot)
 $target = Join-Path $packagesDir "dcc_mcp_houdini.json"
-Set-Content -LiteralPath $target -Value $json -Encoding UTF8
+[IO.File]::WriteAllText($target, $json, [Text.UTF8Encoding]::new($false))
 
 Write-Host "Installed Houdini package: $target"
 Write-Host "Package root: $resolvedRoot"

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -273,11 +273,19 @@ def _startup_py() -> str:
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 
 
 def _load_bootstrap():
-    path = Path(__file__).with_name("dcc_mcp_houdini_bootstrap.py")
+    root = os.environ.get("DCC_MCP_HOUDINI_ROOT")
+    script = globals().get("__file__")
+    if root:
+        path = Path(root) / "scripts/dcc_mcp_houdini_bootstrap.py"
+    elif script:
+        path = Path(script).with_name("dcc_mcp_houdini_bootstrap.py")
+    else:
+        raise RuntimeError("DCC_MCP_HOUDINI_ROOT is not set")
     spec = importlib.util.spec_from_file_location("dcc_mcp_houdini_bootstrap", str(path))
     if spec is None or spec.loader is None:
         raise RuntimeError("Cannot load {}".format(path))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -216,6 +216,34 @@ def test_windows_installer_writes_bomless_package_json(tmp_path: Path) -> None:
     assert json.loads(raw) == json.loads(expected)
 
 
+def test_startup_hook_uses_package_root_without_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pkg = _load_packaging_script()
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    marker = tmp_path / "bootstrap_calls"
+    (scripts / "dcc_mcp_houdini_bootstrap.py").write_text(
+        """from pathlib import Path
+
+class Server:
+    mcp_url = "http://127.0.0.1:8765/mcp"
+
+def bootstrap_and_start():
+    marker = Path({marker!r})
+    marker.write_text((marker.read_text() if marker.exists() else "") + "1")
+    return Server()
+""".format(marker=str(marker)),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DCC_MCP_HOUDINI_ROOT", str(tmp_path))
+
+    exec(compile(pkg._startup_py(), "<houdini-startup>", "exec"), {})
+
+    assert marker.read_text(encoding="utf-8") == "1"
+
+
 def test_pick_core_wheels_includes_py37_and_abi3_for_platform() -> None:
     pkg = _load_packaging_script()
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
+import subprocess
 import sys
 import xml.etree.ElementTree as ET
 import zipfile
@@ -171,6 +174,46 @@ def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
     assert matrix["core"] == "0.19.15"
     assert matrix["server"] == pkg.get_package_version()
     assert matrix["cli"] == pkg.get_package_version()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows PowerShell 5.1")
+def test_windows_installer_writes_bomless_package_json(tmp_path: Path) -> None:
+    pkg = _load_packaging_script()
+    package_root = tmp_path / "quickinstall"
+    packages_dir = package_root / "packages"
+    packages_dir.mkdir(parents=True)
+    (package_root / "install.ps1").write_text(pkg._install_ps1(), encoding="utf-8")
+    (packages_dir / "dcc_mcp_houdini.json.template").write_text(pkg._package_json_template(), encoding="utf-8")
+
+    powershell = Path(os.environ["SystemRoot"]) / "System32/WindowsPowerShell/v1.0/powershell.exe"
+    home = tmp_path / "home"
+    env = os.environ.copy()
+    env["USERPROFILE"] = str(home)
+    subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(package_root / "install.ps1"),
+            "-HoudiniVersion",
+            "21.0",
+            "-PackageRoot",
+            str(package_root),
+        ],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    target = home / "Documents/houdini21.0/packages/dcc_mcp_houdini.json"
+    raw = target.read_bytes()
+    assert raw[:1] == b"{"
+    expected = pkg._package_json_template().replace("__PACKAGE_ROOT__", package_root.as_posix())
+    assert json.loads(raw) == json.loads(expected)
 
 
 def test_pick_core_wheels_includes_py37_and_abi3_for_platform() -> None:


### PR DESCRIPTION
## Summary
- write the generated Houdini package manifest with UTF-8 encoding and no byte-order mark
- resolve the shared startup bootstrap from `DCC_MCP_HOUDINI_ROOT`, so Houdini startup hooks do not require a `__file__` global
- add regressions for Windows PowerShell 5.1 output and startup-hook execution without `__file__`

## Validation
- `python -m pytest` (465 passed, 1 skipped)
- `python -m pytest tests/test_packaging.py -m packaging` (2 passed)
- `python -m ruff check src tests tools packaging`
- `python -m ruff format --check src tests tools packaging`
- `python tools/check_py37_syntax.py src tests tools packaging`
- Houdini 21 `hconfig` verbose smoke loaded and processed the generated package without a syntax error