### PR TITLE
feat: complete reusable HDA lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
-| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
+| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `update_hda_definition`, `sync_hda_instance` |
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
 | `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 188 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 191 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
-| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda` |
+| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `update_hda_definition`, `sync_hda_instance` |
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
 | `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |

--- a/llms.txt
+++ b/llms.txt
@@ -54,7 +54,7 @@ server.list_skills()
 - `houdini_camera_light__list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light`
 - `houdini_materials__create_material`, `assign_material`
 - `houdini_lookdev__list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset`
-- `houdini_hda__install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`
+- `houdini_hda__install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `update_hda_definition`, `sync_hda_instance`
 - `houdini_chops__create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info`
 - `houdini_constraints__create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint`
 - `houdini_export_preset__list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset`

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -38,6 +38,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Material library & presets | `load_skill("houdini-material-library")` → `houdini_material_library__list_material_presets` → `houdini_material_library__save_material_preset` / `houdini_material_library__load_material_preset` → `houdini_material_library__assign_texture` |
 | Inspect textures & colors | `load_skill("houdini-material-library")` → `houdini_material_library__list_images` → `houdini_material_library__list_color_spaces` → `houdini_material_library__reload_image` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
+| Publish or revise an HDA | `load_skill("houdini-hda")` → `houdini_hda__promote_hda_parameters` → `houdini_hda__save_node_as_hda` / `houdini_hda__update_hda_definition` → `houdini_hda__sync_hda_instance` |
 | Cross-DCC asset import | `load_skill("houdini-import-to-scene")` → `houdini_import_to_scene__import_to_scene` (uses AssetDescriptor contract from dcc-mcp-core) |
 | Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
 | Inspect a Solaris USD Stage | `load_skill("houdini-usd-lops")` → `houdini_usd_lops__list_stage_prims` → `houdini_usd_lops__get_prim_info` / `houdini_usd_lops__get_prim_attributes` |

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: houdini-hda
 description: >-
-  HDA skill - install, inspect, create, cook, and save Houdini Digital Assets
-  with typed parameters. Use when loading .hda/.otl assets or executing an HDA
-  node as part of automation. Not for generic node edits.
+  HDA skill - install, inspect, create, cook, publish, version, and synchronize
+  Houdini Digital Assets with typed public parameters. Use when loading .hda/.otl
+  assets, turning a node graph into a reusable HDA, or upgrading an HDA instance.
+  Not for generic node edits.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
@@ -12,15 +13,17 @@ metadata:
     dcc: houdini
     layer: domain
     stage: authoring
-    version: "1.0.0"
+    version: "1.1.0"
     tags: [houdini, hda, otl, digital-asset, automation]
-    search-hint: "install hda, load otl, execute hda, create hda node, save digital asset"
-    search-aliases: [use hda, install hda, load otl, run digital asset, instantiate hda, execute hda, save hda, create digital asset]
+    search-hint: "install hda, expose controls, publish definition, upgrade instance, save digital asset"
+    search-aliases: [use hda, install hda, load otl, run digital asset, instantiate hda, execute hda, save hda, create digital asset, promote hda parameters, update hda definition, sync hda instance]
     example-prompts:
       - "Install this .hda file and run the asset"
       - "Use the labs::my_asset HDA under /obj with these parameters"
       - "Save /obj/geo1 as a digital asset"
-    intent: "Install, inspect, instantiate, cook, and save Houdini Digital Assets."
+      - "Promote these internal controls and publish a new HDA definition version"
+      - "Upgrade this HDA instance and run its version handler"
+    intent: "Install, inspect, instantiate, cook, publish, version, and synchronize Houdini Digital Assets."
     recall-context:
       app_type: houdini
       domain: assets
@@ -45,3 +48,18 @@ metadata:
 Typed Houdini Digital Asset operations. `execute_hda` is the main high-level
 entry point: it can install an asset file, instantiate a node, set parameters,
 press button parms, and cook the node.
+
+## Reusable asset lifecycle
+
+1. Build and test the internal node graph.
+2. Use `promote_hda_parameters` on an unlocked HDA or subnet to clone selected
+   parameter tuples onto its public interface and link the internal controls.
+3. Use `save_node_as_hda` for a new asset, or `update_hda_definition` to publish
+   unlocked edits and advance an existing definition version.
+4. Use `sync_hda_instance` to reload a library, match an instance to the current
+   definition, and run its native `SyncNodeVersion` handler.
+5. Use `houdini-hda-automation` inspection and validation tools when a reusable
+   asset needs pipeline-level verification.
+
+`update_hda_definition` updates the current definition. Creating or migrating
+between separately namespaced operator types remains an explicit pipeline choice.

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/promote_hda_parameters.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/promote_hda_parameters.py
@@ -1,0 +1,100 @@
+"""Promote internal parameter tuples onto a reusable HDA interface."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_PARM_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+
+
+def promote_hda_parameters(node_path: str, promotions: List[Dict[str, Any]]) -> dict:
+    """Clone internal parm templates onto *node_path* and link the sources."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        node = hou.node(node_path)
+        if node is None:
+            raise ValueError("Houdini node not found: {}".format(node_path))
+        if not promotions:
+            raise ValueError("promotions must not be empty")
+
+        definition = node.type().definition()
+        if definition is not None and node.matchesCurrentDefinition():
+            raise ValueError("HDA must be unlocked before promoting internal parameters")
+        interface_owner = definition or node
+        group = interface_owner.parmTemplateGroup()
+
+        prepared = []
+        names = set()
+        parent_prefix = node.path().rstrip("/") + "/"
+        for promotion in promotions:
+            source_path = promotion.get("source_node_path")
+            source_parm_name = promotion.get("source_parm")
+            target_name = promotion.get("name") or source_parm_name
+            if not _PARM_NAME.match(target_name or ""):
+                raise ValueError("Invalid promoted parameter name: {!r}".format(target_name))
+            if target_name in names or group.find(target_name) is not None:
+                raise ValueError("Promoted parameter already exists: {}".format(target_name))
+            names.add(target_name)
+
+            source = hou.node(source_path) if source_path else None
+            if source is None:
+                raise ValueError("Source node not found: {}".format(source_path))
+            if not source.path().startswith(parent_prefix):
+                raise ValueError("Source node must be inside the HDA node: {}".format(source.path()))
+            source_tuple = source.parmTuple(source_parm_name)
+            if source_tuple is None:
+                raise ValueError("Source parameter tuple not found: {}/{}".format(source.path(), source_parm_name))
+
+            template = source_tuple.parmTemplate().clone()
+            label = promotion.get("label") or template.label()
+            template.setName(target_name)
+            template.setLabel(label)
+            prepared.append((source, source_tuple, source_parm_name, target_name, label, template))
+
+        for _source, _source_tuple, _source_name, _target_name, _label, template in prepared:
+            group.append(template)
+        interface_owner.setParmTemplateGroup(group)
+
+        promoted = []
+        for source, source_tuple, source_parm_name, target_name, label, _template in prepared:
+            values = source_tuple.eval()
+            target_tuple = node.parmTuple(target_name)
+            if target_tuple is None:
+                raise RuntimeError("Promoted parameter tuple was not created: {}".format(target_name))
+            target_tuple.set(values)
+            source_tuple.set(target_tuple, language=hou.exprLanguage.Hscript)
+            promoted.append(
+                {
+                    "name": target_name,
+                    "label": label,
+                    "source": "{}/{}".format(source.path(), source_parm_name),
+                    "component_count": len(values),
+                }
+            )
+
+        return skill_success(
+            "Promoted HDA parameters",
+            node_path=node.path(),
+            interface_owner="definition" if definition is not None else "node",
+            promoted=promoted,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to promote HDA parameters")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return promote_hda_parameters(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/sync_hda_instance.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/sync_hda_instance.py
@@ -1,0 +1,81 @@
+"""Synchronize an HDA instance with a loaded definition and version handler."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _hda_common import validate_hda_path  # noqa: E402
+
+
+def sync_hda_instance(
+    node_path: str,
+    from_version: str,
+    hda_file: Optional[str] = None,
+    match_current: bool = True,
+    sync_delayed: bool = True,
+) -> dict:
+    """Reload an optional library and run the HDA version synchronization hook."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not isinstance(from_version, str) or not from_version.strip():
+            raise ValueError("from_version must be a non-empty string")
+        from_version = from_version.strip()
+        if hda_file:
+            path = validate_hda_path(hda_file, must_exist=True)
+            normalized = os.path.normcase(os.path.abspath(str(path)))
+            loaded = {os.path.normcase(os.path.abspath(item)) for item in hou.hda.loadedFiles()}
+            if normalized in loaded:
+                hou.hda.reloadFile(str(path))
+            else:
+                hou.hda.installFile(str(path))
+
+        node = hou.node(node_path)
+        if node is None:
+            raise ValueError("Houdini node not found: {}".format(node_path))
+        definition = node.type().definition()
+        if definition is None:
+            raise ValueError("Node is not a Houdini Digital Asset: {}".format(node_path))
+
+        delayed = bool(node.isDelayedDefinition())
+        if sync_delayed and delayed:
+            node.syncDelayedDefinition()
+        if match_current and not node.matchesCurrentDefinition():
+            node.matchCurrentDefinition()
+        node.syncNodeVersionIfNeeded(from_version)
+
+        return skill_success(
+            "Synchronized HDA instance",
+            node_path=node.path(),
+            node_type_name=definition.nodeTypeName(),
+            library_path=definition.libraryFilePath(),
+            from_version=from_version,
+            version=definition.version(),
+            delayed_definition_synced=bool(sync_delayed and delayed),
+            matched_current_definition=node.matchesCurrentDefinition(),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to synchronize HDA instance")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return sync_hda_instance(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/update_hda_definition.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/update_hda_definition.py
@@ -1,0 +1,62 @@
+"""Publish an HDA instance into its definition and advance its version."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def update_hda_definition(
+    node_path: str,
+    version: str,
+    update_contents: bool = True,
+    match_current: bool = True,
+) -> dict:
+    """Save unlocked contents, set definition metadata version, and optionally lock."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError("version must be a non-empty string")
+        version = version.strip()
+        node = hou.node(node_path)
+        if node is None:
+            raise ValueError("Houdini node not found: {}".format(node_path))
+        definition = node.type().definition()
+        if definition is None:
+            raise ValueError("Node is not a Houdini Digital Asset: {}".format(node_path))
+
+        old_version = definition.version()
+        was_matched = node.matchesCurrentDefinition()
+        contents_updated = bool(update_contents and not was_matched)
+        if contents_updated:
+            definition.updateFromNode(node)
+        definition.setVersion(version)
+        if match_current and not was_matched:
+            node.matchCurrentDefinition()
+
+        return skill_success(
+            "Updated HDA definition",
+            node_path=node.path(),
+            node_type_name=definition.nodeTypeName(),
+            library_path=definition.libraryFilePath(),
+            old_version=old_version,
+            version=version,
+            contents_updated=contents_updated,
+            matched_current_definition=node.matchesCurrentDefinition(),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to update HDA definition")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return update_hda_definition(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
@@ -111,6 +111,146 @@ tools:
       on-failure:
         - houdini_hda__list_hda_definitions
 
+  - name: promote_hda_parameters
+    description: >-
+      Promote parameter tuples from child nodes onto an unlocked HDA or subnet
+      interface and create native channel references back to the public controls.
+    input_schema:
+      type: object
+      required: [node_path, promotions]
+      properties:
+        node_path:
+          type: string
+          description: "Unlocked HDA instance or subnet that owns the public interface."
+        promotions:
+          type: array
+          minItems: 1
+          description: "Internal parameter tuples to expose on the asset interface."
+          items:
+            type: object
+            required: [source_node_path, source_parm]
+            properties:
+              source_node_path:
+                type: string
+                description: "Path to a child node inside node_path."
+              source_parm:
+                type: string
+                description: "Source parameter tuple name."
+              name:
+                type: string
+                description: "Optional public parameter name; defaults to source_parm."
+              label:
+                type: string
+                description: "Optional public label; defaults to the source label."
+            additionalProperties: false
+    read_only: false
+    destructive: false
+    idempotent: false
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 60
+    source_file: scripts/promote_hda_parameters.py
+    tool_role: action
+    risk: medium
+    search_aliases: [promote hda parameter, expose hda control, create hda interface, link internal parameter]
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    next-tools:
+      on-success:
+        - houdini_hda__save_node_as_hda
+        - houdini_hda__update_hda_definition
+      on-failure:
+        - houdini_parameters__list_parms
+
+  - name: update_hda_definition
+    description: >-
+      Publish unlocked instance contents into its HDA definition, set the
+      definition version, and optionally match the instance to the new definition.
+    input_schema:
+      type: object
+      required: [node_path, version]
+      properties:
+        node_path:
+          type: string
+          description: "Existing HDA instance whose definition will be updated."
+        version:
+          type: string
+          description: "Non-empty definition version metadata."
+        update_contents:
+          type: boolean
+          default: true
+          description: "Publish unlocked instance contents before setting the version."
+        match_current:
+          type: boolean
+          default: true
+          description: "Match and lock the instance to the updated definition."
+    read_only: false
+    destructive: true
+    idempotent: false
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 120
+    source_file: scripts/update_hda_definition.py
+    tool_role: action
+    risk: high
+    search_aliases: [update hda definition, publish hda changes, bump hda version, save hda definition]
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    next-tools:
+      on-success:
+        - houdini_hda__sync_hda_instance
+      on-failure:
+        - houdini_hda_automation__inspect_hda_definition
+
+  - name: sync_hda_instance
+    description: >-
+      Reload or install an optional HDA library, match an instance to its current
+      definition, and run the asset's native version synchronization handler.
+    input_schema:
+      type: object
+      required: [node_path, from_version]
+      properties:
+        node_path:
+          type: string
+          description: "HDA instance to synchronize."
+        from_version:
+          type: string
+          description: "Previous instance version passed to the SyncNodeVersion handler."
+        hda_file:
+          type: string
+          description: "Optional HDA/OTL library to install or reload first."
+        match_current:
+          type: boolean
+          default: true
+          description: "Match the instance to the loaded current definition."
+        sync_delayed:
+          type: boolean
+          default: true
+          description: "Load delayed definition contents before synchronization."
+    read_only: false
+    destructive: true
+    idempotent: false
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 120
+    source_file: scripts/sync_hda_instance.py
+    tool_role: action
+    risk: high
+    search_aliases: [sync hda instance, upgrade hda instance, match current definition, run hda version handler]
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    next-tools:
+      on-success:
+        - houdini_hda_automation__validate_hda
+      on-failure:
+        - houdini_hda_automation__inspect_hda_definition
+
   - name: save_node_as_hda
     description: >-
       Create a Houdini Digital Asset from an existing node and save it to an

--- a/tests/test_hda_lifecycle.py
+++ b/tests/test_hda_lifecycle.py
@@ -1,0 +1,146 @@
+"""Mock-HOM tests for the reusable HDA lifecycle tools."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS = Path(__file__).parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-hda" / "scripts"
+
+
+def _load_script(name: str) -> ModuleType:
+    path = _SCRIPTS / name
+    spec = importlib.util.spec_from_file_location("hda_lifecycle_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_promote_hda_parameters_clones_interface_and_links_internal_tuple() -> None:
+    mod = _load_script("promote_hda_parameters.py")
+    template = MagicMock()
+    cloned = MagicMock()
+    template.clone.return_value = cloned
+    source_tuple = MagicMock()
+    source_tuple.parmTemplate.return_value = template
+    source_tuple.eval.return_value = (1.25,)
+    target_tuple = MagicMock()
+    group = MagicMock()
+    group.find.return_value = None
+
+    node_type = MagicMock()
+    node_type.definition.return_value = None
+    parent = MagicMock()
+    parent.path.return_value = "/obj/solar_asset"
+    parent.type.return_value = node_type
+    parent.parmTemplateGroup.return_value = group
+    parent.parmTuple.return_value = target_tuple
+    source = MagicMock()
+    source.path.return_value = "/obj/solar_asset/bloom"
+    source.parmTuple.return_value = source_tuple
+    mock_hou = MagicMock()
+    mock_hou.node.side_effect = lambda path: {
+        "/obj/solar_asset": parent,
+        "/obj/solar_asset/bloom": source,
+    }.get(path)
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.promote_hda_parameters(
+            "/obj/solar_asset",
+            [
+                {
+                    "source_node_path": "/obj/solar_asset/bloom",
+                    "source_parm": "gain",
+                    "name": "bloom_gain",
+                    "label": "Bloom Gain",
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    assert result["context"]["promoted"] == [
+        {
+            "name": "bloom_gain",
+            "label": "Bloom Gain",
+            "source": "/obj/solar_asset/bloom/gain",
+            "component_count": 1,
+        }
+    ]
+    cloned.setName.assert_called_once_with("bloom_gain")
+    cloned.setLabel.assert_called_once_with("Bloom Gain")
+    group.append.assert_called_once_with(cloned)
+    parent.setParmTemplateGroup.assert_called_once_with(group)
+    target_tuple.set.assert_called_once_with((1.25,))
+    source_tuple.set.assert_called_once_with(target_tuple, language=mock_hou.exprLanguage.Hscript)
+
+
+def test_update_hda_definition_saves_unlocked_contents_bumps_version_and_locks() -> None:
+    mod = _load_script("update_hda_definition.py")
+    definition = MagicMock()
+    definition.version.return_value = "1.1.0"
+    definition.libraryFilePath.return_value = "/assets/solar.hda"
+    definition.nodeTypeName.return_value = "studio::solar"
+    node_type = MagicMock()
+    node_type.definition.return_value = definition
+    node = MagicMock()
+    node.path.return_value = "/obj/solar1"
+    node.type.return_value = node_type
+    node.matchesCurrentDefinition.side_effect = [False, True]
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = node
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.update_hda_definition("/obj/solar1", "1.2.0")
+
+    assert result["success"] is True
+    assert result["context"] == {
+        "node_path": "/obj/solar1",
+        "node_type_name": "studio::solar",
+        "library_path": "/assets/solar.hda",
+        "old_version": "1.1.0",
+        "version": "1.2.0",
+        "contents_updated": True,
+        "matched_current_definition": True,
+    }
+    definition.updateFromNode.assert_called_once_with(node)
+    definition.setVersion.assert_called_once_with("1.2.0")
+    node.matchCurrentDefinition.assert_called_once_with()
+
+
+def test_sync_hda_instance_matches_definition_and_runs_version_handler() -> None:
+    mod = _load_script("sync_hda_instance.py")
+    definition = MagicMock()
+    definition.version.return_value = "1.2.0"
+    definition.libraryFilePath.return_value = "/assets/solar.hda"
+    definition.nodeTypeName.return_value = "studio::solar"
+    node_type = MagicMock()
+    node_type.definition.return_value = definition
+    node = MagicMock()
+    node.path.return_value = "/obj/solar1"
+    node.type.return_value = node_type
+    node.isDelayedDefinition.return_value = True
+    node.matchesCurrentDefinition.side_effect = [False, True]
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = node
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.sync_hda_instance("/obj/solar1", "1.1.0")
+
+    assert result["success"] is True
+    assert result["context"] == {
+        "node_path": "/obj/solar1",
+        "node_type_name": "studio::solar",
+        "library_path": "/assets/solar.hda",
+        "from_version": "1.1.0",
+        "version": "1.2.0",
+        "delayed_definition_synced": True,
+        "matched_current_definition": True,
+    }
+    node.syncDelayedDefinition.assert_called_once_with()
+    node.matchCurrentDefinition.assert_called_once_with()
+    node.syncNodeVersionIfNeeded.assert_called_once_with("1.1.0")


### PR DESCRIPTION
## Summary
- promote selected child parameter tuples onto an unlocked HDA or subnet interface using native HOM templates and channel references
- publish unlocked contents, advance definition metadata versions, and optionally match the authoring instance
- synchronize existing instances against reloaded definitions and run the native `SyncNodeVersion` handler
- document the reusable HDA lifecycle and add mock-HOM contract coverage

## Why
Reusable node graphs need a supported path from internal controls to a stable public interface, plus explicit definition and instance version lifecycle operations. This extends the existing `houdini-hda` skill instead of adding an overlapping package.

## Validation
- `python -m pytest -q` — 494 passed, 1 skipped, 3 deselected
- `python tools/lint_skills.py` — 31 skills, 0 errors, 0 warnings
- `python -m ruff check .`
- `python -m ruff format --check .`
- `git diff --check`

## References
- https://www.sidefx.com/docs/houdini/hom/hou/HDADefinition.html
- https://www.sidefx.com/docs/houdini/hom/hou/OpNode.html
- https://www.sidefx.com/docs/houdini/hom/hou/ParmTuple.html
- https://www.sidefx.com/docs/houdini/assets/versioning_systems.html