### PR TITLE
fix: report live render outputs and diagnostics

### DIFF
--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -14,6 +14,7 @@ from dcc_mcp_houdini import _isolated_jobs
 
 _SUMMARY_WARNING_LIMIT = 10
 _SUMMARY_TEXT_LIMIT = 500
+_STDERR_TAIL_BYTES = 256 * 1024
 
 
 def _hython_executable() -> Path:
@@ -101,15 +102,18 @@ def _with_progress(status: Dict[str, Any]) -> Dict[str, Any]:
     result = dict(status)
     expected = list(result.get("expected_outputs") or [])
     before = dict(result.get("output_snapshot") or {})
-    completed = 0
+    observed_written_files = []
     for output in expected:
         signature = _file_signature(output)
         if signature is not None and signature != before.get(output):
-            completed += 1
+            observed_written_files.append(output)
+    completed = len(observed_written_files)
     total = len(expected)
     result["completed"] = completed
     result["total"] = total
     result["progress"] = float(completed) / total if total else None
+    if result.get("state") not in _isolated_jobs._TERMINAL_STATES or "written_files" not in result:
+        result["written_files"] = observed_written_files
 
     started_at = result.get("started_at")
     if started_at is not None:
@@ -129,17 +133,61 @@ def _with_progress(status: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def _stderr_tail(status: Dict[str, Any]) -> str:
+    """Read at most the bounded tail of the worker's stderr stream."""
+    stderr_path = status.get("stderr_path")
+    if not stderr_path:
+        return ""
+
+    try:
+        with Path(str(stderr_path)).open("rb") as stream:
+            stream.seek(0, os.SEEK_END)
+            size = stream.tell()
+            offset = max(0, size - _STDERR_TAIL_BYTES)
+            stream.seek(offset)
+            payload = stream.read(_STDERR_TAIL_BYTES)
+    except OSError:
+        return ""
+    if offset:
+        newline = payload.find(b"\n")
+        payload = payload[newline + 1 :] if newline >= 0 else b""
+    return payload.decode("utf-8", errors="replace")
+
+
+def _warning_lines(status: Dict[str, Any]) -> List[Any]:
+    """Merge worker warnings with unique, non-empty stderr diagnostics."""
+    raw_warnings = status.get("warnings", []) or []
+    status_warnings = list(raw_warnings) if isinstance(raw_warnings, (list, tuple)) else [raw_warnings]
+    warnings = []
+    seen = set()
+    for warning in status_warnings:
+        normalized = " ".join(str(warning).splitlines())
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            warnings.append(warning)
+    # Houdini render diagnostics are not consistently prefixed with "Warning";
+    # stderr is the worker's dedicated diagnostic stream, so retain every line.
+    for raw_line in _stderr_tail(status).splitlines():
+        warning = " ".join(raw_line.splitlines())
+        if warning and warning not in seen:
+            seen.add(warning)
+            warnings.append(warning)
+    return warnings
+
+
 def read_render_job(job_id: str, include_details: bool = False) -> Dict[str, Any]:
     result = _with_progress(_isolated_jobs.read_job(job_id))
+    warnings = _warning_lines(result)
+    result["warning_count"] = len(warnings)
+    if include_details:
+        result["warnings"] = warnings
     if not include_details:
         result.pop("expected_outputs", None)
         result.pop("output_snapshot", None)
         written_files = list(result.pop("written_files", []) or [])
         result["written_file_count"] = len(written_files)
         result["recent_written_files"] = written_files[-10:]
-        raw_warnings = result.pop("warnings", []) or []
-        warnings = list(raw_warnings) if isinstance(raw_warnings, (list, tuple)) else [raw_warnings]
-        result["warning_count"] = len(warnings)
+        result.pop("warnings", None)
         result["recent_warnings"] = [
             " ".join(str(warning).splitlines())[:_SUMMARY_TEXT_LIMIT] for warning in warnings[-_SUMMARY_WARNING_LIMIT:]
         ]

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -525,16 +525,10 @@ class TestRenderExecution:
         job_id = "f" * 32
         job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
         job_dir.mkdir(parents=True)
-        outputs = [job_dir / "beauty.{:04d}.exr".format(frame) for frame in (1, 2, 3)]
-        outputs[0].write_bytes(b"stale")
-        outputs[1].write_bytes(b"new")
-        snapshot = {
-            str(outputs[0]): {
-                "mtime_ns": outputs[0].stat().st_mtime_ns,
-                "size": outputs[0].stat().st_size,
-            },
-            str(outputs[1]): {"mtime_ns": 1, "size": 1},
-        }
+        outputs = [job_dir / "beauty.{:04d}.exr".format(frame) for frame in range(1, 31)]
+        for output in outputs[:25]:
+            output.write_bytes(b"new")
+        snapshot = {str(output): {"mtime_ns": 1, "size": 1} for output in outputs[:25]}
         (job_dir / "status.json").write_text(
             json.dumps(
                 {
@@ -543,6 +537,7 @@ class TestRenderExecution:
                     "started_at": 10.0,
                     "expected_outputs": [str(path) for path in outputs],
                     "output_snapshot": snapshot,
+                    "written_files": [],
                 }
             ),
             encoding="utf-8",
@@ -554,15 +549,18 @@ class TestRenderExecution:
             summary = mod.read_render_job(job_id)
             details = mod.read_render_job(job_id, include_details=True)
 
-        assert summary["completed"] == 1
-        assert summary["total"] == 3
-        assert summary["progress"] == pytest.approx(1.0 / 3.0)
+        assert summary["completed"] == 25
+        assert summary["total"] == 30
+        assert summary["progress"] == pytest.approx(25.0 / 30.0)
         assert summary["elapsed_secs"] == 30.0
-        assert summary["eta_secs"] == 60.0
+        assert summary["eta_secs"] == 6.0
+        assert summary["written_file_count"] == 25
+        assert summary["recent_written_files"] == [str(output) for output in outputs[15:25]]
         assert "expected_outputs" not in summary
         assert "output_snapshot" not in summary
         assert details["expected_outputs"] == [str(path) for path in outputs]
         assert details["output_snapshot"] == snapshot
+        assert details["written_files"] == [str(output) for output in outputs[:25]]
 
     def test_cancel_complete_race_preserves_completed_state(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "_background_render.py")
@@ -634,7 +632,12 @@ class TestRenderExecution:
         job_id = "6" * 32
         job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
         job_dir.mkdir(parents=True)
-        warnings = ["warning {}\n{}".format(index, "x" * 600) for index in range(12)]
+        shared_prefix = "x" * 600
+        warnings = [
+            shared_prefix + " first",
+            shared_prefix + " second",
+            *["warning {}\n{}".format(index, "x" * 600) for index in range(10)],
+        ]
         (job_dir / "status.json").write_text(
             json.dumps({"job_id": job_id, "state": "failed", "warnings": warnings}),
             encoding="utf-8",
@@ -648,6 +651,48 @@ class TestRenderExecution:
         assert len(summary["recent_warnings"]) == 10
         assert all("\n" not in warning and len(warning) <= 500 for warning in summary["recent_warnings"])
         assert details["warnings"] == warnings
+
+    def test_get_render_job_surfaces_bounded_stderr_warnings(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "5" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        stderr = job_dir / "stderr.log"
+        stderr_warnings = [
+            "Property 'vblur' cannot be specified on a per-instance at this time.",
+            "Pixel filter 'minmax' - Mode idcover requires PrimId channel",
+        ]
+        stderr_lines = [warning for warning in stderr_warnings for _ in range(2)]
+        stderr_limit = mod.read_render_job.__globals__["_STDERR_TAIL_BYTES"]
+        stderr.write_text(
+            "outside bounded tail\n{}\n{}\n".format(
+                "x" * (stderr_limit + 1),
+                "\n".join(stderr_lines),
+            ),
+            encoding="utf-8",
+        )
+        (job_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "state": "running",
+                    "stderr_path": str(stderr),
+                    "warnings": ["worker warning", stderr_warnings[0]],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            summary = mod.read_render_job(job_id)
+            details = mod.read_render_job(job_id, include_details=True)
+
+        expected_warnings = ["worker warning", *stderr_warnings]
+        assert summary["warning_count"] == len(expected_warnings)
+        assert summary["recent_warnings"] == expected_warnings
+        assert all(len(warning) <= 500 for warning in summary["recent_warnings"])
+        assert details["warning_count"] == len(expected_warnings)
+        assert details["warnings"] == expected_warnings
 
     def test_get_render_job_tool_forwards_include_details(self) -> None:
         mod = _load_script("houdini-render", "get_render_job.py")


### PR DESCRIPTION
## Summary

- project newly observed frame outputs into `written_file_count` and `recent_written_files` while a background render is still running
- preserve worker-authored output lists for completed, failed, cancelled, and interrupted jobs
- merge unique renderer diagnostics from a bounded 256 KiB stderr tail, including messages that do not carry a warning prefix
- cover a 25-of-30 active render and the unprefixed Karma diagnostic strings

## Validation

- `python -m pytest` (480 passed, 1 skipped, 2 deselected)
- `python -m pytest tests/test_render_camera_light_skills.py -q` (44 passed)
- `python -m ruff check src tests tools packaging`
- `python -m ruff format --check src tests tools packaging`
- `python tools/check_py37_syntax.py src tests tools packaging`