### PR TITLE
fix: verify Windows render exit races by handle

### DIFF
--- a/src/dcc_mcp_houdini/_windows_process.py
+++ b/src/dcc_mcp_houdini/_windows_process.py
@@ -129,7 +129,10 @@ def _terminate_handles(kernel32: Any, handles: Dict[int, Any]) -> None:
         if kernel32.WaitForSingleObject(handle, 0) == _WAIT_OBJECT_0:
             continue
         if error_code == _ERROR_ACCESS_DENIED:
-            _raise_windows_error("Access was denied while terminating an owned background process", error_code)
+            # TerminateProcess reports ERROR_ACCESS_DENIED for an already
+            # terminated process whose kernel handle is still open. The
+            # bounded WaitForSingleObject pass below remains authoritative.
+            continue
         _raise_windows_error("Failed to terminate an owned background process", error_code)
 
 

--- a/tests/test_windows_process.py
+++ b/tests/test_windows_process.py
@@ -1,0 +1,47 @@
+"""Windows process boundary regressions."""
+
+from __future__ import annotations
+
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dcc_mcp_houdini import _windows_process
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows process boundary")
+
+
+def test_exiting_descendant_access_denied_is_verified_by_bounded_wait() -> None:
+    kernel32 = MagicMock()
+    handle = object()
+    kernel32.WaitForSingleObject.side_effect = [
+        _windows_process._WAIT_TIMEOUT,
+        _windows_process._WAIT_TIMEOUT,
+        _windows_process._WAIT_OBJECT_0,
+    ]
+    kernel32.TerminateProcess.return_value = False
+
+    with patch.object(_windows_process.ctypes, "get_last_error", return_value=_windows_process._ERROR_ACCESS_DENIED):
+        _windows_process._terminate_handles(kernel32, {4321: handle})
+        _windows_process._wait_for_handles(kernel32, {4321: handle}, time.monotonic() + 1)
+
+
+def test_access_denied_descendant_that_stays_live_still_fails() -> None:
+    kernel32 = MagicMock()
+    handle = object()
+    kernel32.WaitForSingleObject.side_effect = [
+        _windows_process._WAIT_TIMEOUT,
+        _windows_process._WAIT_TIMEOUT,
+        _windows_process._WAIT_TIMEOUT,
+    ]
+    kernel32.TerminateProcess.return_value = False
+
+    with patch.object(
+        _windows_process.ctypes,
+        "get_last_error",
+        return_value=_windows_process._ERROR_ACCESS_DENIED,
+    ), pytest.raises(RuntimeError, match="did not exit"):
+        _windows_process._terminate_handles(kernel32, {4321: handle})
+        _windows_process._wait_for_handles(kernel32, {4321: handle}, time.monotonic() + 1)


### PR DESCRIPTION
## Summary

- treat `ERROR_ACCESS_DENIED` from `TerminateProcess` as a possible completed-exit race after a descendant handle was already opened with terminate rights
- keep `WaitForSingleObject` as the bounded, authoritative exit check
- retain failure behavior when the descendant remains live through the cancellation deadline

## Why

Microsoft documents that `TerminateProcess` returns `ERROR_ACCESS_DENIED` when called through an open handle after the process has already terminated, and that termination is asynchronous and should be verified with `WaitForSingleObject`:
https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess

A fresh released-package regression exposed this race after the initial native process-tree change. Reporting the transient error immediately produced a false cancellation failure even though the owned process was exiting.

## Validation

- deterministic RED/GREEN tests cover both the exiting race and a descendant that remains live
- real released-package-shaped parent/child cancellation harness passes 20/20 with the source fix and no survivors
- 50 focused Windows process/render tests pass
- Ruff, format, bundled skill validation, Python 3.7 syntax, wheel/sdist build, and Twine checks pass