### PR TITLE
fix(render): separate ROP errors and warnings

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -3,7 +3,8 @@ name: houdini-render
 description: >-
   Pipeline skill — viewport capture/flipbook plus ROP render settings and
   render execution through typed, runtime-aware tools. Exports report
-  written_files, elapsed time, and warnings without hanging the host. Pair with
+  written_files, elapsed time, and separate error/warning diagnostics without
+  hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -1,4 +1,4 @@
-"""Render a ROP node and report written files, elapsed time, and warnings."""
+"""Render a ROP node and report written files, elapsed time, and diagnostics."""
 
 from __future__ import annotations
 
@@ -51,6 +51,7 @@ def render_rop(
                 background=True,
                 **job,
             )
+        errors: List[str] = []
         warnings: List[str] = []
         start = time.time()
         rendered = True
@@ -60,10 +61,14 @@ def render_rop(
             rendered = False
             applied_range = None
             execution_mode = None
-            warnings.append("Render failed: {}".format(render_exc))
+            errors.append("Render failed: {}".format(render_exc))
         elapsed = round(time.time() - start, 3)
-        if hasattr(rop, "errors"):
-            warnings.extend(list(rop.errors()))
+        rop_errors = getattr(rop, "errors", None)
+        if callable(rop_errors):
+            errors.extend(str(error) for error in rop_errors())
+        rop_warnings = getattr(rop, "warnings", None)
+        if callable(rop_warnings):
+            warnings.extend(str(warning) for warning in rop_warnings())
         written = expanded_outputs(output_pattern)
         return skill_success(
             "Rendered ROP",
@@ -75,6 +80,7 @@ def render_rop(
             output_pattern=output_pattern,
             written_files=written,
             skipped=[] if written or not output_pattern else [output_pattern],
+            errors=errors,
             warnings=warnings,
         )
     except Exception as exc:

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -1097,7 +1097,8 @@ class TestRenderExecution:
         rop.parmTuple.return_value = None
         rop.parm.side_effect = lambda n: picture if n == "picture" else None
         rop.render.side_effect = lambda verbose=False: out.write_bytes(b"exr")
-        rop.errors.return_value = []
+        rop.errors.return_value = ["missing texture"]
+        rop.warnings.return_value = ["low sample count"]
         mock_hou = MagicMock()
         mock_hou.node.return_value = rop
         mock_hou.isUIAvailable.return_value = False
@@ -1109,6 +1110,32 @@ class TestRenderExecution:
         assert result["context"]["rendered"] is True
         assert result["context"]["written_files"] == [str(out)]
         assert "elapsed_secs" in result["context"]
+        assert result["context"]["errors"] == ["missing texture"]
+        assert result["context"]["warnings"] == ["low sample count"]
+
+    def test_render_rop_reports_render_exception_as_error(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        picture = _scalar_parm(str(tmp_path / "beauty.exr"))
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        rop.render.side_effect = RuntimeError("renderer unavailable")
+        rop.errors.return_value = ["driver failed"]
+        rop.warnings.return_value = ["fallback disabled"]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = False
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.render_rop("/out/mantra1")
+
+        assert result["success"] is True
+        assert result["context"]["rendered"] is False
+        assert result["context"]["errors"] == [
+            "Render failed: renderer unavailable",
+            "driver failed",
+        ]
+        assert result["context"]["warnings"] == ["fallback disabled"]
 
     def test_render_rop_uses_solaris_execute_and_outputimage(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")


### PR DESCRIPTION
## Summary
- return native ROP errors in the `errors` field instead of mixing them into warnings
- populate `warnings` from `hou.RopNode.warnings()`
- classify foreground render exceptions as errors while preserving the existing structured result contract

## Validation
- `python -m pytest tests/test_render_camera_light_skills.py -q` (49 passed)
- `python -m ruff check ...`
- `python -m ruff format --check ...`