### PR TITLE
fix: report partial render outputs accurately

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -77,7 +77,9 @@ def main() -> None:
         logged_cook_errors = _cook_errors(status)
         candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
         written_files = updated_outputs(candidates, before)
-        verification_state = "verified" if written_files else "not_observed"
+        verification_state = "not_observed"
+        if written_files:
+            verification_state = "verified" if len(written_files) == len(candidates) else "partial"
         if not output_pattern:
             verification_state = "unavailable"
         output_verification = {

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -58,6 +58,7 @@ def _run_render_worker(
     include_launch_snapshot=True,
     ignore_inputs=False,
     job_kind="render",
+    rop_errors=(),
 ):
     mod = _load_render_worker()
     if pattern is _DEFAULT_PATTERN:
@@ -82,7 +83,7 @@ def _run_render_worker(
         )
     status_path.write_text(json.dumps(status), encoding="utf-8")
     rop = _node("/stage/karma", "karma", "usdrender_rop")
-    rop.errors.return_value = []
+    rop.errors.return_value = list(rop_errors)
     mock_hou = MagicMock()
     mock_hou.node.return_value = rop
     mock_hou.text.expandStringAtFrame.side_effect = lambda value, frame: value.replace(
@@ -707,6 +708,30 @@ class TestRenderExecution:
         )
         assert status["state"] == "completed"
         assert status["written_files"] == [str(tmp_path / "beauty.0005.exr")]
+
+    def test_background_worker_reports_partial_outputs_when_range_fails(self, tmp_path: Path) -> None:
+        expected = [tmp_path / "beauty.{:04d}.exr".format(frame) for frame in range(1, 8)]
+
+        def render(_rop, _frame_range):
+            for output in expected[:2]:
+                output.write_bytes(b"new")
+            return [1.0, 7.0], "execute"
+
+        status = _run_render_worker(
+            tmp_path,
+            [1, 7, 1],
+            expected,
+            {},
+            render,
+            rop_errors=["Command Exit Code: 1"],
+        )
+
+        assert status["state"] == "failed"
+        assert status["output_verification"] == {
+            "state": "partial",
+            "expected_output_count": 7,
+            "written_file_count": 2,
+        }
 
     def test_background_worker_recovers_from_cached_launcher_without_snapshot(self, tmp_path: Path) -> None:
         output = tmp_path / "karma_beauty.1080.exr"


### PR DESCRIPTION
## Summary
- report partial frame-range output as `partial` instead of `verified`
- preserve observed output counts when a ROP range fails
- add a regression for a seven-frame render that writes two frames before failing

## Validation
- `python -m pytest` (466 passed, 1 skipped, 2 deselected)
- `python -m pytest tests/test_render_camera_light_skills.py -q`
- `python -m ruff check src tests tools packaging`
- `python -m ruff format --check src tests tools packaging`
- `python tools/check_py37_syntax.py src tests tools packaging`