### PR TITLE
fix: use OS-assigned MCP instance ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 ```python
 import dcc_mcp_houdini
 server = dcc_mcp_houdini.start_server()
-# MCP URL: http://127.0.0.1:8765/mcp
+print(server.mcp_url)  # OS-assigned instance endpoint
 ```
 
 ## Skills-First Workflow
@@ -105,7 +105,7 @@ When adding or changing bundled skills, load the project skill:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `DCC_MCP_HOUDINI_PORT` | `8765` | MCP HTTP port |
+| `DCC_MCP_HOUDINI_PORT` | `0` | MCP instance port (`0` lets the OS choose) |
 | `DCC_MCP_GATEWAY_PORT` | `9765` | Gateway election |
 | `DCC_MCP_MINIMAL` | `1` | Progressive loading |
 | `DCC_MCP_HOUDINI_AUTOSTART` | `1` | Auto-start via `123.py` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Add to `claude_desktop_config.json`:
 {
   "mcpServers": {
     "houdini": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,7 +16,7 @@
 If your Gemini client supports MCP over HTTP, configure:
 
 ```
-Endpoint: http://127.0.0.1:8765/mcp
+Gateway endpoint: http://127.0.0.1:9765/mcp
 Protocol: MCP Streamable HTTP (2025-03-26 spec)
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ skill and is CC0-1.0.
 
 ## Features
 
-- Embedded MCP Streamable HTTP server inside Houdini (port 8765)
+- Embedded MCP Streamable HTTP server inside Houdini (OS-assigned instance port)
 - Auto-gateway with first-wins election (gateway port 9765)
 - Progressive skill loading (discover → load → unload)
 - Houdini Python (`hython`) and interactive UI-thread dispatch
@@ -98,7 +98,7 @@ as process ownership evidence.
 import dcc_mcp_houdini
 
 server = dcc_mcp_houdini.start_server()
-print(server.mcp_url)  # http://127.0.0.1:8765/mcp
+print(server.mcp_url)  # Exact direct endpoint selected by the OS
 ```
 
 Default minimal mode (`DCC_MCP_MINIMAL=1`) loads only:
@@ -230,8 +230,8 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.19.33`
-- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.33,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
+- `dcc-mcp-core >= 0.19.45`
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.45,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/docs/guide/local-mcp-debug.md
+++ b/docs/guide/local-mcp-debug.md
@@ -26,10 +26,12 @@ In the **Python Source Editor** (or a shelf tool):
 import dcc_mcp_houdini
 
 server = dcc_mcp_houdini.start_server()
-print(server.mcp_url)  # http://127.0.0.1:8765/mcp
+print(server.mcp_url)  # Exact direct endpoint selected by the OS
 ```
 
-The first Houdini instance to bind port **8765** becomes the **gateway** when auto-gateway is enabled (default). Additional instances register on ephemeral ports.
+Every Houdini instance binds an OS-assigned port and registers its exact URL.
+The gateway remains on stable port **9765**, so agents and the CLI can discover
+multiple simultaneous Houdini instances without hard-coded instance ports.
 
 For auto-start on every session, copy [`examples/houdini_123.py`](../../examples/houdini_123.py) into your Houdini scripts path (see file header).
 
@@ -44,7 +46,7 @@ Copy from [`examples/mcp/cursor-houdini-streamable-http.json`](../../examples/mc
 {
   "mcpServers": {
     "houdini-local": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }

--- a/examples/houdini_bootstrap.py
+++ b/examples/houdini_bootstrap.py
@@ -6,13 +6,15 @@ Run with:
 
 from __future__ import annotations
 
+from typing import Optional
+
 from dcc_mcp_core.host import BlockingDispatcher
 
 from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
 from dcc_mcp_houdini.server import HoudiniMcpServer
 
 
-def main(port: int = 18765) -> None:
+def main(port: Optional[int] = None) -> None:
     """Start the MCP server and block while the headless host pumps jobs."""
     blocking = BlockingDispatcher()
     dispatcher = HoudiniCallableDispatcher(blocking)

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -4,8 +4,8 @@
 
 | File | URL | When to use |
 |------|-----|-------------|
-| `cursor-houdini-streamable-http.json` | `http://127.0.0.1:8765/mcp` | Direct connection to the first Houdini MCP server |
+| `cursor-houdini-streamable-http.json` | `http://127.0.0.1:9765/mcp` | Stable gateway that discovers all Houdini instances |
 
-If you run a standalone gateway on port **9765**, change the URL to `http://127.0.0.1:9765/mcp`.
+Set `DCC_MCP_HOUDINI_PORT` only when a fixed direct instance URL is required.
 
 See [`docs/guide/local-mcp-debug.md`](../../docs/guide/local-mcp-debug.md) for the full dev-link + debugpy workflow.

--- a/examples/mcp/cursor-houdini-streamable-http.json
+++ b/examples/mcp/cursor-houdini-streamable-http.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "houdini-local": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }

--- a/examples/start_server.py
+++ b/examples/start_server.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 import dcc_mcp_houdini
 
 print("Starting dcc-mcp-houdini server...")
-server = dcc_mcp_houdini.start_server(port=8765)
+server = dcc_mcp_houdini.start_server()
 
-print(f"Server started on port {server.port}")
 print(f"MCP endpoint: {server.mcp_url}")
 print(f"Loaded skills: {server.loaded_skill_count()}")
 

--- a/install.md
+++ b/install.md
@@ -50,13 +50,12 @@ The recommended path is the bundled Houdini package:
 2. The package adds `scripts/` to `HOUDINI_PATH`; on startup `123.py` extracts
    bundled wheels into `vendor/` and starts the MCP server unless
    `DCC_MCP_HOUDINI_AUTOSTART=0`.
-3. Start Houdini and watch the console for:
-   `dcc-mcp-houdini MCP server started: http://127.0.0.1:8765/mcp`.
+3. Start Houdini and watch the console for the exact OS-assigned instance URL.
 
-Autostart mode exposes MCP at:
+Agents should connect through the stable local gateway:
 
 ```text
-http://127.0.0.1:8765/mcp
+http://127.0.0.1:9765/mcp
 ```
 
 Multi-instance auto-gateway mode (`DCC_MCP_GATEWAY_PORT=9765`) uses:
@@ -70,7 +69,7 @@ You can also start the server manually from an `hython` session:
 ```python
 import dcc_mcp_houdini
 server = dcc_mcp_houdini.start_server()
-print(server.mcp_url)  # http://127.0.0.1:8765/mcp
+print(server.mcp_url)  # Exact direct endpoint selected by the OS
 ```
 
 ## MCP Config
@@ -81,7 +80,7 @@ Use this JSON for Cursor, Claude Desktop, or any MCP Streamable HTTP host:
 {
   "mcpServers": {
     "houdini": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -4,16 +4,19 @@
 
 ```python
 import dcc_mcp_houdini
-server = dcc_mcp_houdini.start_server(port=8765)
-server.mcp_url  # http://127.0.0.1:8765/mcp
+server = dcc_mcp_houdini.start_server()
+server.mcp_url  # exact OS-assigned instance URL
 dcc_mcp_houdini.stop_server()
 ```
 
 ## MCP host config
 
 ```json
-{"mcpServers": {"houdini": {"url": "http://127.0.0.1:8765/mcp"}}}
+{"mcpServers": {"houdini": {"url": "http://127.0.0.1:9765/mcp"}}}
 ```
+
+The gateway is stable; use `dcc-mcp-cli list` to inspect the transient direct
+URL for every registered Houdini instance.
 
 ## Progressive loading
 

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -35,7 +35,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.19.33"
+MIN_CORE_VERSION = "0.19.45"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 
@@ -256,12 +256,10 @@ def bootstrap_and_start() -> object:
 
     import dcc_mcp_houdini
 
-    port = int(os.environ.get("DCC_MCP_HOUDINI_PORT", "8765"))
     gateway_raw = os.environ.get("DCC_MCP_GATEWAY_PORT")
     gateway_port = int(gateway_raw) if gateway_raw and gateway_raw.isdigit() else None
     registry_dir = os.environ.get("DCC_MCP_REGISTRY_DIR") or None
     return dcc_mcp_houdini.start_server(
-        port=port,
         gateway_port=gateway_port,
         registry_dir=registry_dir,
         wait_ready=False,
@@ -408,7 +406,7 @@ $target = Join-Path $packagesDir "dcc_mcp_houdini.json"
 
 Write-Host "Installed Houdini package: $target"
 Write-Host "Package root: $resolvedRoot"
-Write-Host "Start Houdini $HoudiniVersion; MCP defaults to http://127.0.0.1:8765/mcp"
+Write-Host "Start Houdini $HoudiniVersion; connect through the gateway at http://127.0.0.1:9765/mcp"
 """
 
 
@@ -429,7 +427,7 @@ sed "s#__PACKAGE_ROOT__#$ROOT_ESCAPED#g" \
 
 echo "Installed Houdini package: $PACKAGES_DIR/dcc_mcp_houdini.json"
 echo "Package root: $ROOT_ESCAPED"
-echo "Start Houdini $HOUDINI_VERSION; MCP defaults to http://127.0.0.1:8765/mcp"
+echo "Start Houdini $HOUDINI_VERSION; connect through the gateway at http://127.0.0.1:9765/mcp"
 """
 
 
@@ -463,7 +461,8 @@ The DCC-MCP shelf is loaded from toolbar/DCC-MCP.shelf.
 Disable autostart by setting DCC_MCP_HOUDINI_AUTOSTART=0.
 Background render children set DCC_MCP_BACKGROUND_RENDER=1; startup hooks must
 not start another MCP adapter when this child-only marker is present.
-MCP URL defaults to http://127.0.0.1:8765/mcp.
+Instance ports are assigned by the operating system. Connect through the stable
+gateway at http://127.0.0.1:9765/mcp or discover exact URLs with dcc-mcp-cli.
 """.format(version=version, core_version=core_version, platform=platform, core_policy=core_policy)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.19.33: HostExecutionBridge routes HostUiDispatcherBase to HTTP calls.
-    "dcc-mcp-core>=0.19.33,<1.0.0",
+    # 0.19.45: instance ports default to operating-system assignment.
+    "dcc-mcp-core>=0.19.45,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/skills/dcc-mcp-houdini-setup/SKILL.md
+++ b/skills/dcc-mcp-houdini-setup/SKILL.md
@@ -83,7 +83,7 @@ port by default. Configure the MCP host with:
 {
   "mcpServers": {
     "houdini": {
-      "url": "http://127.0.0.1:8765/mcp"
+      "url": "http://127.0.0.1:9765/mcp"
     }
   }
 }
@@ -104,15 +104,15 @@ with Houdini. The recommended path is the bundled Houdini package:
    or a `dcc_mcp_houdini.json` package file pointing at the package root).
 2. The package adds `scripts/` to `HOUDINI_PATH`; on startup `123.py` extracts
    bundled wheels into `vendor/` and starts the MCP server.
-3. Start Houdini and watch the console / shell for:
-   `dcc-mcp-houdini MCP server started: http://127.0.0.1:8765/mcp`.
+3. Start Houdini and watch the console / shell for the exact OS-assigned
+   instance URL. Agents normally connect through the stable gateway on `9765`.
 
 To run from a manual `hython` session instead of the package autostart:
 
 ```python
 import dcc_mcp_houdini
 server = dcc_mcp_houdini.start_server()
-print(server.mcp_url)  # http://127.0.0.1:8765/mcp
+print(server.mcp_url)  # Exact direct endpoint selected by the OS
 ```
 
 Set `DCC_MCP_HOUDINI_AUTOSTART=0` to disable package autostart.
@@ -144,8 +144,8 @@ Expected behavior:
   `bin/hython` path, then pass `--hython`.
 - Pip bootstrap fails: run `hython -m ensurepip --upgrade`, then repeat install.
 - MCP connection refused: Houdini is not running, autostart is disabled
-  (`DCC_MCP_HOUDINI_AUTOSTART=0`), or the host points at `9765` while the
-  session is on the direct `8765` port.
+  (`DCC_MCP_HOUDINI_AUTOSTART=0`), or the stable gateway on `9765` is not
+  running. Use `dcc-mcp-cli list` to inspect direct URLs.
 - Tool missing: call `dcc_capability_manifest` or `search_skills`, then
   `load_skill("<skill-name>")`.
 - Autostart silent: check the Houdini console for a

--- a/skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py
+++ b/skills/dcc-mcp-houdini-setup/scripts/setup_dcc_mcp_houdini.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-DEFAULT_DIRECT_URL = "http://127.0.0.1:8765/mcp"
 DEFAULT_GATEWAY_URL = "http://127.0.0.1:9765/mcp"
 
 
@@ -192,8 +191,8 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--mcp-url",
-        default=DEFAULT_DIRECT_URL,
-        help="MCP URL to write into generated host config. Default: direct autostart URL.",
+        default=DEFAULT_GATEWAY_URL,
+        help="MCP URL to write into generated host config. Default: stable local gateway.",
     )
     parser.add_argument(
         "--server-name",

--- a/src/dcc_mcp_houdini/_readiness.py
+++ b/src/dcc_mcp_houdini/_readiness.py
@@ -151,12 +151,20 @@ def wait_until_ready(server: Any, timeout: int = 30) -> bool:
     """Block until ``/v1/readyz`` returns 200 (or ``/health`` as fallback)."""
     import time
     import urllib.error
+    import urllib.parse
     import urllib.request
 
-    port = getattr(server, "port", None)
-    if port is None and hasattr(server, "_options"):
-        port = getattr(server._options, "port", 8765)
-    port = int(port or 8765)
+    mcp_url = getattr(server, "mcp_url", None)
+    try:
+        port = urllib.parse.urlsplit(mcp_url).port if isinstance(mcp_url, str) else None
+    except ValueError:
+        port = None
+    if port is None:
+        port = getattr(getattr(server, "_handle", None), "port", None)
+    if port is None or int(port) <= 0:
+        logger.warning("Houdini MCP readiness skipped: server has no bound instance port")
+        return False
+    port = int(port)
 
     urls = (
         f"http://127.0.0.1:{port}/v1/readyz",

--- a/src/dcc_mcp_houdini/cli.py
+++ b/src/dcc_mcp_houdini/cli.py
@@ -13,7 +13,7 @@ from dcc_mcp_houdini import start_server, stop_server
 def main(argv: Optional[list[str]] = None) -> int:
     """Run the Houdini MCP server."""
     parser = argparse.ArgumentParser(description="Houdini MCP Server")
-    parser.add_argument("--port", type=int, default=8765, help="Port to listen on")
+    parser.add_argument("--port", type=int, default=None, help="Instance port (default: operating-system assigned)")
     parser.add_argument("--gateway-port", type=int, default=None, help="Gateway port")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)

--- a/src/dcc_mcp_houdini/server.py
+++ b/src/dcc_mcp_houdini/server.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 SERVER_NAME = "dcc-mcp-houdini"
 SERVER_VERSION = __version__
-DEFAULT_PORT = 8765
+DEFAULT_PORT = 0
 
 _BUILTIN_SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 _DCC_NAME = "houdini"
@@ -52,7 +52,7 @@ def _host_dispatcher_from(dispatcher: Any) -> Any:
 class HoudiniServerOptions:
     """Adapter-local options collapsed for the dcc-mcp-core 0.17+ server contract."""
 
-    port: int = DEFAULT_PORT
+    port: Optional[int] = None
     extra_skill_paths: Optional[List[str]] = None
     server_name: str = SERVER_NAME
     server_version: str = SERVER_VERSION
@@ -121,7 +121,7 @@ class HoudiniMcpServer(DccServerBase):
 
     def __init__(
         self,
-        port: int = DEFAULT_PORT,
+        port: Optional[int] = None,
         extra_skill_paths: Optional[List[str]] = None,
         server_name: str = SERVER_NAME,
         server_version: str = SERVER_VERSION,
@@ -585,7 +585,7 @@ _host_instance: Any = None
 
 
 def start_server(
-    port: int = DEFAULT_PORT,
+    port: Optional[int] = None,
     extra_skill_paths: Optional[List[str]] = None,
     register_builtins: bool = True,
     include_bundled: bool = True,

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   channels and expressions; export/import channel JSON; bake channels and
   trigger bounded simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   export. Create and manage CHOP networks, motion clips, audio-driven
   channels, and filter effects.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   constraints using OBJ-level blend nodes and CHOP-driven channel
   referencing. List and delete existing constraints.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   with typed parameters. Use when loading .hda/.otl assets or executing an HDA
   node as part of automation. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checkpoint/resume, scene snapshots, and husk option configuration. Pair with
   houdini-karma for renderer setup and houdini-render for viewport/ROP renders.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   ImportToSceneResult. Use as the receiving end of the asset import pipeline
   after an asset-source skill resolves the descriptor.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   light mixer, and image output through typed tools. Pair with houdini-render
   for full render execution and houdini-camera-light for scene setup.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   configure rig skeletons, set rig poses, capture joint skinning weights,
   and apply motion capture data via SOP-level KineFX nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   houdini-materials (create/assign) and houdini-lookdev (shader-network
   editing, adapter-owned presets).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   nodes through typed HOM operations. Use when building lookdev/material
   workflows. Not for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   written_files, elapsed time, and warnings without hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   to low-res target. Pair with houdini-render for render output and
   houdini-materials for shader assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Stage. Use it to list prims, inspect one prim, or read bounded attribute
   values. Not for USD authoring, import, or export.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.33+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -26,7 +26,7 @@ def test_server_options() -> None:
     from dcc_mcp_houdini.server import HoudiniServerOptions
 
     opts = HoudiniServerOptions()
-    assert opts.port == 8765
+    assert opts.port is None
     assert opts.server_name == "dcc-mcp-houdini"
     assert opts.gateway_port is None
 
@@ -40,6 +40,15 @@ def test_server_options_to_core() -> None:
 
     assert core_opts is not None
     assert core_opts.port == 9000
+
+
+def test_server_options_preserve_explicit_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit dynamic-port request must not be replaced by the environment."""
+    monkeypatch.setenv("DCC_MCP_HOUDINI_PORT", "18765")
+
+    from dcc_mcp_houdini.server import HoudiniServerOptions
+
+    assert HoudiniServerOptions(port=0).to_core_options().port == 0
 
 
 def test_file_registry_registration_survives_disabled_failover(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -105,28 +105,28 @@ def test_assemble_houdini_package_can_pin_validated_core(
     dist_dir.mkdir()
     adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
     adapter_wheel.write_bytes(b"adapter")
-    core_wheel = tmp_path / "dcc_mcp_core-0.19.42-cp38-abi3-win_amd64.whl"
+    core_wheel = tmp_path / "dcc_mcp_core-0.19.45-cp38-abi3-win_amd64.whl"
     core_wheel.write_bytes(b"core")
 
     def fail_resolve(min_version=pkg.MIN_CORE_VERSION):
         raise AssertionError("explicit core version should skip PyPI latest resolution")
 
     def download_core_wheels(version_arg, platform, dest_dir):
-        assert version_arg == "0.19.42"
+        assert version_arg == "0.19.45"
         assert platform == "win64"
         return [core_wheel]
 
     monkeypatch.setattr(pkg, "resolve_core_version", fail_resolve)
     monkeypatch.setattr(pkg, "download_core_wheels", download_core_wheels)
 
-    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.42")
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.45")
 
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
         readme = zf.read("dcc_mcp_houdini/README.txt").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
-    assert "dcc-mcp-core wheels: 0.19.42" in readme
-    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.42." in readme
+    assert "dcc-mcp-core wheels: 0.19.45" in readme
+    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.45." in readme
 
 
 def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
@@ -140,7 +140,7 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
     )
 
     with pytest.raises(RuntimeError, match="Bundled core drift"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.42")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.45")
 
 
 def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
@@ -150,12 +150,12 @@ def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> Non
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.42-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.45-cp38-abi3-win_amd64.whl",
         include_scene_hook=False,
     )
 
     with pytest.raises(RuntimeError, match="/scripts/456.py"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.42")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.45")
 
 
 def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
@@ -165,13 +165,13 @@ def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.42-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.45-cp38-abi3-win_amd64.whl",
     )
 
-    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.42")
+    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.45")
 
     assert matrix["adapter"] == pkg.get_package_version()
-    assert matrix["core"] == "0.19.42"
+    assert matrix["core"] == "0.19.45"
     assert matrix["server"] == pkg.get_package_version()
     assert matrix["cli"] == pkg.get_package_version()
 
@@ -285,7 +285,7 @@ assert spec and spec.loader
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 server = module.bootstrap_and_start()
-assert server["port"] == 8765
+assert "port" not in server
 """
     result = subprocess.run(
         [sys.executable, "-I", "-S", "-c", code, str(root)],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,11 +94,18 @@ def test_wait_until_ready_uses_urllib(monkeypatch: pytest.MonkeyPatch) -> None:
         def __exit__(self, *args):
             return False
 
-    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: FakeResp())
+    requested_urls = []
+
+    def fake_urlopen(url, **kwargs):
+        requested_urls.append(url)
+        return FakeResp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     server = MagicMock()
-    server.port = 8765
+    server.mcp_url = "http://127.0.0.1:54321/mcp"
     assert wait_until_ready(server, timeout=1) is True
+    assert requested_urls == ["http://127.0.0.1:54321/v1/readyz"]
 
 
 def test_api_helpers() -> None:


### PR DESCRIPTION
## Summary
- delegate the default MCP instance listener to the OS with port 0
- preserve explicit fixed-port arguments and DCC-specific environment overrides
- keep the stable gateway control-plane port unchanged
- require dcc-mcp-core 0.19.45 for the shared dynamic-port contract

## Validation
- 487 tests passed, 1 skipped, 2 deselected; quick-install, Ruff, and package build passed
- fresh no-cache PyPI install verified dcc-mcp-core 0.19.45 and dcc-mcp-server 0.19.45
- two same-type instances received distinct ports and were discoverable by both the local CLI and gateway