### PR TITLE
fix: honor Houdini flipbook increments and camera selection

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -24,6 +24,8 @@ Typed camera and light authoring for agents. All tools are `affinity: main`.
 View tools (`frame_view`, `get_view_state`) are UI-aware: in a headless
 `hython` session they return a structured `warnings` payload with
 `framed: false` / `ui_available: false` instead of failing.
+When both a node and camera are supplied, `frame_view` frames the node first
+and activates the camera last so the returned `active_camera` is authoritative.
 
 ## Tool groups
 

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
@@ -48,12 +48,6 @@ def frame_view(
                 warnings=["No Scene Viewer pane is open"],
             )
         viewport = viewer.curViewport()
-        if camera_path:
-            cam = get_node(hou, camera_path)
-            try:
-                viewport.setCamera(cam)
-            except Exception as cam_exc:  # noqa: BLE001
-                warnings.append("Could not set camera: {}".format(cam_exc))
         framed = False
         if node_path:
             node = get_node(hou, node_path)
@@ -63,16 +57,36 @@ def frame_view(
                 framed = True
             except Exception as frame_exc:  # noqa: BLE001
                 warnings.append("Could not frame node: {}".format(frame_exc))
-        else:
+        elif not camera_path:
             try:
                 viewport.frameAll()
                 framed = True
             except Exception as frame_exc:  # noqa: BLE001
                 warnings.append("Could not frame view: {}".format(frame_exc))
+
+        # Apply the camera last. Framing operations change the viewport view and
+        # can disconnect a camera that was selected first.
+        active_camera = None
+        if camera_path:
+            cam = get_node(hou, camera_path)
+            try:
+                viewport.setCamera(cam)
+                active = viewport.camera()
+                active_camera = active.path() if active is not None else None
+                framed = framed or active_camera == camera_path
+                if active_camera != camera_path:
+                    warnings.append("Viewport did not activate camera: {}".format(camera_path))
+                try:
+                    viewport.draw()
+                except Exception:  # noqa: BLE001
+                    pass
+            except Exception as cam_exc:  # noqa: BLE001
+                warnings.append("Could not set camera: {}".format(cam_exc))
         return skill_success(
             "Framed view",
             framed=framed,
             camera_path=camera_path,
+            active_camera=active_camera,
             node_path=node_path,
             warnings=warnings,
         )

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/tools.yaml
@@ -94,8 +94,9 @@ tools:
           type: number
   - name: frame_view
     description: >-
-      Look through a camera and/or frame a node in the Scene Viewer. UI-aware:
-      returns framed=false with a warning when headless.
+      Frame a node and/or activate a camera in the Scene Viewer, applying the
+      camera last and reporting active_camera. UI-aware: returns framed=false
+      with a warning when headless.
     source_file: scripts/frame_view.py
     execution: sync
     affinity: main

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -29,8 +29,9 @@ agent can detect and skip cleanly when rendering is unavailable.
 
 ## Tool groups
 
-- **`viewport`:** `capture_viewport` (single frame), `flipbook` (range). Both
-  clamp resolution to 4096 and return `written_files` / `skipped` / `warnings`.
+- **`viewport`:** `capture_viewport` (single frame), `flipbook` (range with an
+  optional positive increment and explicit camera). Both clamp resolution to
+  4096 and return `written_files` / `skipped` / `warnings`.
 - **`render`:** `get_render_settings` (read-only), `set_render_settings`
   (reports `unsupported` fields per ROP type), `render_rop` (foreground or
   isolated `hython` background job), `get_render_job` (polls and reconciles
@@ -48,7 +49,8 @@ agent can detect and skip cleanly when rendering is unavailable.
 2. `set_render_settings(rop_path="/out/mantra1", camera="/obj/rendercam", resolution=[1280,720], output_path="/tmp/beauty.exr")`
 3. `get_render_settings("/out/mantra1")` → verify
 4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only)
-5. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive Houdini; foreground results in headless Houdini
+5. `flipbook(output_path="/tmp/preview.$F4.jpg", frame_range=[1,24,4], camera_path="/obj/rendercam")` for a sparse camera preview (UI only)
+6. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive Houdini; foreground results in headless Houdini
 
 ### Render Layers & AOVs
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
@@ -31,6 +31,7 @@ def flipbook(
     output_path: str,
     frame_range: List[float],
     resolution: Optional[List[int]] = None,
+    camera_path: Optional[str] = None,
 ) -> dict:
     """Flipbook the current viewport across *frame_range* to *output_path*.
 
@@ -43,7 +44,14 @@ def flipbook(
         return skill_error("Houdini not available", "hou could not be imported")
 
     if not frame_range or len(frame_range) < 2:
-        return skill_error("Invalid frame range", "frame_range must be [start, end]")
+        return skill_error("Invalid frame range", "frame_range must be [start, end, optional increment]")
+
+    start, end = float(frame_range[0]), float(frame_range[1])
+    increment = float(frame_range[2]) if len(frame_range) >= 3 else 1.0
+    if increment <= 0:
+        return skill_error("Invalid frame increment", "frame_range increment must be greater than zero")
+    if end < start:
+        return skill_error("Invalid frame range", "frame_range end must be greater than or equal to start")
 
     try:
         clamped = clamp_resolution(resolution)
@@ -66,13 +74,22 @@ def flipbook(
                 skipped=[output_path],
                 warnings=["No Scene Viewer pane is open"],
             )
-        start, end = float(frame_range[0]), float(frame_range[1])
         parent = os.path.dirname(os.path.abspath(output_path))
         if parent and not os.path.isdir(parent):
             os.makedirs(parent, exist_ok=True)
         warnings: List[str] = []
+        viewport = viewer.curViewport()
+        if camera_path:
+            camera = hou.node(camera_path)
+            if camera is None:
+                return skill_error("Camera not found", "No Houdini node exists at {}".format(camera_path))
+            viewport.setCamera(camera)
+            active = viewport.camera()
+            if active is None or active.path() != camera_path:
+                return skill_error("Camera activation failed", "Viewport did not activate {}".format(camera_path))
         settings = viewer.flipbookSettings().stash()
         settings.frameRange((start, end))
+        settings.frameIncrement(increment)
         settings.output(output_path)
         try:
             settings.outputToMPlay(False)
@@ -84,13 +101,17 @@ def flipbook(
                 settings.resolution(tuple(clamped))
             except Exception as res_exc:  # noqa: BLE001
                 warnings.append("Could not set resolution: {}".format(res_exc))
-        viewer.flipbook(viewer.curViewport(), settings)
+        viewer.flipbook(viewport, settings)
         written = _glob_outputs(output_path)
+        normalized_range = [start, end]
+        if len(frame_range) >= 3:
+            normalized_range.append(increment)
         return skill_success(
             "Flipbook complete",
             captured=bool(written),
             output_path=output_path,
-            frame_range=[start, end],
+            frame_range=normalized_range,
+            camera_path=camera_path,
             resolution=clamped,
             written_files=written,
             skipped=[] if written else [output_path],

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -32,7 +32,8 @@ tools:
   - name: flipbook
     description: >-
       Flipbook the current viewport across a frame range to image files (use a
-      $F token in output_path). UI-aware.
+      $F token in output_path). Supports an optional frame increment and an
+      explicit camera. UI-aware.
     source_file: scripts/flipbook.py
     execution: async
     affinity: main
@@ -57,11 +58,15 @@ tools:
           items: {type: number}
           minItems: 2
           maxItems: 3
+          description: "[start, end, optional positive increment]."
         resolution:
           type: array
           items: {type: integer}
           minItems: 2
           maxItems: 2
+        camera_path:
+          type: string
+          description: "Optional camera node to activate before capture."
   - name: get_render_settings
     description: >-
       Read renderer, camera, resolution, frame range, output path, and image

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -199,6 +199,27 @@ class TestViewSkills:
         assert result["success"] is True
         assert result["context"]["ui_available"] is False
 
+    def test_frame_view_camera_only_preserves_camera_view(self) -> None:
+        mod = _load_script("houdini-camera-light", "frame_view.py")
+        cam = _node("/obj/shotcam", "shotcam", "cam")
+        viewport = MagicMock()
+        viewport.camera.return_value = cam
+        viewer = MagicMock()
+        viewer.curViewport.return_value = viewport
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+        mock_hou.node.return_value = cam
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.frame_view(camera_path="/obj/shotcam")
+
+        assert result["success"] is True
+        assert result["context"]["framed"] is True
+        assert result["context"]["active_camera"] == "/obj/shotcam"
+        viewport.setCamera.assert_called_once_with(cam)
+        viewport.frameAll.assert_not_called()
+
 
 class TestViewportCapture:
     def test_capture_viewport_headless_skips(self, tmp_path: Path) -> None:
@@ -232,6 +253,51 @@ class TestViewportCapture:
         assert result["context"]["written_files"] == [str(out)]
         # resolution clamped to MAX_DIMENSION
         assert result["context"]["resolution"] == [4096, 720]
+
+    def test_flipbook_applies_increment_and_camera(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "flipbook.py")
+        out = tmp_path / "frame.$F4.jpg"
+        written = tmp_path / "frame.0001.jpg"
+        settings = MagicMock()
+        cam = _node("/obj/shotcam", "shotcam", "cam")
+        viewport = MagicMock()
+        viewport.camera.return_value = cam
+        viewer = MagicMock()
+        viewer.curViewport.return_value = viewport
+        viewer.flipbookSettings.return_value.stash.return_value = settings
+        viewer.flipbook.side_effect = lambda vp, s: written.write_bytes(b"img")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+        mock_hou.node.return_value = cam
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.flipbook(
+                str(out),
+                frame_range=[1, 10, 3],
+                camera_path="/obj/shotcam",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["frame_range"] == [1.0, 10.0, 3.0]
+        assert result["context"]["camera_path"] == "/obj/shotcam"
+        settings.frameRange.assert_called_once_with((1.0, 10.0))
+        settings.frameIncrement.assert_called_once_with(3.0)
+        viewport.setCamera.assert_called_once_with(cam)
+        viewer.flipbook.assert_called_once_with(viewport, settings)
+
+    def test_flipbook_rejects_non_positive_increment(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "flipbook.py")
+        mock_hou = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.flipbook(
+                str(tmp_path / "frame.$F4.jpg"),
+                frame_range=[1, 10, 0],
+            )
+
+        assert result["success"] is False
+        assert "increment" in result["error"].lower()
 
 
 class TestRenderSettings:

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -220,6 +220,30 @@ class TestViewSkills:
         viewport.setCamera.assert_called_once_with(cam)
         viewport.frameAll.assert_not_called()
 
+    def test_frame_view_frames_node_before_activating_camera(self) -> None:
+        mod = _load_script("houdini-camera-light", "frame_view.py")
+        events = []
+        geo = _node("/obj/geo1", "geo1")
+        cam = _node("/obj/shotcam", "shotcam", "cam")
+        geo.setSelected.side_effect = lambda *args, **kwargs: events.append("select")
+        viewport = MagicMock()
+        viewport.frameSelected.side_effect = lambda: events.append("frame")
+        viewport.setCamera.side_effect = lambda camera: events.append("camera")
+        viewport.camera.return_value = cam
+        viewer = MagicMock()
+        viewer.curViewport.return_value = viewport
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+        mock_hou.node.side_effect = lambda path: {"/obj/geo1": geo, "/obj/shotcam": cam}[path]
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.frame_view(node_path="/obj/geo1", camera_path="/obj/shotcam")
+
+        assert result["success"] is True
+        assert result["context"]["active_camera"] == "/obj/shotcam"
+        assert events == ["select", "frame", "camera"]
+
 
 class TestViewportCapture:
     def test_capture_viewport_headless_skips(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- apply the optional third `frame_range` value through Houdini's `hou.FlipbookSettings.frameIncrement`
- allow `flipbook` to activate and verify an explicit camera before capture
- frame nodes before activating the requested camera, avoid `frameAll` for camera-only calls, and report the authoritative `active_camera`
- document the sparse camera-preview contract

## Regression
A viewport preview accepted `[start, end, increment]` but ignored the increment and rendered every frame. A camera-only `frame_view` call also ran `frameAll` after `setCamera`, so the subsequent preview could use the free perspective view despite a successful result.

## Validation
- `135 passed` across skill lint, script behavior, and discovery/load tests
- `491 passed, 1 skipped, 2 deselected` in a fresh no-cache Windows Python 3.12 environment against released core 0.19.45
- Ruff clean for both changed skills and their tests
- `git diff --check` clean

The implementation follows the public SideFX HOM contracts for [`frameIncrement`](https://www.sidefx.com/docs/houdini/hom/hou/FlipbookSettings.html) and [`setCamera`](https://www.sidefx.com/docs/houdini/hom/hou/GeometryViewport.html).