### PR TITLE
feat(skills): add read-only Solaris USD inspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 30 skill packages, 185 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 188 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/llms.txt
+++ b/llms.txt
@@ -32,7 +32,7 @@ server.list_skills()
 - `houdini_success`, `houdini_error`, `with_houdini`
 - `build_minimal_mode_config`, `build_minimal_mode_for_stages`, `MINIMAL_SKILLS`, `STAGES`, `STAGE_SKILLS`
 
-## Bundled tools (30 skills, 180+ tools)
+## Bundled tools (31 skills, 180+ tools)
 
 ### bootstrap (default)
 - `houdini_scripting__execute_python`, `get_session_info`

--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -39,6 +39,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "interchange": (
         "houdini-interchange",
         "houdini-export-preset",
+        "houdini-usd-lops",
     ),
     "pipeline": (
         "houdini-render",

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -7,7 +7,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
 | `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-material-library`, `houdini-hda`, `houdini-light-rig` | no |
-| `interchange` | `houdini-interchange`, `houdini-export-preset`, `houdini-import-to-scene` | no |
+| `interchange` | `houdini-interchange`, `houdini-export-preset`, `houdini-import-to-scene`, `houdini-usd-lops` | no |
 | `pipeline` | `houdini-render`, `houdini-karma`, `houdini-husk`, `houdini-animation`, `houdini-chops`, `houdini-constraints`, `houdini-kinefx`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake` | no |
 
 ## Common chains
@@ -40,6 +40,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | Cross-DCC asset import | `load_skill("houdini-import-to-scene")` → `houdini_import_to_scene__import_to_scene` (uses AssetDescriptor contract from dcc-mcp-core) |
 | Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
+| Inspect a Solaris USD Stage | `load_skill("houdini-usd-lops")` → `houdini_usd_lops__list_stage_prims` → `houdini_usd_lops__get_prim_info` / `houdini_usd_lops__get_prim_attributes` |
 | Manage export presets | `load_skill("houdini-export-preset")` → `houdini_export_preset__save_export_preset` → `houdini_export_preset__list_export_presets` → `houdini_export_preset__load_export_preset` |
 | Automate HDA + PDG/ROP | `load_skill("houdini-hda-automation")` → `houdini_hda_automation__scan_hda_libraries` → `houdini_hda_automation__inspect_hda_definition` → `houdini_hda_automation__instantiate_hda` → `houdini_hda_automation__validate_hda` → `houdini_hda_automation__cook_top_network` / `houdini_hda_automation__execute_rop_chain` |
 | Project + shot packaging | `load_skill("houdini-pipeline")` → `houdini_pipeline__set_project` → `houdini_pipeline__validate_scene` → `houdini_pipeline__collect_dependencies` → `houdini_pipeline__export_shot_package` |

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: houdini-usd-lops
+description: >-
+  Solaris/USD query skill — read-only inspection of a LOP node's composed
+  Stage. Use it to list prims, inspect one prim, or read bounded attribute
+  values. Not for USD authoring, import, or export.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [houdini, solaris, usd, lops, stage, prims]
+    search-hint: "inspect Solaris stage, list USD prims, prim info, USD attributes"
+    search-aliases: [inspect usd stage, list lops prims, usd prim info, usd attributes, material binding]
+    example-prompts:
+      - "List the prims composed by /stage/karma1"
+      - "Inspect /World/geo on the Stage from /stage/OUT"
+      - "Show bounded attributes containing primvars on /World/geo"
+    intent: "Inspect a composed Solaris USD Stage without authoring changes."
+    recall-context:
+      app_type: houdini
+      domain: usd
+      workflow-stage: interchange
+      task-category: query
+    requires: []
+    produces: [usd_stage_report]
+    preconditions:
+      - type: software
+        name: houdini
+        version: ">=20.5"
+    side-effects: {}
+    tools: tools.yaml
+---
+
+# houdini-usd-lops
+
+Read-only inspection of the composed USD Stage returned by a LOP node.
+
+1. `list_stage_prims` for a bounded Stage inventory.
+2. `get_prim_info` for type, state, visibility, transform, bounds, and material binding.
+3. `get_prim_attributes` for filtered, size-bounded attribute values at a time code.
+
+Load `houdini-interchange` instead when the task is file import or export.

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/_usd_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/_usd_common.py
@@ -1,0 +1,130 @@
+"""Shared, dependency-free helpers for read-only USD inspection."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Dict, Tuple
+
+
+def require_absolute_path(value: str, label: str) -> str:
+    """Validate and return an absolute Houdini or USD path."""
+    path = str(value or "").strip()
+    if not path.startswith("/"):
+        raise ValueError("{} must be an absolute path".format(label))
+    return path
+
+
+def require_range(value: int, label: str, minimum: int, maximum: int) -> int:
+    """Validate an integer bound for callers that bypass JSON Schema."""
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise ValueError("{} must be an integer from {} to {}".format(label, minimum, maximum))
+    return value
+
+
+def resolve_stage(hou: Any, lop_node_path: str) -> Tuple[Any, Any]:
+    """Resolve a Houdini LOP node and its composed USD Stage."""
+    node_path = require_absolute_path(lop_node_path, "lop_node_path")
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError("Houdini node not found: {}".format(node_path))
+    stage_method = getattr(node, "stage", None)
+    if not callable(stage_method):
+        raise ValueError("Houdini node is not a LOP node: {}".format(node_path))
+    stage = stage_method()
+    if stage is None:
+        raise RuntimeError("LOP node returned no composed USD Stage: {}".format(node_path))
+    return node, stage
+
+
+def resolve_prim(stage: Any, prim_path: str) -> Any:
+    """Resolve a valid prim from *stage*."""
+    path = require_absolute_path(prim_path, "prim_path")
+    prim = stage.GetPrimAtPath(path)
+    if not prim:
+        raise ValueError("USD prim not found: {}".format(path))
+    return prim
+
+
+def make_time_code(Usd: Any, value: Any) -> Any:
+    """Create default or numeric ``Usd.TimeCode`` with finite-number validation."""
+    if value is None:
+        return Usd.TimeCode.Default()
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("time_code must be a finite number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("time_code must be a finite number")
+    return Usd.TimeCode(number)
+
+
+def _json_safe(value: Any, budget: Dict[str, int]) -> Tuple[Any, bool]:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value, False
+    if isinstance(value, float):
+        return (value, False) if math.isfinite(value) else (str(value), False)
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace"), False
+
+    if isinstance(value, dict):
+        output: Dict[str, Any] = {}
+        truncated = False
+        for key, item in value.items():
+            if budget["remaining"] <= 0:
+                truncated = True
+                break
+            budget["remaining"] -= 1
+            output[str(key)], child_truncated = _json_safe(item, budget)
+            truncated = truncated or child_truncated
+        return output, truncated
+
+    if not isinstance(value, (str, bytes)):
+        try:
+            iterator = iter(value)
+        except TypeError:
+            iterator = None
+        if iterator is not None:
+            output = []
+            truncated = False
+            while budget["remaining"] > 0:
+                try:
+                    item = next(iterator)
+                except StopIteration:
+                    break
+                budget["remaining"] -= 1
+                converted, child_truncated = _json_safe(item, budget)
+                output.append(converted)
+                truncated = truncated or child_truncated
+            else:
+                try:
+                    next(iterator)
+                except StopIteration:
+                    pass
+                else:
+                    truncated = True
+            return output, truncated
+
+    path = getattr(value, "path", None)
+    if isinstance(path, str):
+        return path, False
+    return str(value), False
+
+
+def bounded_value(value: Any, max_items: int, max_chars: int) -> dict:
+    """Return a JSON-safe value with explicit item and serialized-size bounds."""
+    require_range(max_items, "max_value_items", 1, 256)
+    require_range(max_chars, "max_value_chars", 64, 4096)
+    converted, item_truncated = _json_safe(value, {"remaining": max_items})
+    serialized = json.dumps(converted, ensure_ascii=False, separators=(",", ":"))
+    if len(serialized) > max_chars:
+        return {
+            "value": None,
+            "value_preview": serialized[:max_chars],
+            "truncated": True,
+            "truncation_reasons": ["characters"] + (["items"] if item_truncated else []),
+        }
+    return {
+        "value": converted,
+        "truncated": item_truncated,
+        "truncation_reasons": ["items"] if item_truncated else [],
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/get_prim_attributes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/get_prim_attributes.py
@@ -1,0 +1,105 @@
+"""Read bounded attribute values from one USD prim."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _usd_common import (  # noqa: E402
+    bounded_value,
+    make_time_code,
+    require_range,
+    resolve_prim,
+    resolve_stage,
+)
+
+
+def get_prim_attributes(
+    lop_node_path: str,
+    prim_path: str,
+    name_filter: Optional[str] = None,
+    time_code: Optional[float] = None,
+    max_attributes: int = 50,
+    max_value_items: int = 64,
+    max_value_chars: int = 1024,
+) -> dict:
+    """Return filtered USD attributes within explicit payload bounds."""
+    try:
+        import hou  # noqa: PLC0415
+        from pxr import Usd  # noqa: PLC0415
+    except ImportError as exc:
+        return skill_error("Houdini USD APIs not available", str(exc))
+
+    try:
+        require_range(max_attributes, "max_attributes", 1, 100)
+        require_range(max_value_items, "max_value_items", 1, 256)
+        require_range(max_value_chars, "max_value_chars", 64, 4096)
+        if name_filter is not None and len(str(name_filter)) > 128:
+            raise ValueError("name_filter must be at most 128 characters")
+        node, stage = resolve_stage(hou, lop_node_path)
+        prim = resolve_prim(stage, prim_path)
+        usd_time = make_time_code(Usd, time_code)
+        lowered_filter = str(name_filter).lower() if name_filter else None
+        matching = sorted(
+            (
+                attribute
+                for attribute in prim.GetAttributes()
+                if lowered_filter is None or lowered_filter in str(attribute.GetName()).lower()
+            ),
+            key=lambda attribute: str(attribute.GetName()),
+        )
+
+        records = []
+        value_truncated_count = 0
+        for attribute in matching[:max_attributes]:
+            value = bounded_value(attribute.Get(usd_time), max_value_items, max_value_chars)
+            if value["truncated"]:
+                value_truncated_count += 1
+            record = {
+                "name": str(attribute.GetName()),
+                "type_name": str(attribute.GetTypeName()),
+                "authored": bool(attribute.HasAuthoredValueOpinion()),
+            }
+            record.update(value)
+            records.append(record)
+
+        return skill_success(
+            "Read USD prim attributes",
+            lop_node_path=str(node.path()),
+            prim_path=str(prim.GetPath()),
+            time_code="default" if time_code is None else float(time_code),
+            name_filter=name_filter,
+            attributes=records,
+            matched_count=len(matching),
+            returned_count=len(records),
+            truncated=len(matching) > len(records) or value_truncated_count > 0,
+            attribute_list_truncated=len(matching) > len(records),
+            value_truncated_count=value_truncated_count,
+            bounds={
+                "max_attributes": max_attributes,
+                "max_value_items": max_value_items,
+                "max_value_chars": max_value_chars,
+            },
+        )
+    except ValueError as exc:
+        return skill_error("Invalid USD attribute query", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read USD prim attributes")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_prim_attributes(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/get_prim_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/get_prim_info.py
@@ -1,0 +1,99 @@
+"""Inspect one prim on a composed Solaris USD Stage."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _usd_common import make_time_code, resolve_prim, resolve_stage  # noqa: E402
+
+
+def _vector(value: Any, length: int) -> list:
+    return [float(value[index]) for index in range(length)]
+
+
+def _world_transform(UsdGeom: Any, prim: Any, time: Any) -> Optional[list]:
+    if not UsdGeom.Xformable(prim):
+        return None
+    matrix = UsdGeom.XformCache(time).GetLocalToWorldTransform(prim)
+    return [[float(matrix[row][column]) for column in range(4)] for row in range(4)]
+
+
+def _world_bounds(UsdGeom: Any, prim: Any, time: Any) -> Optional[dict]:
+    purposes = [
+        UsdGeom.Tokens.default_,
+        UsdGeom.Tokens.proxy,
+        UsdGeom.Tokens.render,
+        UsdGeom.Tokens.guide,
+    ]
+    aligned = UsdGeom.BBoxCache(time, purposes, useExtentsHint=True).ComputeWorldBound(prim).ComputeAlignedRange()
+    if aligned.IsEmpty():
+        return None
+    return {"min": _vector(aligned.GetMin(), 3), "max": _vector(aligned.GetMax(), 3)}
+
+
+def _visibility(UsdGeom: Any, prim: Any, time: Any) -> Optional[str]:
+    imageable = UsdGeom.Imageable(prim)
+    return str(imageable.ComputeVisibility(time)) if imageable else None
+
+
+def _material_path(UsdShade: Any, prim: Any) -> Optional[str]:
+    binding = UsdShade.MaterialBindingAPI(prim).ComputeBoundMaterial()
+    material = binding[0] if isinstance(binding, tuple) else binding
+    return str(material.GetPath()) if material else None
+
+
+def get_prim_info(lop_node_path: str, prim_path: str, time_code: Optional[float] = None) -> dict:
+    """Return typed read-only information for one USD prim."""
+    try:
+        import hou  # noqa: PLC0415
+        from pxr import Usd, UsdGeom, UsdShade  # noqa: PLC0415
+    except ImportError as exc:
+        return skill_error("Houdini USD APIs not available", str(exc))
+
+    try:
+        node, stage = resolve_stage(hou, lop_node_path)
+        prim = resolve_prim(stage, prim_path)
+        usd_time = make_time_code(Usd, time_code)
+        info = {
+            "path": str(prim.GetPath()),
+            "name": str(prim.GetName()),
+            "type_name": str(prim.GetTypeName()),
+            "active": bool(prim.IsActive()),
+            "defined": bool(prim.IsDefined()),
+            "loaded": bool(prim.IsLoaded()),
+            "instance": bool(prim.IsInstance()),
+            "instance_proxy": bool(prim.IsInstanceProxy()),
+            "visibility": _visibility(UsdGeom, prim, usd_time),
+            "world_transform": _world_transform(UsdGeom, prim, usd_time),
+            "world_bounds": _world_bounds(UsdGeom, prim, usd_time),
+            "material_binding": _material_path(UsdShade, prim),
+        }
+        return skill_success(
+            "Inspected USD prim",
+            lop_node_path=str(node.path()),
+            time_code="default" if time_code is None else float(time_code),
+            prim=info,
+        )
+    except ValueError as exc:
+        return skill_error("Invalid USD prim query", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to inspect USD prim")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_prim_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/list_stage_prims.py
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/scripts/list_stage_prims.py
@@ -1,0 +1,104 @@
+"""List a bounded portion of a composed Solaris USD Stage."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _usd_common import require_absolute_path, require_range, resolve_prim, resolve_stage  # noqa: E402
+
+
+def _has_children(Usd: Any, prim: Any) -> bool:
+    probe = iter(Usd.PrimRange(prim))
+    next(probe, None)  # PrimRange includes its root.
+    return next(probe, None) is not None
+
+
+def _prim_summary(prim: Any, depth: int) -> dict:
+    return {
+        "path": str(prim.GetPath()),
+        "name": str(prim.GetName()),
+        "type_name": str(prim.GetTypeName()),
+        "depth": depth,
+        "active": bool(prim.IsActive()),
+        "defined": bool(prim.IsDefined()),
+        "loaded": bool(prim.IsLoaded()),
+        "instance": bool(prim.IsInstance()),
+        "instance_proxy": bool(prim.IsInstanceProxy()),
+    }
+
+
+def list_stage_prims(
+    lop_node_path: str,
+    root_path: str = "/",
+    max_depth: int = 3,
+    limit: int = 200,
+) -> dict:
+    """Return at most *limit* descendants up to *max_depth*."""
+    try:
+        import hou  # noqa: PLC0415
+        from pxr import Usd  # noqa: PLC0415
+    except ImportError as exc:
+        return skill_error("Houdini USD APIs not available", str(exc))
+
+    try:
+        require_range(max_depth, "max_depth", 1, 16)
+        require_range(limit, "limit", 1, 500)
+        usd_root = require_absolute_path(root_path, "root_path")
+        node, stage = resolve_stage(hou, lop_node_path)
+        root = stage.GetPseudoRoot() if usd_root == "/" else resolve_prim(stage, usd_root)
+        root_depth = root.GetPath().pathElementCount
+        traversal = iter(Usd.PrimRange(root))
+        next(traversal, None)  # The requested root is context, not a result row.
+        prims = []
+        depth_truncated = False
+
+        while len(prims) < limit:
+            prim = next(traversal, None)
+            if prim is None:
+                break
+            depth = prim.GetPath().pathElementCount - root_depth
+            prims.append(_prim_summary(prim, depth))
+            if depth >= max_depth:
+                depth_truncated = depth_truncated or _has_children(Usd, prim)
+                traversal.PruneChildren()
+
+        limit_truncated = len(prims) == limit and next(traversal, None) is not None
+        truncation_reasons = []
+        if limit_truncated:
+            truncation_reasons.append("limit")
+        if depth_truncated:
+            truncation_reasons.append("max_depth")
+
+        return skill_success(
+            "Listed USD Stage prims",
+            lop_node_path=str(node.path()),
+            root_path=usd_root,
+            prims=prims,
+            returned_count=len(prims),
+            truncated=bool(truncation_reasons),
+            truncation_reasons=truncation_reasons,
+            bounds={"max_depth": max_depth, "limit": limit},
+        )
+    except ValueError as exc:
+        return skill_error("Invalid USD Stage query", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list USD Stage prims")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_stage_prims(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/tools.yaml
@@ -1,0 +1,142 @@
+tools:
+  - name: list_stage_prims
+    description: >-
+      List prims below a root path on the composed USD Stage of a LOP node.
+      Traversal and output are bounded by max_depth and limit.
+    source_file: scripts/list_stage_prims.py
+    execution: sync
+    affinity: main
+    group: usd-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [list usd prims, inspect stage tree, solaris prim inventory, lops stage]
+    produces: [usd_stage_report]
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [lop_node_path]
+      properties:
+        lop_node_path:
+          type: string
+          description: Absolute Houdini path of the LOP node whose composed Stage is inspected.
+        root_path:
+          type: string
+          default: "/"
+          description: Absolute USD prim path below which descendants are listed.
+        max_depth:
+          type: integer
+          minimum: 1
+          maximum: 16
+          default: 3
+          description: Maximum descendant depth relative to root_path.
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 500
+          default: 200
+          description: Maximum number of prim records returned.
+    next-tools:
+      on-success:
+        - houdini_usd_lops__get_prim_info
+      on-failure:
+        - houdini_scene__get_node_info
+  - name: get_prim_info
+    description: >-
+      Inspect one USD prim on a LOP Stage, including type, active state,
+      computed visibility, world transform, world bounds, and bound material.
+    source_file: scripts/get_prim_info.py
+    execution: sync
+    affinity: main
+    group: usd-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [usd prim info, prim visibility, world bounds, world transform, material binding]
+    produces: [usd_stage_report]
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [lop_node_path, prim_path]
+      properties:
+        lop_node_path:
+          type: string
+          description: Absolute Houdini path of the LOP node whose composed Stage is inspected.
+        prim_path:
+          type: string
+          description: Absolute USD prim path to inspect.
+        time_code:
+          type: number
+          description: Optional USD time code. Omit to use the default time code.
+    next-tools:
+      on-success:
+        - houdini_usd_lops__get_prim_attributes
+      on-failure:
+        - houdini_usd_lops__list_stage_prims
+  - name: get_prim_attributes
+    description: >-
+      Read attributes from one USD prim at an optional time code. Name matching
+      and explicit count, item, and character limits keep payloads bounded.
+    source_file: scripts/get_prim_attributes.py
+    execution: sync
+    affinity: main
+    group: usd-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [usd prim attributes, primvars, inspect usd values, filtered attributes]
+    produces: [usd_stage_report]
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [lop_node_path, prim_path]
+      properties:
+        lop_node_path:
+          type: string
+          description: Absolute Houdini path of the LOP node whose composed Stage is inspected.
+        prim_path:
+          type: string
+          description: Absolute USD prim path whose attributes are read.
+        name_filter:
+          type: string
+          maxLength: 128
+          description: Optional case-insensitive substring matched against attribute names.
+        time_code:
+          type: number
+          description: Optional USD time code. Omit to use the default time code.
+        max_attributes:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 50
+          description: Maximum number of matching attributes returned.
+        max_value_items:
+          type: integer
+          minimum: 1
+          maximum: 256
+          default: 64
+          description: Maximum sequence or mapping items retained in each attribute value.
+        max_value_chars:
+          type: integer
+          minimum: 64
+          maximum: 4096
+          default: 1024
+          description: Maximum serialized characters retained for each attribute value.
+    next-tools:
+      on-failure:
+        - houdini_usd_lops__get_prim_info

--- a/tests/test_usd_lops_skill.py
+++ b/tests/test_usd_lops_skill.py
@@ -1,0 +1,449 @@
+"""Tests for bounded, read-only Solaris/USD inspection (no Houdini process)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+from dcc_mcp_core import McpHttpConfig, create_skill_server, validate_skill
+from dcc_mcp_core.host import QueueDispatcher, StandaloneHost
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+_SKILL_ROOT = _SKILLS_ROOT / "houdini-usd-lops"
+
+
+def _load_script(name: str) -> ModuleType:
+    path = _SKILL_ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location("usd_lops_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Attribute:
+    def __init__(self, name: str, value: Any, type_name: str = "float[]") -> None:
+        self._name = name
+        self._value = value
+        self._type_name = type_name
+        self.time_code = None
+
+    def GetName(self) -> str:
+        return self._name
+
+    def GetTypeName(self) -> str:
+        return self._type_name
+
+    def Get(self, time_code: Any) -> Any:
+        self.time_code = time_code
+        return self._value
+
+    def HasAuthoredValueOpinion(self) -> bool:
+        return True
+
+
+class _Prim:
+    def __init__(
+        self,
+        path: str,
+        type_name: str = "Xform",
+        children: Optional[List["_Prim"]] = None,
+        attributes: Optional[List[_Attribute]] = None,
+    ) -> None:
+        self._path = path
+        self._type_name = type_name
+        self._children = children or []
+        self._attributes = attributes or []
+
+    def __bool__(self) -> bool:
+        return True
+
+    def GetPath(self) -> "_Path":
+        return _Path(self._path)
+
+    def GetName(self) -> str:
+        return self._path.rsplit("/", 1)[-1]
+
+    def GetTypeName(self) -> str:
+        return self._type_name
+
+    def GetChildren(self) -> List["_Prim"]:
+        return self._children
+
+    def GetAttributes(self) -> List[_Attribute]:
+        return self._attributes
+
+    def IsActive(self) -> bool:
+        return True
+
+    def IsDefined(self) -> bool:
+        return True
+
+    def IsLoaded(self) -> bool:
+        return True
+
+    def IsInstance(self) -> bool:
+        return False
+
+    def IsInstanceProxy(self) -> bool:
+        return False
+
+
+class _Path(str):
+    @property
+    def pathElementCount(self) -> int:
+        return len([part for part in self.split("/") if part])
+
+
+class _PrimRangeIterator:
+    def __init__(self, root: _Prim) -> None:
+        self._stack = [iter([root])]
+        self._current = None
+        self._prune_current = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> _Prim:
+        if self._current is not None and not self._prune_current:
+            self._stack.append(iter(self._current.GetChildren()))
+        self._current = None
+        self._prune_current = False
+        while self._stack:
+            try:
+                self._current = next(self._stack[-1])
+                return self._current
+            except StopIteration:
+                self._stack.pop()
+        raise StopIteration
+
+    def PruneChildren(self) -> None:
+        self._prune_current = True
+
+
+class _PrimRange:
+    def __init__(self, root: _Prim) -> None:
+        self._root = root
+
+    def __iter__(self) -> _PrimRangeIterator:
+        return _PrimRangeIterator(self._root)
+
+
+class _Stage:
+    def __init__(self, root: _Prim, prims: Dict[str, _Prim]) -> None:
+        self._root = root
+        self._prims = prims
+
+    def GetPseudoRoot(self) -> _Prim:
+        return self._root
+
+    def GetPrimAtPath(self, path: str) -> Optional[_Prim]:
+        return self._prims.get(path)
+
+
+class _LopNode:
+    def __init__(self, stage: _Stage) -> None:
+        self._stage = stage
+
+    def path(self) -> str:
+        return "/stage/OUT"
+
+    def stage(self) -> _Stage:
+        return self._stage
+
+
+def _hou_module(stage: _Stage) -> ModuleType:
+    module = ModuleType("hou")
+    node = _LopNode(stage)
+    module.node = lambda path: node if path == "/stage/OUT" else None  # type: ignore[attr-defined]
+    return module
+
+
+class _TimeCode:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    @classmethod
+    def Default(cls) -> "_TimeCode":
+        return cls("default")
+
+
+class _XformCache:
+    def __init__(self, time_code: _TimeCode) -> None:
+        self.time_code = time_code
+
+    def GetLocalToWorldTransform(self, prim: _Prim) -> List[List[float]]:
+        del prim
+        return [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [10.0, 20.0, 30.0, 1.0],
+        ]
+
+
+class _Range:
+    def IsEmpty(self) -> bool:
+        return False
+
+    def GetMin(self) -> List[float]:
+        return [-1.0, -2.0, -3.0]
+
+    def GetMax(self) -> List[float]:
+        return [1.0, 2.0, 3.0]
+
+
+class _Bound:
+    def ComputeAlignedRange(self) -> _Range:
+        return _Range()
+
+
+class _BBoxCache:
+    def __init__(self, time_code: _TimeCode, purposes: List[str], useExtentsHint: bool) -> None:
+        self.args = (time_code, purposes, useExtentsHint)
+
+    def ComputeWorldBound(self, prim: _Prim) -> _Bound:
+        del prim
+        return _Bound()
+
+
+class _Imageable:
+    def __init__(self, prim: _Prim) -> None:
+        self.prim = prim
+
+    def __bool__(self) -> bool:
+        return True
+
+    def ComputeVisibility(self, time_code: _TimeCode) -> str:
+        del time_code
+        return "inherited"
+
+
+class _Material:
+    def GetPath(self) -> str:
+        return "/World/Looks/clay"
+
+
+class _MaterialBindingAPI:
+    def __init__(self, prim: _Prim) -> None:
+        self.prim = prim
+
+    def ComputeBoundMaterial(self) -> tuple:
+        return _Material(), None
+
+
+def _pxr_module() -> ModuleType:
+    module = ModuleType("pxr")
+    module.Usd = SimpleNamespace(TimeCode=_TimeCode, PrimRange=_PrimRange)  # type: ignore[attr-defined]
+    module.UsdGeom = SimpleNamespace(  # type: ignore[attr-defined]
+        Tokens=SimpleNamespace(default_="default", proxy="proxy", render="render", guide="guide"),
+        Xformable=lambda prim: prim,
+        XformCache=_XformCache,
+        BBoxCache=_BBoxCache,
+        Imageable=_Imageable,
+    )
+    module.UsdShade = SimpleNamespace(MaterialBindingAPI=_MaterialBindingAPI)  # type: ignore[attr-defined]
+    return module
+
+
+def _sample_stage(attributes: Optional[List[_Attribute]] = None) -> _Stage:
+    mesh = _Prim("/World/mesh", "Mesh", attributes=attributes)
+    light = _Prim("/World/keyLight", "DistantLight")
+    world = _Prim("/World", children=[mesh, light])
+    root = _Prim("/", children=[world])
+    return _Stage(root, {prim.GetPath(): prim for prim in (world, mesh, light)})
+
+
+def test_skill_validates_clean() -> None:
+    report = validate_skill(str(_SKILL_ROOT))
+    assert report.is_clean, report.issues
+
+
+def test_scripts_import_without_hou_or_pxr() -> None:
+    with patch.dict(sys.modules, {"hou": None, "pxr": None}):
+        for script in ("list_stage_prims.py", "get_prim_info.py", "get_prim_attributes.py"):
+            module = _load_script(script)
+            assert "hou" not in module.__dict__
+            assert "pxr" not in module.__dict__
+
+
+def test_list_stage_prims_reports_limit_and_depth_truncation() -> None:
+    module = _load_script("list_stage_prims.py")
+    stage = _sample_stage()
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        limited = module.list_stage_prims("/stage/OUT", max_depth=3, limit=2)
+        shallow = module.list_stage_prims("/stage/OUT", max_depth=1, limit=10)
+
+    assert limited["success"] is True
+    assert [prim["path"] for prim in limited["context"]["prims"]] == ["/World", "/World/mesh"]
+    assert limited["context"]["truncation_reasons"] == ["limit"]
+    assert shallow["context"]["returned_count"] == 1
+    assert shallow["context"]["truncation_reasons"] == ["max_depth"]
+
+
+def test_list_stage_prims_pulls_only_limit_plus_one_from_wide_stage() -> None:
+    module = _load_script("list_stage_prims.py")
+    pulled = []
+
+    class _WideRoot(_Prim):
+        def GetChildren(self):
+            for index in range(1000):
+                pulled.append(index)
+                yield _Prim("/prim{}".format(index))
+
+    root = _WideRoot("/")
+    stage = _Stage(root, {})
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        result = module.list_stage_prims("/stage/OUT", limit=1)
+
+    assert result["success"] is True
+    assert result["context"]["truncation_reasons"] == ["limit"]
+    assert pulled == [0, 1]
+
+
+def test_list_stage_prims_rejects_invalid_bounds() -> None:
+    module = _load_script("list_stage_prims.py")
+    stage = _sample_stage()
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        result = module.list_stage_prims("/stage/OUT", max_depth=0, limit=501)
+    assert result["success"] is False
+    assert "max_depth" in result["error"]
+
+
+def test_get_prim_info_returns_typed_computed_fields() -> None:
+    module = _load_script("get_prim_info.py")
+    stage = _sample_stage()
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        result = module.get_prim_info("/stage/OUT", "/World/mesh", time_code=12.5)
+
+    assert result["success"] is True
+    prim = result["context"]["prim"]
+    assert prim["type_name"] == "Mesh"
+    assert prim["active"] is True
+    assert prim["visibility"] == "inherited"
+    assert prim["world_transform"][3] == [10.0, 20.0, 30.0, 1.0]
+    assert prim["world_bounds"] == {"min": [-1.0, -2.0, -3.0], "max": [1.0, 2.0, 3.0]}
+    assert prim["material_binding"] == "/World/Looks/clay"
+
+
+def test_get_prim_info_rejects_non_finite_time_code() -> None:
+    module = _load_script("get_prim_info.py")
+    stage = _sample_stage()
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        result = module.get_prim_info("/stage/OUT", "/World/mesh", time_code=float("inf"))
+    assert result["success"] is False
+    assert "finite number" in result["error"]
+
+
+def test_get_prim_attributes_filters_and_bounds_values() -> None:
+    attributes = [
+        _Attribute("primvars:displayColor", [1, 2, 3, 4]),
+        _Attribute("primvars:label", "x" * 100, "string"),
+        _Attribute("visibility", "inherited", "token"),
+    ]
+    module = _load_script("get_prim_attributes.py")
+    stage = _sample_stage(attributes)
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        result = module.get_prim_attributes(
+            "/stage/OUT",
+            "/World/mesh",
+            name_filter="PRIMVARS",
+            time_code=7,
+            max_attributes=2,
+            max_value_items=2,
+            max_value_chars=64,
+        )
+
+    assert result["success"] is True
+    context = result["context"]
+    assert context["matched_count"] == 2
+    assert context["returned_count"] == 2
+    assert context["value_truncated_count"] == 2
+    assert context["truncated"] is True
+    assert context["attributes"][0]["value"] == [1, 2]
+    assert context["attributes"][0]["truncation_reasons"] == ["items"]
+    assert context["attributes"][1]["value"] is None
+    assert len(context["attributes"][1]["value_preview"]) == 64
+    assert attributes[0].time_code.value == 7.0
+
+
+def test_get_prim_attributes_rejects_oversized_name_filter() -> None:
+    module = _load_script("get_prim_attributes.py")
+    stage = _sample_stage()
+    with patch.dict(sys.modules, {"hou": _hou_module(stage), "pxr": _pxr_module()}):
+        result = module.get_prim_attributes("/stage/OUT", "/World/mesh", name_filter="x" * 129)
+    assert result["success"] is False
+    assert "128 characters" in result["error"]
+
+
+def _post_mcp(url: str, payload: dict) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return json.loads(response.read())
+
+
+def test_scan_load_tools_list_and_call_integration(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MCP_LOG_LEVEL", "WARN")
+    monkeypatch.setenv("DCC_MCP_LOG_LEVEL", "WARN")
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    config = McpHttpConfig(port=0, server_name="houdini-usd-lops-test")
+    config.gateway_port = 0
+    dispatcher = QueueDispatcher()
+    host = StandaloneHost(dispatcher)
+    calls = []
+
+    def executor(script_path: str, params: dict, **metadata: Any) -> dict:
+        calls.append({"script_path": script_path, "params": params, **metadata})
+        return {"success": True, "message": "captured", "context": params}
+
+    server = create_skill_server("houdini", config)
+    server.attach_dispatcher(dispatcher)
+    server.set_in_process_executor(executor)
+    assert server.discover(extra_paths=[str(_SKILLS_ROOT)]) >= 1
+    loaded = server.load_skill("houdini-usd-lops")
+    assert set(loaded) == {
+        "houdini_usd_lops__list_stage_prims",
+        "houdini_usd_lops__get_prim_info",
+        "houdini_usd_lops__get_prim_attributes",
+    }
+
+    host.start()
+    handle = server.start()
+    try:
+        listed = _post_mcp(handle.mcp_url(), {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        tools = {tool["name"]: tool for tool in listed["result"]["tools"]}
+        assert {"list_stage_prims", "get_prim_info", "get_prim_attributes"} <= set(tools)
+        assert tools["list_stage_prims"]["annotations"]["readOnlyHint"] is True
+
+        called = _post_mcp(
+            handle.mcp_url(),
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "list_stage_prims", "arguments": {"lop_node_path": "/stage/OUT"}},
+            },
+        )
+        assert called["result"]["isError"] is False
+        assert called["result"]["structuredContent"]["success"] is True
+    finally:
+        handle.shutdown()
+        host.stop()
+
+    assert len(calls) == 1
+    assert calls[0]["params"] == {"lop_node_path": "/stage/OUT"}
+    assert calls[0]["action_name"] == "houdini_usd_lops__list_stage_prims"
+    assert calls[0]["thread_affinity"] == "main"
+    assert calls[0]["execution"] == "sync"


### PR DESCRIPTION
## Summary

- add an on-demand `houdini-usd-lops` skill with typed read-only tools for bounded Stage traversal, single-prim inspection, and filtered attribute reads
- use lazy `Usd.PrimRange` traversal with separate `limit` and `max_depth` truncation metadata
- bound attribute count, value item count, serialized value size, and attribute-name filtering
- register the skill in the interchange stage and document the inspection workflow

## Validation

- Python 3.7 syntax parse for the new scripts and tests
- `python -m ruff check src tests tools packaging examples`
- `python -m ruff format --check src tests tools packaging examples`
- `python tools/lint_skills.py --require-cli --warnings-as-errors`
- `python -m pytest` (`479 passed, 1 skipped, 2 deselected`)

No Houdini process or production render was started during validation.