### PR TITLE
fix: budget Houdini UI host dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ server = dcc_mcp_houdini.start_server()
 
 Houdini `hou.*` APIs require the UI thread. The adapter wires:
 
-- `BlockingDispatcher` + `HoudiniHost` → `hou.ui.addEventLoopCallback`
+- `HostUiDispatcherBase` + `HostPumpController` + `HoudiniUiPump` → one throttled `hou.ui.addEventLoopCallback` with an 8 ms queue budget
 - Headless `hython` → inline / standalone dispatcher
 
 ## Skill authoring

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.19.9`
-- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.9,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
+- `dcc-mcp-core >= 0.19.33`
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.33,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@ server.list_skills()
 ## Public exports
 
 - `HoudiniMcpServer`, `start_server`, `stop_server`, `get_server`
-- `HoudiniHost`, `HoudiniCallableDispatcher`, `create_execution_stack`
+- `HoudiniUiDispatcher`, `HoudiniUiPump`, `HoudiniHost`, `HoudiniCallableDispatcher`, `create_execution_stack`
 - `houdini_success`, `houdini_error`, `with_houdini`
 - `build_minimal_mode_config`, `build_minimal_mode_for_stages`, `MINIMAL_SKILLS`, `STAGES`, `STAGE_SKILLS`
 

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -35,7 +35,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.19.9"
+MIN_CORE_VERSION = "0.19.33"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.19.9: py37-lite pure-Python fallback for older Houdini runtimes.
-    "dcc-mcp-core>=0.19.9,<1.0.0",
+    # 0.19.33: HostExecutionBridge routes HostUiDispatcherBase to HTTP calls.
+    "dcc-mcp-core>=0.19.33,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_houdini/__init__.py
+++ b/src/dcc_mcp_houdini/__init__.py
@@ -72,7 +72,13 @@ from dcc_mcp_houdini.dispatcher import (
     HoudiniStandaloneDispatcher,
     create_execution_stack,
 )
-from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
+from dcc_mcp_houdini.host import (
+    HoudiniCallableDispatcher,
+    HoudiniEventLoopTimerAdapter,
+    HoudiniHost,
+    HoudiniUiDispatcher,
+    HoudiniUiPump,
+)
 from dcc_mcp_houdini.server import (
     DEFAULT_PORT,
     SERVER_NAME,
@@ -100,6 +106,7 @@ __all__ = [
     "HoudiniCallableDispatcher",
     "HoudiniCapabilityManifestBuilder",
     "HoudiniContextSnapshotProvider",
+    "HoudiniEventLoopTimerAdapter",
     "HoudiniHost",
     "HoudiniMcpServer",
     "HoudiniResourceBinder",
@@ -107,6 +114,8 @@ __all__ = [
     "HoudiniSemanticIndex",
     "HoudiniServerOptions",
     "HoudiniStandaloneDispatcher",
+    "HoudiniUiDispatcher",
+    "HoudiniUiPump",
     "MINIMAL_SKILLS",
     "MissingParamError",
     "ProjectToolsIntegration",

--- a/src/dcc_mcp_houdini/dispatcher/__init__.py
+++ b/src/dcc_mcp_houdini/dispatcher/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from dcc_mcp_houdini.dispatcher.standalone import HoudiniStandaloneDispatcher
-from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
+from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost, HoudiniUiDispatcher, HoudiniUiPump
 
 __all__ = [
     "HoudiniCallableDispatcher",
     "HoudiniHost",
     "HoudiniStandaloneDispatcher",
+    "HoudiniUiDispatcher",
+    "HoudiniUiPump",
     "create_execution_stack",
 ]
 
@@ -17,21 +19,20 @@ def create_execution_stack():
     """Create the dispatcher + optional host adapter for the current environment.
 
     Returns:
-        ``(dispatcher, host)`` where *host* is a started :class:`HoudiniHost`.
-        Interactive Houdini uses its UI event loop; headless ``hython`` uses
-        the host adapter's blocking queue pump.
+        ``(dispatcher, host)`` where interactive Houdini receives a started
+        :class:`HoudiniUiPump`, while headless ``hython`` uses inline dispatch.
     """
     try:
         import hou  # noqa: PLC0415
 
-        _ = hou.isUIAvailable()
+        ui_available = bool(hou.isUIAvailable())
     except ImportError:
-        pass
+        ui_available = False
 
-    from dcc_mcp_core.host import BlockingDispatcher
+    if not ui_available:
+        return HoudiniStandaloneDispatcher(), None
 
-    blocking = BlockingDispatcher()
-    dispatcher = HoudiniCallableDispatcher(blocking)
-    host = HoudiniHost(blocking)
+    dispatcher = HoudiniUiDispatcher()
+    host = HoudiniUiPump(dispatcher)
     host.start()
     return dispatcher, host

--- a/src/dcc_mcp_houdini/host.py
+++ b/src/dcc_mcp_houdini/host.py
@@ -3,12 +3,168 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import threading
+import time
+import uuid
 from typing import Any, Callable, Optional
 
+from dcc_mcp_core import HostPumpController, HostUiDispatcherBase
 from dcc_mcp_core.host import BlockingDispatcher, HostAdapter
 
 TickFn = Callable[[], Optional[float]]
+logger = logging.getLogger(__name__)
+
+
+class HoudiniEventLoopTimerAdapter:
+    """Adapt Houdini's single event-loop callback to the core pump timer."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        error_retry_secs: float = 0.05,
+    ) -> None:
+        if error_retry_secs <= 0:
+            raise ValueError("error_retry_secs must be > 0")
+        self._clock = clock
+        self._error_retry_secs = float(error_retry_secs)
+        self._lock = threading.Lock()
+        self._tick: Optional[TickFn] = None
+        self._callback: Optional[Callable[[], None]] = None
+        self._next_due = 0.0
+        self._tick_thread_ident: Optional[int] = None
+
+    @property
+    def installed(self) -> bool:
+        """Return whether the Houdini callback is registered."""
+        with self._lock:
+            return self._callback is not None
+
+    @property
+    def tick_thread_ident(self) -> Optional[int]:
+        """Thread id of the most recent due event-loop tick."""
+        return self._tick_thread_ident
+
+    def install(self, tick: TickFn) -> None:
+        """Install exactly one Houdini event-loop callback."""
+        import hou  # noqa: PLC0415
+
+        with self._lock:
+            self._tick = tick
+            self._next_due = 0.0
+            if self._callback is not None:
+                return
+
+            def _callback() -> None:
+                now = self._clock()
+                with self._lock:
+                    due_tick = self._tick
+                    if due_tick is None or now < self._next_due:
+                        return
+                    self._next_due = float("inf")
+
+                self._tick_thread_ident = threading.get_ident()
+                try:
+                    interval = due_tick()
+                except Exception:  # noqa: BLE001
+                    logger.exception("Houdini host pump tick failed")
+                    interval = self._error_retry_secs
+
+                if interval is None:
+                    self.uninstall()
+                    return
+                with self._lock:
+                    if self._tick is not None and self._next_due != 0.0:
+                        self._next_due = self._clock() + max(float(interval), 0.0)
+
+            self._callback = _callback
+
+        try:
+            hou.ui.addEventLoopCallback(_callback)
+        except Exception:
+            with self._lock:
+                self._callback = None
+                self._tick = None
+            raise
+
+    def uninstall(self) -> None:
+        """Remove the registered callback, if any."""
+        with self._lock:
+            callback = self._callback
+            self._callback = None
+            self._tick = None
+            self._next_due = 0.0
+        if callback is None:
+            return
+        with contextlib.suppress(Exception):
+            import hou  # noqa: PLC0415
+
+            hou.ui.removeEventLoopCallback(callback)
+
+    def schedule_soon(self) -> None:
+        """Make the already-registered callback drain on its next invocation."""
+        with self._lock:
+            if self._callback is not None:
+                self._next_due = 0.0
+
+
+class HoudiniUiDispatcher(HostUiDispatcherBase):
+    """Thin Houdini wrapper around the shared core UI dispatcher."""
+
+    def __init__(self) -> None:
+        super().__init__(label="houdini-ui")
+        self._owner_thread_ident = threading.get_ident()
+        self._pump_controller: Optional[HostPumpController] = None
+
+    def attach_pump_controller(self, controller: HostPumpController) -> None:
+        """Attach the controller that schedules Houdini event-loop ticks."""
+        self._pump_controller = controller
+
+    def detach_pump_controller(self, controller: Optional[HostPumpController] = None) -> None:
+        """Detach a stopped controller without disturbing a replacement."""
+        if controller is None or self._pump_controller is controller:
+            self._pump_controller = None
+
+    def poke_host_pump(self) -> None:
+        """Ask the existing Houdini callback to drain queued work soon."""
+        controller = self._pump_controller
+        if controller is not None:
+            controller.schedule_soon()
+
+    def is_host_thread(self) -> bool:
+        """Recognise both the construction thread and observed pump thread."""
+        return threading.get_ident() == self._owner_thread_ident or super().is_host_thread()
+
+    def dispatch_callable(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        affinity: str = "main",
+        context: Any = None,
+        action_name: str = "",
+        skill_name: Optional[str] = None,
+        execution: str = "sync",
+        timeout_hint_secs: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run ``func`` through the shared UI-thread job lifecycle."""
+        _ = (context, execution)
+        if (affinity or "main").lower() == "main" and self.is_host_thread():
+            return func(*args, **kwargs)
+
+        label = ".".join(part for part in (skill_name, action_name) if part) or "houdini-call"
+        request_id = f"{label}:{uuid.uuid4().hex}"
+        timeout_ms = timeout_hint_secs * 1000 if timeout_hint_secs and timeout_hint_secs > 0 else None
+        outcome = self.submit_callable(
+            request_id,
+            lambda: func(*args, **kwargs),
+            affinity=affinity,
+            timeout_ms=timeout_ms,
+        )
+        if outcome.get("success"):
+            return outcome.get("output")
+        raise RuntimeError(outcome.get("error") or "Houdini UI dispatch failed")
 
 
 class HoudiniCallableDispatcher:
@@ -80,12 +236,65 @@ class HoudiniInlineCallableDispatcher:
         return func(*args, **kwargs)
 
 
-class HoudiniHost(HostAdapter):
-    """Drive a dcc-mcp-core dispatcher from Houdini's main thread.
+class HoudiniUiPump:
+    """Drive an interactive Houdini dispatcher through the core pump."""
 
-    Interactive Houdini registers the core dispatcher tick with
-    ``hou.ui.addEventLoopCallback``; headless ``hython`` uses the
-    blocking loop from :class:`HostAdapter`.
+    def __init__(
+        self,
+        dispatcher: HoudiniUiDispatcher,
+        *,
+        budget_ms: int = 8,
+        timer_adapter: Optional[HoudiniEventLoopTimerAdapter] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._timer = timer_adapter or HoudiniEventLoopTimerAdapter(clock=clock)
+        self._controller = HostPumpController(
+            dispatcher,
+            self._timer,
+            budget_ms=budget_ms,
+            clock=clock,
+            shutdown_pump_on_stop=True,
+        )
+        dispatcher.attach_pump_controller(self._controller)
+
+    @property
+    def controller(self) -> HostPumpController:
+        """Return the shared core pump controller."""
+        return self._controller
+
+    @property
+    def stats(self):
+        """Return queue, timing, and overrun counters."""
+        return self._controller.stats
+
+    @property
+    def tick_thread_ident(self) -> Optional[int]:
+        """Thread id of the most recent Houdini event-loop tick."""
+        return self._timer.tick_thread_ident
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the event-loop callback is installed."""
+        return self._controller.is_running
+
+    def start(self) -> None:
+        """Install the pump once; repeated starts are harmless."""
+        self._dispatcher.attach_pump_controller(self._controller)
+        self._controller.start()
+
+    def stop(self) -> None:
+        """Stop the pump and unblock queued waiters; idempotent."""
+        self._controller.stop()
+        self._dispatcher.detach_pump_controller(self._controller)
+
+
+class HoudiniHost(HostAdapter):
+    """Legacy queue host retained for direct and headless integrations.
+
+    New interactive server stacks use :class:`HoudiniUiPump`.  Keeping this
+    adapter preserves the public ``HoudiniHost(blocking).run_headless()``
+    contract used by standalone bootstrap scripts.
     """
 
     def __init__(self, dispatcher, **kwargs) -> None:
@@ -113,8 +322,7 @@ class HoudiniHost(HostAdapter):
 
         def _callback() -> bool:
             self._tick_thread_ident = threading.get_ident()
-            interval = tick_fn()
-            return interval is not None
+            return tick_fn() is not None
 
         self._callback = _callback
         hou.ui.addEventLoopCallback(_callback)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   channels and expressions; export/import channel JSON; bake channels and
   trigger bounded simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   export. Create and manage CHOP networks, motion clips, audio-driven
   channels, and filter effects.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   constraints using OBJ-level blend nodes and CHOP-driven channel
   referencing. List and delete existing constraints.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   with typed parameters. Use when loading .hda/.otl assets or executing an HDA
   node as part of automation. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checkpoint/resume, scene snapshots, and husk option configuration. Pair with
   houdini-karma for renderer setup and houdini-render for viewport/ROP renders.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   ImportToSceneResult. Use as the receiving end of the asset import pipeline
   after an asset-source skill resolves the descriptor.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   light mixer, and image output through typed tools. Pair with houdini-render
   for full render execution and houdini-camera-light for scene setup.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   configure rig skeletons, set rig poses, capture joint skinning weights,
   and apply motion capture data via SOP-level KineFX nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   houdini-materials (create/assign) and houdini-lookdev (shader-network
   editing, adapter-owned presets).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   nodes through typed HOM operations. Use when building lookdev/material
   workflows. Not for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   written_files, elapsed time, and warnings without hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   to low-res target. Pair with houdini-render for render output and
   houdini-materials for shader assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Stage. Use it to list prims, inspect one prim, or read bounded attribute
   values. Not for USD authoring, import, or export.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.9+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,0 +1,201 @@
+"""Regression tests for Houdini's budgeted UI-thread pump."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeHoudiniUi:
+    def __init__(self) -> None:
+        self.callbacks = []
+
+    def addEventLoopCallback(self, callback) -> None:
+        self.callbacks.append(callback)
+
+    def removeEventLoopCallback(self, callback) -> None:
+        self.callbacks.remove(callback)
+
+
+def _fake_hou(ui_available: bool = True):
+    ui = _FakeHoudiniUi()
+    return SimpleNamespace(isUIAvailable=lambda: ui_available, ui=ui), ui
+
+
+def _wait_until(predicate, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError("condition was not met before timeout")
+
+
+def test_interactive_stack_uses_one_budgeted_core_ui_pump() -> None:
+    from dcc_mcp_core import HostUiDispatcherBase
+
+    from dcc_mcp_houdini.dispatcher import create_execution_stack
+
+    hou, ui = _fake_hou()
+    with patch.dict(sys.modules, {"hou": hou}):
+        dispatcher, host = create_execution_stack()
+        try:
+            assert isinstance(dispatcher, HostUiDispatcherBase)
+            assert host.is_running
+            assert len(ui.callbacks) == 1
+
+            host.start()
+            assert len(ui.callbacks) == 1
+        finally:
+            host.stop()
+            host.stop()
+
+    assert ui.callbacks == []
+
+
+def test_legacy_houdini_host_retains_headless_bootstrap_contract() -> None:
+    from dcc_mcp_core.host import BlockingDispatcher
+
+    from dcc_mcp_houdini.host import HoudiniHost
+
+    stop = threading.Event()
+    stop.set()
+    HoudiniHost(BlockingDispatcher()).run_headless(stop_event=stop)
+
+
+def test_event_loop_adapter_throttles_due_ticks_and_isolates_exceptions() -> None:
+    from dcc_mcp_houdini.host import HoudiniEventLoopTimerAdapter
+
+    clock = _FakeClock()
+    hou, ui = _fake_hou()
+    timer = HoudiniEventLoopTimerAdapter(clock=clock, error_retry_secs=0.1)
+    calls = []
+
+    def failing_tick():
+        calls.append("failed")
+        raise RuntimeError("boom")
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        timer.install(failing_tick)
+        timer.install(failing_tick)
+        assert len(ui.callbacks) == 1
+
+        ui.callbacks[0]()
+        ui.callbacks[0]()
+        assert calls == ["failed"]
+
+        timer.install(lambda: calls.append("recovered") or 0.5)
+        clock.advance(0.1)
+        ui.callbacks[0]()
+        ui.callbacks[0]()
+        assert calls == ["failed", "recovered"]
+
+        clock.advance(0.5)
+        ui.callbacks[0]()
+        assert calls == ["failed", "recovered", "recovered"]
+
+        timer.install(lambda: timer.schedule_soon() or calls.append("wake") or 0.5)
+        ui.callbacks[0]()
+        ui.callbacks[0]()
+        assert calls[-2:] == ["wake", "wake"]
+
+        timer.uninstall()
+        timer.uninstall()
+        timer.install(lambda: 1.0)
+        assert len(ui.callbacks) == 1
+        timer.uninstall()
+
+    assert ui.callbacks == []
+
+
+def test_host_controller_applies_budget_and_exposes_overrun_stats(monkeypatch) -> None:
+    from dcc_mcp_houdini.host import HoudiniEventLoopTimerAdapter, HoudiniUiDispatcher, HoudiniUiPump
+
+    clock = _FakeClock()
+    hou, ui = _fake_hou()
+    dispatcher = HoudiniUiDispatcher()
+    timer = HoudiniEventLoopTimerAdapter(clock=clock)
+    host = HoudiniUiPump(dispatcher, budget_ms=4, timer_adapter=timer, clock=clock)
+    budgets = []
+
+    def drain_queue(budget_ms):
+        budgets.append(budget_ms)
+        clock.advance(0.009)
+        return {"drained": 1, "remaining": 0, "elapsed_ms": 9.0, "overrun": True}
+
+    monkeypatch.setattr(dispatcher, "drain_queue", drain_queue)
+    with patch.dict(sys.modules, {"hou": hou}):
+        host.start()
+        ui.callbacks[0]()
+        ui.callbacks[0]()
+
+        assert budgets == [4]
+        assert host.stats.ticks == 1
+        assert host.stats.drained_jobs == 1
+        assert host.stats.overrun_count == 1
+        assert host.stats.last_elapsed_ms == 9.0
+
+        clock.advance(0.05)
+        ui.callbacks[0]()
+        assert budgets == [4, 4]
+        host.stop()
+
+
+def test_ui_dispatcher_cancels_queued_work_and_survives_task_errors() -> None:
+    from dcc_mcp_houdini.host import HoudiniUiDispatcher, HoudiniUiPump
+
+    hou, ui = _fake_hou()
+    dispatcher = HoudiniUiDispatcher()
+    host = HoudiniUiPump(dispatcher)
+    cancelled = []
+    failed = []
+    recovered = []
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        host.start()
+
+        cancel_thread = threading.Thread(
+            target=lambda: cancelled.append(dispatcher.submit_callable("cancel-me", lambda: "never", affinity="main"))
+        )
+        cancel_thread.start()
+        _wait_until(lambda: dispatcher.queue_size() == 1)
+        assert dispatcher.cancel("cancel-me") is True
+        cancel_thread.join(timeout=1)
+
+        def fail() -> None:
+            raise ValueError("task failed")
+
+        fail_thread = threading.Thread(
+            target=lambda: failed.append(dispatcher.submit_callable("fail", fail, affinity="main"))
+        )
+        fail_thread.start()
+        _wait_until(lambda: dispatcher.queue_size() == 2)
+        ui.callbacks[0]()
+        fail_thread.join(timeout=1)
+
+        ok_thread = threading.Thread(
+            target=lambda: recovered.append(dispatcher.submit_callable("recover", lambda: "ok", affinity="main"))
+        )
+        ok_thread.start()
+        _wait_until(lambda: dispatcher.queue_size() == 1)
+        ui.callbacks[0]()
+        ok_thread.join(timeout=1)
+        host.stop()
+
+    assert cancelled[0]["error"] == "Cancelled"
+    assert failed[0]["error"] == "task failed"
+    assert recovered[0]["output"] == "ok"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -105,28 +105,28 @@ def test_assemble_houdini_package_can_pin_validated_core(
     dist_dir.mkdir()
     adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
     adapter_wheel.write_bytes(b"adapter")
-    core_wheel = tmp_path / "dcc_mcp_core-0.19.17-cp38-abi3-win_amd64.whl"
+    core_wheel = tmp_path / "dcc_mcp_core-0.19.42-cp38-abi3-win_amd64.whl"
     core_wheel.write_bytes(b"core")
 
     def fail_resolve(min_version=pkg.MIN_CORE_VERSION):
         raise AssertionError("explicit core version should skip PyPI latest resolution")
 
     def download_core_wheels(version_arg, platform, dest_dir):
-        assert version_arg == "0.19.17"
+        assert version_arg == "0.19.42"
         assert platform == "win64"
         return [core_wheel]
 
     monkeypatch.setattr(pkg, "resolve_core_version", fail_resolve)
     monkeypatch.setattr(pkg, "download_core_wheels", download_core_wheels)
 
-    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.17")
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.42")
 
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
         readme = zf.read("dcc_mcp_houdini/README.txt").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
-    assert "dcc-mcp-core wheels: 0.19.17" in readme
-    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.17." in readme
+    assert "dcc-mcp-core wheels: 0.19.42" in readme
+    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.42." in readme
 
 
 def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
@@ -136,11 +136,11 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.7-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.33-cp38-abi3-win_amd64.whl",
     )
 
     with pytest.raises(RuntimeError, match="Bundled core drift"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.42")
 
 
 def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
@@ -150,12 +150,12 @@ def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> Non
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.15-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.42-cp38-abi3-win_amd64.whl",
         include_scene_hook=False,
     )
 
     with pytest.raises(RuntimeError, match="/scripts/456.py"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.42")
 
 
 def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
@@ -165,13 +165,13 @@ def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.15-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.42-cp38-abi3-win_amd64.whl",
     )
 
-    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.15")
+    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.42")
 
     assert matrix["adapter"] == pkg.get_package_version()
-    assert matrix["core"] == "0.19.15"
+    assert matrix["core"] == "0.19.42"
     assert matrix["server"] == pkg.get_package_version()
     assert matrix["cli"] == pkg.get_package_version()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,18 +57,29 @@ def test_houdini_server_options_port() -> None:
     assert bridge.host_dispatcher is dispatcher.host_dispatcher
 
 
+def test_houdini_ui_dispatcher_bridge_attaches_http_queue() -> None:
+    from dcc_mcp_houdini.host import HoudiniUiDispatcher
+    from dcc_mcp_houdini.server import HoudiniServerOptions
+
+    dispatcher = HoudiniUiDispatcher()
+    bridge = HoudiniServerOptions(dispatcher=dispatcher).to_core_options().execution.mode.bridge
+    host_dispatcher = bridge.resolve_host_dispatcher()
+
+    assert bridge.dispatcher is dispatcher
+    assert host_dispatcher is not None
+    handle = host_dispatcher.post(lambda: "http-main")
+    assert dispatcher.pending_count() == 1
+    assert dispatcher.drain_queue(8) == (1, 0)
+    assert handle.wait(0) == "http-main"
+
+
 def test_create_execution_stack_without_hou() -> None:
     from dcc_mcp_houdini.dispatcher import create_execution_stack
-    from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
+    from dcc_mcp_houdini.dispatcher.standalone import HoudiniStandaloneDispatcher
 
     dispatcher, host = create_execution_stack()
-    try:
-        assert isinstance(dispatcher, HoudiniCallableDispatcher)
-        assert isinstance(host, HoudiniHost)
-        assert host.is_running
-        assert dispatcher.host_dispatcher is not None
-    finally:
-        host.stop()
+    assert isinstance(dispatcher, HoudiniStandaloneDispatcher)
+    assert host is None
 
 
 def test_wait_until_ready_uses_urllib(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- route interactive Houdini through the shared HostUiDispatcherBase and HostPumpController lifecycle
- keep exactly one throttled hou.ui event-loop callback with an 8 ms queue-drain budget and shared overrun statistics
- preserve the existing headless HoudiniHost bootstrap contract and use the standalone dispatcher outside the UI
- raise the dcc-mcp-core runtime floor to 0.19.33 so HTTP main-affinity work joins the same host pump

## Important boundary

The budget limits queue draining between jobs. It cannot preempt a single hou/HOM call that is already running; long operations must continue to use the existing deferred/background job contracts.

## Validation

- 486 passed, 1 skipped, 2 deselected
- released dcc-mcp-core 0.19.42 integration smoke
- Ruff lint and format checks
- Python 3.7 syntax check
- 31 bundled skills validated with 0 errors and 0 warnings
- wheel and sdist build plus Twine validation