### PR TITLE
fix: make Windows render cancellation self-contained

### DIFF
--- a/src/dcc_mcp_houdini/_isolated_jobs.py
+++ b/src/dcc_mcp_houdini/_isolated_jobs.py
@@ -13,6 +13,11 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
+if os.name == "nt":
+    from dcc_mcp_houdini._windows_process import terminate_process_tree as _terminate_windows_process_tree
+else:
+    _terminate_windows_process_tree = None
+
 _JOB_ROOT_NAME = "dcc-mcp-houdini-render-jobs"
 _PROCESS_HANDLES: Dict[str, Any] = {}
 _PROCESS_LOCK = threading.RLock()
@@ -134,14 +139,10 @@ def _terminate_process_tree(process: Any) -> None:
     if process.poll() is not None:
         return
     if os.name == "nt":
-        completed = subprocess.run(  # noqa: S603
-            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        if completed.returncode and process.poll() is None:
-            raise RuntimeError("Failed to terminate the background process tree")
+        if _terminate_windows_process_tree is None:
+            raise RuntimeError("Windows process-tree termination is unavailable")
+        _terminate_windows_process_tree(process, timeout_secs=_CANCEL_GRACE_SECS)
+        return
     else:
         killpg = getattr(os, "killpg", None)
         if killpg is None:

--- a/src/dcc_mcp_houdini/_windows_process.py
+++ b/src/dcc_mcp_houdini/_windows_process.py
@@ -1,0 +1,181 @@
+"""Windows-native process-tree termination for adapter-owned workers."""
+
+from __future__ import annotations
+
+import ctypes
+import subprocess
+import time
+from ctypes import wintypes
+from typing import Any, Dict, Iterable, List, Set, Tuple
+
+_TH32CS_SNAPPROCESS = 0x00000002
+_PROCESS_TERMINATE = 0x0001
+_SYNCHRONIZE = 0x00100000
+_WAIT_OBJECT_0 = 0x00000000
+_WAIT_TIMEOUT = 0x00000102
+_ERROR_ACCESS_DENIED = 5
+_ERROR_NO_MORE_FILES = 18
+_ERROR_INVALID_PARAMETER = 87
+_MAX_PATH = 260
+
+
+class _ProcessEntry32W(ctypes.Structure):
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ProcessID", wintypes.DWORD),
+        ("th32DefaultHeapID", ctypes.c_size_t),
+        ("th32ModuleID", wintypes.DWORD),
+        ("cntThreads", wintypes.DWORD),
+        ("th32ParentProcessID", wintypes.DWORD),
+        ("pcPriClassBase", wintypes.LONG),
+        ("dwFlags", wintypes.DWORD),
+        ("szExeFile", wintypes.WCHAR * _MAX_PATH),
+    ]
+
+
+def _kernel32() -> Any:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.Process32FirstW.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ProcessEntry32W)]
+    kernel32.Process32FirstW.restype = wintypes.BOOL
+    kernel32.Process32NextW.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ProcessEntry32W)]
+    kernel32.Process32NextW.restype = wintypes.BOOL
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    kernel32.TerminateProcess.restype = wintypes.BOOL
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    return kernel32
+
+
+def _raise_windows_error(message: str, error_code: int) -> None:
+    error = ctypes.WinError(error_code)
+    raise RuntimeError("{}: {}".format(message, error)) from error
+
+
+def _snapshot_processes(kernel32: Any) -> List[Tuple[int, int]]:
+    snapshot = kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
+    invalid_handle = ctypes.c_void_p(-1).value
+    if not snapshot or snapshot == invalid_handle:
+        _raise_windows_error("Failed to snapshot the background process tree", ctypes.get_last_error())
+    entries: List[Tuple[int, int]] = []
+    try:
+        entry = _ProcessEntry32W()
+        entry.dwSize = ctypes.sizeof(entry)
+        if not kernel32.Process32FirstW(snapshot, ctypes.byref(entry)):
+            error_code = ctypes.get_last_error()
+            if error_code == _ERROR_NO_MORE_FILES:
+                return entries
+            _raise_windows_error("Failed to inspect the background process tree", error_code)
+        while True:
+            entries.append((int(entry.th32ProcessID), int(entry.th32ParentProcessID)))
+            entry.dwSize = ctypes.sizeof(entry)
+            if not kernel32.Process32NextW(snapshot, ctypes.byref(entry)):
+                error_code = ctypes.get_last_error()
+                if error_code != _ERROR_NO_MORE_FILES:
+                    _raise_windows_error("Failed to inspect the background process tree", error_code)
+                return entries
+    finally:
+        kernel32.CloseHandle(snapshot)
+
+
+def _find_descendants(entries: Iterable[Tuple[int, int]], ancestor_pids: Set[int]) -> Set[int]:
+    descendants: Set[int] = set()
+    remaining = list(entries)
+    while True:
+        discovered = {
+            pid
+            for pid, parent_pid in remaining
+            if pid not in ancestor_pids and pid not in descendants and parent_pid in ancestor_pids.union(descendants)
+        }
+        if not discovered:
+            return descendants
+        descendants.update(discovered)
+
+
+def _capture_descendant_handles(
+    kernel32: Any,
+    known_pids: Set[int],
+    handles: Dict[int, Any],
+) -> int:
+    descendants = _find_descendants(_snapshot_processes(kernel32), known_pids)
+    new_pids = descendants.difference(known_pids)
+    known_pids.update(descendants)
+    opened = 0
+    for pid in sorted(new_pids):
+        handle = kernel32.OpenProcess(_PROCESS_TERMINATE | _SYNCHRONIZE, False, pid)
+        if not handle:
+            error_code = ctypes.get_last_error()
+            if error_code == _ERROR_INVALID_PARAMETER:
+                continue
+            _raise_windows_error("Failed to open an owned background process", error_code)
+        handles[pid] = handle
+        opened += 1
+    return opened
+
+
+def _terminate_handles(kernel32: Any, handles: Dict[int, Any]) -> None:
+    for handle in handles.values():
+        if kernel32.WaitForSingleObject(handle, 0) == _WAIT_OBJECT_0:
+            continue
+        if kernel32.TerminateProcess(handle, 1):
+            continue
+        error_code = ctypes.get_last_error()
+        if kernel32.WaitForSingleObject(handle, 0) == _WAIT_OBJECT_0:
+            continue
+        if error_code == _ERROR_ACCESS_DENIED:
+            _raise_windows_error("Access was denied while terminating an owned background process", error_code)
+        _raise_windows_error("Failed to terminate an owned background process", error_code)
+
+
+def _remaining_millis(deadline: float) -> int:
+    remaining = max(0.0, deadline - time.monotonic())
+    return min(int(remaining * 1000), 0xFFFFFFFE)
+
+
+def _wait_for_handles(kernel32: Any, handles: Dict[int, Any], deadline: float) -> None:
+    for handle in handles.values():
+        result = kernel32.WaitForSingleObject(handle, _remaining_millis(deadline))
+        if result == _WAIT_OBJECT_0:
+            continue
+        if result == _WAIT_TIMEOUT:
+            raise RuntimeError("Background process tree did not exit")
+        _raise_windows_error("Failed while waiting for the background process tree", ctypes.get_last_error())
+
+
+def terminate_process_tree(process: Any, timeout_secs: float) -> None:
+    """Terminate an owned Popen process and every descendant without spawning a helper."""
+    if process.poll() is not None:
+        return
+    kernel32 = _kernel32()
+    root_pid = int(process.pid)
+    known_pids = {root_pid}
+    handles: Dict[int, Any] = {}
+    deadline = time.monotonic() + timeout_secs
+    try:
+        _capture_descendant_handles(kernel32, known_pids, handles)
+        try:
+            process.kill()
+        except OSError:
+            if process.poll() is None:
+                raise
+        _terminate_handles(kernel32, handles)
+        try:
+            process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("Background process tree did not exit") from exc
+        _wait_for_handles(kernel32, handles, deadline)
+
+        while _capture_descendant_handles(kernel32, known_pids, handles):
+            _terminate_handles(kernel32, handles)
+            _wait_for_handles(kernel32, handles, deadline)
+            if time.monotonic() >= deadline:
+                raise RuntimeError("Background process tree did not exit")
+    finally:
+        for handle in handles.values():
+            kernel32.CloseHandle(handle)

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
@@ -14,6 +15,28 @@ import pytest
 
 _SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
 _DEFAULT_PATTERN = object()
+
+
+def _wait_for_windows_process_exit(pid: int, timeout_secs: float) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_object_0 = 0
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.OpenProcess(synchronize, False, pid)
+    if not handle:
+        return True
+    try:
+        return kernel32.WaitForSingleObject(handle, int(timeout_secs * 1000)) == wait_object_0
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def _load_script(skill_name: str, script_name: str) -> ModuleType:
@@ -794,23 +817,61 @@ class TestRenderExecution:
         assert result["success"] is True
         read.assert_called_once_with("7" * 32, include_details=True)
 
-    def test_terminate_process_tree_uses_taskkill_on_windows(self) -> None:
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows process-tree regression")
+    def test_cancel_render_job_survives_external_command_failure(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "_background_render.py")
-        process = MagicMock(pid=4321)
-        process.poll.return_value = None
-        process.wait.return_value = 0
-        completed = MagicMock(returncode=0)
-
-        with patch.object(mod.os, "name", "nt"), patch.object(mod.subprocess, "run", return_value=completed) as run:
-            mod._terminate_process_tree(process)
-
-        run.assert_called_once_with(
-            ["taskkill", "/PID", "4321", "/T", "/F"],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+        job_id = "6" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        (job_dir / "status.json").write_text(
+            json.dumps({"job_id": job_id, "state": "running"}),
+            encoding="utf-8",
         )
-        process.wait.assert_called_once()
+        child_pid_path = tmp_path / "child.pid"
+        child_code = "import time; time.sleep(60)"
+        parent_code = (
+            "import pathlib, subprocess, sys, time; "
+            "child = subprocess.Popen([sys.executable, '-c', {!r}]); "
+            "pathlib.Path({!r}).write_text(str(child.pid), encoding='utf-8'); "
+            "time.sleep(60)"
+        ).format(child_code, str(child_pid_path))
+        process = subprocess.Popen(  # noqa: S603
+            [sys.executable, "-c", parent_code],
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+        mod._PROCESS_HANDLES[job_id] = process
+        child_pid = None
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not child_pid_path.is_file():
+                time.sleep(0.02)
+            assert child_pid_path.is_file()
+            child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+
+            with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+                mod.subprocess, "run", side_effect=OSError("cannot create helper process")
+            ):
+                first = mod.cancel_render_job(job_id)
+                second = mod.cancel_render_job(job_id)
+
+            assert first["state"] == "cancelled"
+            assert first["cancel_requested"] is True
+            assert second["state"] == "cancelled"
+            assert second["cancel_requested"] is False
+            assert job_id not in mod._PROCESS_HANDLES
+            assert process.poll() is not None
+            assert _wait_for_windows_process_exit(child_pid, timeout_secs=5)
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=5)
+            if child_pid is not None and not _wait_for_windows_process_exit(child_pid, timeout_secs=0):
+                subprocess.run(  # noqa: S603
+                    ["taskkill", "/PID", str(child_pid), "/T", "/F"],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
 
     def test_terminate_process_tree_uses_process_group_on_posix(self) -> None:
         mod = _load_script("houdini-render", "_background_render.py")


### PR DESCRIPTION
## Summary

- replace the Windows `taskkill /T /F` helper dependency with in-process Win32 process snapshot and handle operations
- anchor cancellation to the adapter-owned `Popen` root, terminate captured descendants, and rescan for child-spawn races
- retain bounded waits, idempotent repeated cancellation, and the existing POSIX process-group behavior

## Why

Starting an extra `taskkill` process can fail under process/thread resource pressure. The previous path then raised while the owned render worker tree remained live. The native path does not need another process and verifies that every opened descendant handle exits before reporting success.

## Validation

- real Windows parent/child process-tree regression with injected external-command failure
- repeated cancel returns `cancelled` and does not terminate twice
- regression repeated 20 times with no surviving worker
- 48 Houdini render/camera/light tests pass
- Ruff check and format check pass
- 31 bundled skills validate with zero errors/warnings
- Python 3.7 syntax check passes
- wheel/sdist build and Twine checks pass