### PR TITLE
fix(packaging): preserve explicit Houdini autostart setting

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -189,7 +189,6 @@ def _package_json_template() -> str:
     payload = {
         "env": [
             {"DCC_MCP_HOUDINI_ROOT": "__PACKAGE_ROOT__"},
-            {"DCC_MCP_HOUDINI_AUTOSTART": "1"},
             {"PYTHONPATH": "__PACKAGE_ROOT__/vendor;&"},
             {"HOUDINI_PATH": "__PACKAGE_ROOT__;&"},
         ]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -94,6 +94,32 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.packaging
+def test_quickinstall_package_leaves_autostart_to_user_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pkg = _load_packaging_script()
+
+    version = pkg.get_package_version()
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
+    adapter_wheel.write_bytes(b"adapter")
+    core_wheel = tmp_path / "dcc_mcp_core-0.18.2-cp38-abi3-win_amd64.whl"
+    core_wheel.write_bytes(b"core")
+
+    monkeypatch.setattr(pkg, "resolve_core_version", lambda min_version=pkg.MIN_CORE_VERSION: "0.18.2")
+    monkeypatch.setattr(pkg, "download_core_wheels", lambda version, platform, dest_dir: [core_wheel])
+
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out")
+
+    with zipfile.ZipFile(zip_path) as zf:
+        package_json = json.loads(zf.read("dcc_mcp_houdini/packages/dcc_mcp_houdini.json.template").decode("utf-8"))
+    environment_names = {next(iter(entry)) for entry in package_json["env"]}
+    assert "DCC_MCP_HOUDINI_AUTOSTART" not in environment_names
+
+
+@pytest.mark.packaging
 def test_assemble_houdini_package_can_pin_validated_core(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- stop the quick-install Houdini package from overriding `DCC_MCP_HOUDINI_AUTOSTART`
- keep autostart enabled by default through the existing bootstrap fallback when the variable is unset
- add a generated-ZIP regression test for the user environment contract

## Problem
The quick-install package template assigned `DCC_MCP_HOUDINI_AUTOSTART=1` unconditionally. Houdini package loading could therefore replace an explicit user value such as `0`, contradicting the documented opt-out behavior.

## Validation
- generated quick-install packaging tests: 10 passed
- non-E2E test suite: 491 passed, 1 skipped
- Ruff check and format check
- Python 3.7 syntax check
- headless Houdini 21.0.631 package-load smoke: an explicit `0` remains `0` with the updated template