### PR TITLE
feat: add reusable HDA authoring contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
-| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `update_hda_definition`, `sync_hda_instance` |
+| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `author_hda_interface`, `publish_hda_library`, `validate_hda_contract`, `update_hda_definition`, `sync_hda_instance` |
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
 | `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 191 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 194 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
-| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `update_hda_definition`, `sync_hda_instance` |
+| `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `author_hda_interface`, `publish_hda_library`, `validate_hda_contract`, `update_hda_definition`, `sync_hda_instance` |
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
 | `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |

--- a/llms.txt
+++ b/llms.txt
@@ -54,7 +54,7 @@ server.list_skills()
 - `houdini_camera_light__list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light`
 - `houdini_materials__create_material`, `assign_material`
 - `houdini_lookdev__list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset`
-- `houdini_hda__install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `update_hda_definition`, `sync_hda_instance`
+- `houdini_hda__install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `author_hda_interface`, `publish_hda_library`, `validate_hda_contract`, `update_hda_definition`, `sync_hda_instance`
 - `houdini_chops__create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info`
 - `houdini_constraints__create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint`
 - `houdini_export_preset__list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset`

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -38,7 +38,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Material library & presets | `load_skill("houdini-material-library")` → `houdini_material_library__list_material_presets` → `houdini_material_library__save_material_preset` / `houdini_material_library__load_material_preset` → `houdini_material_library__assign_texture` |
 | Inspect textures & colors | `load_skill("houdini-material-library")` → `houdini_material_library__list_images` → `houdini_material_library__list_color_spaces` → `houdini_material_library__reload_image` |
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
-| Publish or revise an HDA | `load_skill("houdini-hda")` → `houdini_hda__promote_hda_parameters` → `houdini_hda__save_node_as_hda` / `houdini_hda__update_hda_definition` → `houdini_hda__sync_hda_instance` |
+| Publish or revise an HDA | `load_skill("houdini-hda")` → `houdini_hda__author_hda_interface` → `houdini_hda__save_node_as_hda` / `houdini_hda__publish_hda_library` → `houdini_hda__validate_hda_contract` → `houdini_hda__sync_hda_instance` |
 | Cross-DCC asset import | `load_skill("houdini-import-to-scene")` → `houdini_import_to_scene__import_to_scene` (uses AssetDescriptor contract from dcc-mcp-core) |
 | Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
 | Inspect a Solaris USD Stage | `load_skill("houdini-usd-lops")` → `houdini_usd_lops__list_stage_prims` → `houdini_usd_lops__get_prim_info` / `houdini_usd_lops__get_prim_attributes` |

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: houdini-hda
 description: >-
-  HDA skill - install, inspect, create, cook, publish, version, and synchronize
-  Houdini Digital Assets with typed public parameters. Use when loading .hda/.otl
-  assets, turning a node graph into a reusable HDA, or upgrading an HDA instance.
-  Not for generic node edits.
+  HDA skill - install, inspect, create, author, publish, validate, cook, and
+  synchronize Houdini Digital Assets with typed public parameters. Use when
+  loading .hda/.otl assets, building reusable interfaces, or publishing an HDA
+  library. Not for generic node edits.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
@@ -15,15 +15,16 @@ metadata:
     stage: authoring
     version: "1.1.0"
     tags: [houdini, hda, otl, digital-asset, automation]
-    search-hint: "install hda, expose controls, publish definition, upgrade instance, save digital asset"
-    search-aliases: [use hda, install hda, load otl, run digital asset, instantiate hda, execute hda, save hda, create digital asset, promote hda parameters, update hda definition, sync hda instance]
+    search-hint: "install hda, expose controls, author interface, publish versioned hda, validate contract"
+    search-aliases: [use hda, install hda, load otl, run digital asset, instantiate hda, execute hda, save hda, create digital asset, promote hda parameters, author hda interface, publish hda, validate hda, update hda definition, sync hda instance]
     example-prompts:
       - "Install this .hda file and run the asset"
       - "Use the labs::my_asset HDA under /obj with these parameters"
       - "Save /obj/geo1 as a digital asset"
       - "Promote these internal controls and publish a new HDA definition version"
+      - "Publish this asset with a safe reusable interface and dependency manifest"
       - "Upgrade this HDA instance and run its version handler"
-    intent: "Install, inspect, instantiate, cook, publish, version, and synchronize Houdini Digital Assets."
+    intent: "Install, author, publish, validate, instantiate, cook, and synchronize Houdini Digital Assets."
     recall-context:
       app_type: houdini
       domain: assets
@@ -52,14 +53,15 @@ press button parms, and cook the node.
 ## Reusable asset lifecycle
 
 1. Build and test the internal node graph.
-2. Use `promote_hda_parameters` on an unlocked HDA or subnet to clone selected
-   parameter tuples onto its public interface and link the internal controls.
-3. Use `save_node_as_hda` for a new asset, or `update_hda_definition` to publish
-   unlocked edits and advance an existing definition version.
-4. Use `sync_hda_instance` to reload a library, match an instance to the current
+2. Use `author_hda_interface` for a complete callback-free declarative interface,
+   or `promote_hda_parameters` to clone selected internal parameter tuples.
+3. Use `save_node_as_hda` for a new asset, then `publish_hda_library` for an
+   explicitly namespaced/versioned library with metadata and dependencies.
+4. Gate the result with `validate_hda_contract`.
+5. Use `sync_hda_instance` to reload a library, match an instance to the current
    definition, and run its native `SyncNodeVersion` handler.
-5. Use `houdini-hda-automation` inspection and validation tools when a reusable
+6. Use `houdini-hda-automation` graph cooking tools when a reusable
    asset needs pipeline-level verification.
 
-`update_hda_definition` updates the current definition. Creating or migrating
-between separately namespaced operator types remains an explicit pipeline choice.
+`update_hda_definition` updates the current definition. `publish_hda_library`
+requires an explicit namespace, version, and overwrite policy.

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/author_hda_interface.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/author_hda_interface.py
@@ -1,0 +1,251 @@
+"""Author a safe declarative parameter interface on an HDA or subnet."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Sequence, Tuple
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_PARM_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+_FORBIDDEN_FIELDS = {
+    "callback",
+    "item_generator_script",
+    "python",
+    "script",
+    "script_callback",
+    "script_callback_language",
+}
+_TYPES = {"folder", "float", "int", "toggle", "string", "menu"}
+
+
+def _values(value: Any, count: int, cast: Any) -> Tuple[Any, ...]:
+    raw = value if isinstance(value, (list, tuple)) else [value] * count
+    if len(raw) != count:
+        raise ValueError("default must contain exactly {} value(s)".format(count))
+    return tuple(cast(item) for item in raw)
+
+
+def _reject_unsafe_fields(spec: Dict[str, Any]) -> None:
+    unsafe = sorted(_FORBIDDEN_FIELDS.intersection(spec))
+    if unsafe:
+        raise ValueError("Executable parameter fields are not allowed: {}".format(", ".join(unsafe)))
+    for child in spec.get("children", []):
+        if isinstance(child, dict):
+            _reject_unsafe_fields(child)
+
+
+def _build_template(
+    hou: Any,
+    spec: Dict[str, Any],
+    names: set,
+    promotions: List[Dict[str, str]],
+) -> Tuple[Any, int]:
+    if not isinstance(spec, dict):
+        raise ValueError("Each parameter template must be an object")
+    _reject_unsafe_fields(spec)
+    kind = str(spec.get("type", "")).strip().lower()
+    name = str(spec.get("name", "")).strip()
+    label = str(spec.get("label") or name).strip()
+    if kind not in _TYPES:
+        raise ValueError("Unsupported parameter type: {!r}".format(kind))
+    if not _PARM_NAME.match(name):
+        raise ValueError("Invalid parameter name: {!r}".format(name))
+    if name in names:
+        raise ValueError("Duplicate parameter name: {}".format(name))
+    if not label:
+        raise ValueError("Parameter label must not be empty: {}".format(name))
+    names.add(name)
+    help_text = spec.get("help")
+
+    if kind == "folder":
+        if spec.get("promotion") is not None:
+            raise ValueError("Folders cannot promote an internal parameter: {}".format(name))
+        children = []
+        count = 1
+        for child in spec.get("children", []):
+            template, child_count = _build_template(hou, child, names, promotions)
+            children.append(template)
+            count += child_count
+        return hou.FolderParmTemplate(name, label, parm_templates=tuple(children)), count
+
+    components = int(spec.get("components", 1))
+    if components < 1 or components > 4:
+        raise ValueError("components must be between 1 and 4: {}".format(name))
+    if kind == "float":
+        kwargs = {
+            "default_value": _values(spec.get("default", 0.0), components, float),
+            "help": help_text,
+        }
+        if "min" in spec:
+            kwargs["min"] = float(spec["min"])
+            kwargs["min_is_strict"] = bool(spec.get("min_is_strict", False))
+        if "max" in spec:
+            kwargs["max"] = float(spec["max"])
+            kwargs["max_is_strict"] = bool(spec.get("max_is_strict", False))
+        if "min" in kwargs and "max" in kwargs and kwargs["min"] > kwargs["max"]:
+            raise ValueError("min cannot exceed max: {}".format(name))
+        template = hou.FloatParmTemplate(name, label, components, **kwargs)
+    elif kind == "int":
+        kwargs = {
+            "default_value": _values(spec.get("default", 0), components, int),
+            "help": help_text,
+        }
+        if "min" in spec:
+            kwargs["min"] = int(spec["min"])
+            kwargs["min_is_strict"] = bool(spec.get("min_is_strict", False))
+        if "max" in spec:
+            kwargs["max"] = int(spec["max"])
+            kwargs["max_is_strict"] = bool(spec.get("max_is_strict", False))
+        if "min" in kwargs and "max" in kwargs and kwargs["min"] > kwargs["max"]:
+            raise ValueError("min cannot exceed max: {}".format(name))
+        template = hou.IntParmTemplate(name, label, components, **kwargs)
+    elif kind == "toggle":
+        if components != 1:
+            raise ValueError("Toggle parameters have exactly one component: {}".format(name))
+        template = hou.ToggleParmTemplate(name, label, default_value=bool(spec.get("default", False)), help=help_text)
+    elif kind == "string":
+        template = hou.StringParmTemplate(
+            name,
+            label,
+            components,
+            default_value=_values(spec.get("default", ""), components, str),
+            help=help_text,
+        )
+    else:
+        if components != 1:
+            raise ValueError("Menu parameters have exactly one component: {}".format(name))
+        items = spec.get("items", [])
+        if not isinstance(items, list) or not items:
+            raise ValueError("Menu parameters require at least one item: {}".format(name))
+        tokens = [str(item.get("token", "")) for item in items]
+        labels = [str(item.get("label") or item.get("token") or "") for item in items]
+        if any(not token for token in tokens) or len(tokens) != len(set(tokens)):
+            raise ValueError("Menu item tokens must be non-empty and unique: {}".format(name))
+        default = spec.get("default", tokens[0])
+        if isinstance(default, int):
+            default_index = default
+        else:
+            if str(default) not in tokens:
+                raise ValueError("Menu default is not a declared token: {}".format(name))
+            default_index = tokens.index(str(default))
+        if default_index < 0 or default_index >= len(tokens):
+            raise ValueError("Menu default index is out of range: {}".format(name))
+        template = hou.MenuParmTemplate(
+            name,
+            label,
+            menu_items=tuple(tokens),
+            menu_labels=tuple(labels),
+            default_value=default_index,
+            help=help_text,
+        )
+
+    promotion = spec.get("promotion")
+    if promotion is not None:
+        if not isinstance(promotion, dict):
+            raise ValueError("promotion must be an object: {}".format(name))
+        source_path = str(promotion.get("source_node_path", "")).strip()
+        source_parm = str(promotion.get("source_parm", "")).strip()
+        if not source_path or not source_parm:
+            raise ValueError("promotion requires source_node_path and source_parm: {}".format(name))
+        promotions.append({"name": name, "source_node_path": source_path, "source_parm": source_parm})
+    return template, 1
+
+
+def author_hda_interface(
+    node_path: str,
+    templates: Sequence[Dict[str, Any]],
+    conflict_policy: str = "error",
+) -> dict:
+    """Apply safe parameter templates and optional native channel promotions."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not templates:
+            raise ValueError("templates must not be empty")
+        if conflict_policy not in {"error", "replace"}:
+            raise ValueError("conflict_policy must be 'error' or 'replace'")
+        node = hou.node(node_path)
+        if node is None:
+            raise ValueError("Houdini node not found: {}".format(node_path))
+        definition = node.type().definition()
+        owner = definition or node
+        group = owner.parmTemplateGroup()
+        names = set()
+        promotions: List[Dict[str, str]] = []
+        prepared = []
+        parameter_count = 0
+        for spec in templates:
+            template, count = _build_template(hou, spec, names, promotions)
+            prepared.append(template)
+            parameter_count += count
+
+        if promotions and definition is not None and node.matchesCurrentDefinition():
+            raise ValueError("HDA must be unlocked before promoting internal parameters")
+        parent_prefix = node.path().rstrip("/") + "/"
+        for promotion in promotions:
+            source = hou.node(promotion["source_node_path"])
+            if source is None or not source.path().startswith(parent_prefix):
+                raise ValueError("Promotion source must be inside the HDA: {}".format(promotion["source_node_path"]))
+            if source.parmTuple(promotion["source_parm"]) is None:
+                raise ValueError(
+                    "Source parameter tuple not found: {}/{}".format(source.path(), promotion["source_parm"])
+                )
+
+        for template in prepared:
+            existing = group.find(template.name())
+            if existing is not None and conflict_policy == "error":
+                raise ValueError("Parameter already exists: {}".format(template.name()))
+            if existing is None:
+                group.append(template)
+            else:
+                group.replace(template.name(), template)
+        owner.setParmTemplateGroup(group)
+
+        promoted = []
+        if promotions:
+            node = hou.node(node_path)
+            if node is None:
+                raise RuntimeError("HDA node disappeared while updating its interface: {}".format(node_path))
+            for promotion in promotions:
+                source = hou.node(promotion["source_node_path"])
+                source_tuple = source.parmTuple(promotion["source_parm"]) if source is not None else None
+                target_tuple = node.parmTuple(promotion["name"])
+                if source_tuple is None or target_tuple is None:
+                    raise RuntimeError("Promoted parameter tuple was not created: {}".format(promotion["name"]))
+                values = source_tuple.eval()
+                target_tuple.set(values)
+                source_tuple.set(target_tuple, language=hou.exprLanguage.Hscript)
+                promoted.append(
+                    {
+                        "name": promotion["name"],
+                        "source": "{}/{}".format(promotion["source_node_path"], promotion["source_parm"]),
+                        "component_count": len(values),
+                    }
+                )
+
+        return skill_success(
+            "Authored HDA parameter interface",
+            node_path=node.path(),
+            interface_owner="definition" if definition is not None else "node",
+            parameter_count=parameter_count,
+            top_level_parameters=[template.name() for template in prepared],
+            promoted=promoted,
+            conflict_policy=conflict_policy,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to author HDA parameter interface")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return author_hda_interface(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/publish_hda_library.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/publish_hda_library.py
@@ -1,0 +1,235 @@
+"""Publish a namespaced, versioned HDA definition with safe metadata sections."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _hda_common import hou_import_error, validate_hda_path
+
+_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+_VERSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_SECTION_PART = re.compile(r"^[A-Za-z0-9._-]+$")
+_MAX_TEXT_BYTES = 2 * 1024 * 1024
+_MAX_RESOURCE_BYTES = 64 * 1024 * 1024
+_MANIFEST_SECTION = "dcc_mcp/manifest.json"
+
+
+def _safe_relative_section(value: str) -> str:
+    value = str(value).strip().strip("/")
+    parts = value.split("/")
+    if not value or any(part in {"", ".", ".."} or not _SECTION_PART.match(part) for part in parts):
+        raise ValueError("Invalid embedded section name: {!r}".format(value))
+    return value
+
+
+def _safe_custom_section(value: str) -> str:
+    name = _safe_relative_section(value)
+    if not name.startswith("dcc_mcp/"):
+        raise ValueError("Custom sections must use the dcc_mcp/ namespace: {}".format(name))
+    if name == _MANIFEST_SECTION or name.startswith("dcc_mcp/resources/"):
+        raise ValueError("Reserved custom section name: {}".format(name))
+    return name
+
+
+def _text(value: Optional[str], field: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("{} must be a string".format(field))
+    if len(value.encode("utf-8")) > _MAX_TEXT_BYTES:
+        raise ValueError("{} exceeds the 2 MiB limit".format(field))
+    return value
+
+
+def publish_hda_library(
+    node_path: str,
+    hda_file_path: str,
+    namespace: str,
+    asset_name: str,
+    version: str,
+    label: Optional[str] = None,
+    icon: Optional[str] = None,
+    help_text: Optional[str] = None,
+    dependencies: Optional[Sequence[str]] = None,
+    custom_sections: Optional[Dict[str, str]] = None,
+    embedded_resources: Optional[Sequence[Dict[str, str]]] = None,
+    conflict_policy: str = "error",
+    update_contents: bool = True,
+    install: bool = True,
+    make_preferred: bool = False,
+) -> dict:
+    """Copy an HDA definition to a public library contract without executable sections."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        namespace = str(namespace).strip()
+        asset_name = str(asset_name).strip()
+        version = str(version).strip()
+        if not _NAME.match(namespace) or not _NAME.match(asset_name):
+            raise ValueError("namespace and asset_name must start with a letter and contain only letters, digits, '_'")
+        if not _VERSION.match(version):
+            raise ValueError("Invalid HDA version: {!r}".format(version))
+        if conflict_policy not in {"error", "overwrite"}:
+            raise ValueError("conflict_policy must be 'error' or 'overwrite'")
+        if make_preferred and not install:
+            raise ValueError("make_preferred requires install=true")
+        label = _text(label, "label")
+        icon = _text(icon, "icon")
+        help_text = _text(help_text, "help_text")
+
+        dependency_list = []
+        if len(dependencies or []) > 256:
+            raise ValueError("dependencies cannot contain more than 256 entries")
+        for dependency in dependencies or []:
+            value = str(dependency).strip()
+            if not value:
+                raise ValueError("dependencies must not contain empty paths")
+            if value not in dependency_list:
+                dependency_list.append(value)
+
+        prepared_sections = []
+        if len(custom_sections or {}) > 64:
+            raise ValueError("custom_sections cannot contain more than 64 entries")
+        for raw_name, contents in (custom_sections or {}).items():
+            name = _safe_custom_section(raw_name)
+            contents = _text(contents, "custom section {}".format(name))
+            if contents is None:
+                raise ValueError("custom section contents must be a string: {}".format(name))
+            prepared_sections.append((name, contents))
+
+        prepared_resources: List[dict] = []
+        if len(embedded_resources or []) > 64:
+            raise ValueError("embedded_resources cannot contain more than 64 entries")
+        section_names = {name for name, _contents in prepared_sections}
+        resource_bytes = 0
+        for resource in embedded_resources or []:
+            if not isinstance(resource, dict):
+                raise ValueError("embedded_resources entries must be objects")
+            path = Path(str(resource.get("file_path", ""))).expanduser()
+            if not path.is_file():
+                raise FileNotFoundError("Embedded resource not found: {}".format(path))
+            if path.stat().st_size > _MAX_RESOURCE_BYTES:
+                raise ValueError("Embedded resource exceeds the 64 MiB limit: {}".format(path))
+            relative_name = _safe_relative_section(resource.get("section_name", ""))
+            section_name = "dcc_mcp/resources/{}".format(relative_name)
+            if section_name in section_names:
+                raise ValueError("Duplicate embedded section name: {}".format(section_name))
+            section_names.add(section_name)
+            contents = path.read_bytes()
+            resource_bytes += len(contents)
+            if resource_bytes > 256 * 1024 * 1024:
+                raise ValueError("Embedded resources exceed the 256 MiB library limit")
+            prepared_resources.append(
+                {
+                    "source_path": str(path),
+                    "section": section_name,
+                    "contents": contents,
+                    "size": len(contents),
+                    "sha256": hashlib.sha256(contents).hexdigest(),
+                }
+            )
+
+        node = hou.node(node_path)
+        if node is None:
+            raise ValueError("Houdini node not found: {}".format(node_path))
+        source_definition = node.type().definition()
+        if source_definition is None:
+            raise ValueError("Node is not a Houdini Digital Asset: {}".format(node_path))
+        target_path = validate_hda_path(hda_file_path, must_exist=False)
+        target_name = hou.hda.fullNodeTypeNameFromComponents("", namespace, asset_name, version)
+        existing_names = []
+        if target_path.is_file():
+            existing_names = [definition.nodeTypeName() for definition in hou.hda.definitionsInFile(str(target_path))]
+        if target_name in existing_names and conflict_policy == "error":
+            raise ValueError("HDA definition already exists: {}".format(target_name))
+
+        contents_updated = bool(update_contents and not node.matchesCurrentDefinition())
+        if contents_updated:
+            source_definition.updateFromNode(node)
+
+        menu_name = label or source_definition.description() or asset_name
+        source_definition.copyToHDAFile(str(target_path), new_name=target_name, new_menu_name=menu_name)
+        published = next(
+            (
+                definition
+                for definition in hou.hda.definitionsInFile(str(target_path))
+                if definition.nodeTypeName() == target_name
+            ),
+            None,
+        )
+        if published is None:
+            raise RuntimeError("Published HDA definition could not be reopened: {}".format(target_name))
+
+        published.setVersion(version)
+        published.setDescription(menu_name)
+        if icon:
+            published.setIcon(icon)
+        if help_text is not None:
+            published.addSection("Help", help_text)
+        for section_name, contents in prepared_sections:
+            published.addSection(section_name, contents)
+        for resource in prepared_resources:
+            published.addSection(resource["section"], resource["contents"])
+
+        manifest = {
+            "schema_version": 1,
+            "node_type_name": target_name,
+            "namespace": namespace,
+            "asset_name": asset_name,
+            "version": version,
+            "dependencies": dependency_list,
+            "custom_sections": sorted(name for name, _contents in prepared_sections),
+            "resources": [
+                {"section": item["section"], "sha256": item["sha256"], "size": item["size"]}
+                for item in prepared_resources
+            ],
+        }
+        published.addSection(_MANIFEST_SECTION, json.dumps(manifest, indent=2, sort_keys=True))
+
+        if install:
+            hou.hda.installFile(str(target_path), force_use_assets=bool(make_preferred))
+
+        return skill_success(
+            "Published HDA library",
+            source_node=node.path(),
+            hda_file_path=str(target_path),
+            node_type_name=target_name,
+            namespace=namespace,
+            asset_name=asset_name,
+            version=version,
+            conflict_policy=conflict_policy,
+            overwritten=target_name in existing_names,
+            contents_updated=contents_updated,
+            installed=bool(install),
+            preferred=bool(make_preferred),
+            sections=sorted(set(section_names) | {_MANIFEST_SECTION} | ({"Help"} if help_text is not None else set())),
+            dependency_count=len(dependency_list),
+            resource_count=len(prepared_resources),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to publish HDA library")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return publish_hda_library(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/validate_hda_contract.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/validate_hda_contract.py
@@ -1,0 +1,370 @@
+"""Validate a reusable HDA definition, interface, dependencies, and instantiation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _hda_common import hou_import_error, validate_hda_path
+
+_MANIFEST_SECTION = "dcc_mcp/manifest.json"
+
+
+def _path_key(value: Any) -> str:
+    return os.path.normcase(os.path.abspath(os.path.expanduser(str(value))))
+
+
+def _diagnostic(items: List[dict], code: str, message: str, severity: str = "error", **context: Any) -> None:
+    entry = {"code": code, "severity": severity, "message": message}
+    if context:
+        entry["context"] = context
+    items.append(entry)
+
+
+def _definition_from_session(hou: Any, node_type_name: str) -> Optional[Any]:
+    for category in hou.nodeTypeCategories().values():
+        try:
+            node_type = category.nodeTypes().get(node_type_name)
+        except Exception:  # noqa: BLE001
+            node_type = None
+        if node_type is not None:
+            try:
+                return node_type.definition()
+            except Exception:  # noqa: BLE001
+                return None
+    return None
+
+
+def _template_type(template: Any) -> str:
+    try:
+        return str(template.type().name()).lower()
+    except Exception:  # noqa: BLE001
+        return type(template).__name__.replace("ParmTemplate", "").lower()
+
+
+def _interface_templates(entries: Sequence[Any], diagnostics: List[dict], path: str = "") -> List[dict]:
+    templates = []
+    for template in entries:
+        name = template.name()
+        kind = _template_type(template)
+        qualified = "{}/{}".format(path, name).strip("/")
+        summary = {"name": name, "label": template.label(), "type": kind, "path": qualified}
+        try:
+            summary["components"] = int(template.numComponents())
+        except Exception:  # noqa: BLE001
+            summary["components"] = 0 if kind == "folder" else 1
+        templates.append(summary)
+        for attr in ("scriptCallback", "itemGeneratorScript"):
+            callback = getattr(template, attr, None)
+            if callable(callback):
+                try:
+                    value = callback()
+                except Exception:  # noqa: BLE001
+                    value = ""
+                if isinstance(value, str) and value.strip():
+                    _diagnostic(
+                        diagnostics,
+                        "unsafe_callback",
+                        "Executable parameter callbacks are not allowed",
+                        parameter=name,
+                        callback_kind=attr,
+                    )
+        children = getattr(template, "parmTemplates", None)
+        if kind == "folder" and callable(children):
+            templates.extend(_interface_templates(children(), diagnostics, qualified))
+    return templates
+
+
+def _section_contents(section: Any) -> bytes:
+    contents = section.contents()
+    return contents.encode("utf-8") if isinstance(contents, str) else bytes(contents)
+
+
+def validate_hda_contract(
+    node_type_name: str,
+    hda_file: Optional[str] = None,
+    expected_version: Optional[str] = None,
+    required_parameters: Optional[Sequence[Dict[str, str]]] = None,
+    required_sections: Optional[Sequence[str]] = None,
+    require_namespace: bool = True,
+    require_type_version: bool = True,
+    require_manifest: bool = False,
+    check_dependencies: bool = True,
+    instantiate: bool = True,
+    parent_path: str = "/obj",
+) -> dict:
+    """Return structured diagnostics for a namespaced, versioned HDA contract."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    installed_for_validation = False
+    library_path = None
+    diagnostics: List[dict] = []
+    try:
+        node_type_name = str(node_type_name).strip()
+        if not node_type_name:
+            raise ValueError("node_type_name must not be empty")
+        if hda_file:
+            library_path = validate_hda_path(hda_file, must_exist=True)
+            definitions = list(hou.hda.definitionsInFile(str(library_path)))
+            definition = next((item for item in definitions if item.nodeTypeName() == node_type_name), None)
+        else:
+            definition = _definition_from_session(hou, node_type_name)
+        if definition is None:
+            _diagnostic(
+                diagnostics, "definition_not_found", "HDA definition was not found", node_type_name=node_type_name
+            )
+            return skill_success(
+                "HDA contract is invalid",
+                valid=False,
+                node_type_name=node_type_name,
+                hda_file=str(library_path) if library_path else None,
+                diagnostics=diagnostics,
+                error_count=1,
+                warning_count=0,
+                interface=[],
+                instantiable=False if instantiate else None,
+            )
+
+        if library_path is not None:
+            loaded = {_path_key(path) for path in hou.hda.loadedFiles()}
+            if _path_key(library_path) not in loaded:
+                hou.hda.installFile(str(library_path))
+                installed_for_validation = True
+                definition = next(
+                    item
+                    for item in hou.hda.definitionsInFile(str(library_path))
+                    if item.nodeTypeName() == node_type_name
+                )
+
+        actual_name = definition.nodeTypeName()
+        actual_version = definition.version() or ""
+        try:
+            _scope, namespace, asset_name, type_version = hou.hda.componentsFromFullNodeTypeName(actual_name)
+        except Exception as exc:  # noqa: BLE001
+            namespace, asset_name, type_version = "", actual_name, ""
+            _diagnostic(diagnostics, "invalid_node_type_name", str(exc), node_type_name=actual_name)
+        if require_namespace and not namespace:
+            _diagnostic(diagnostics, "missing_namespace", "HDA node type name has no namespace")
+        if require_type_version and not type_version:
+            _diagnostic(diagnostics, "missing_type_version", "HDA node type name has no version component")
+        if type_version and actual_version and type_version != actual_version:
+            _diagnostic(
+                diagnostics,
+                "version_mismatch",
+                "HDA metadata version does not match its node type version",
+                type_version=type_version,
+                definition_version=actual_version,
+            )
+        if expected_version is not None and actual_version != str(expected_version):
+            _diagnostic(
+                diagnostics,
+                "unexpected_version",
+                "HDA definition version does not match the expected version",
+                expected=str(expected_version),
+                actual=actual_version,
+            )
+
+        sections = definition.sections()
+        section_names = sorted(sections)
+        for section_name in required_sections or []:
+            if section_name not in sections:
+                _diagnostic(
+                    diagnostics,
+                    "missing_section",
+                    "Required HDA section is missing",
+                    section=section_name,
+                )
+
+        interface = _interface_templates(definition.parmTemplateGroup().entries(), diagnostics)
+        by_name = {}
+        for template in interface:
+            if template["name"] in by_name:
+                _diagnostic(
+                    diagnostics,
+                    "duplicate_parameter",
+                    "Parameter name occurs more than once",
+                    parameter=template["name"],
+                )
+            by_name[template["name"]] = template
+        for requirement in required_parameters or []:
+            name = str(requirement.get("name", ""))
+            expected_type = str(requirement.get("type", "")).lower()
+            actual = by_name.get(name)
+            if actual is None:
+                _diagnostic(diagnostics, "missing_parameter", "Required parameter is missing", parameter=name)
+            elif expected_type and actual["type"] != expected_type:
+                _diagnostic(
+                    diagnostics,
+                    "parameter_type_mismatch",
+                    "Required parameter has a different type",
+                    parameter=name,
+                    expected=expected_type,
+                    actual=actual["type"],
+                )
+
+        manifest = None
+        manifest_section = sections.get(_MANIFEST_SECTION)
+        if manifest_section is None:
+            _diagnostic(
+                diagnostics,
+                "missing_manifest",
+                "HDA dependency manifest is missing",
+                severity="error" if require_manifest else "warning",
+            )
+        else:
+            try:
+                manifest = json.loads(_section_contents(manifest_section).decode("utf-8"))
+            except Exception as exc:  # noqa: BLE001
+                _diagnostic(diagnostics, "invalid_manifest", "HDA dependency manifest is invalid", details=str(exc))
+        if isinstance(manifest, dict):
+            if manifest.get("schema_version") != 1:
+                _diagnostic(diagnostics, "unsupported_manifest", "Unsupported HDA manifest schema version")
+            if manifest.get("node_type_name") and manifest["node_type_name"] != actual_name:
+                _diagnostic(diagnostics, "manifest_name_mismatch", "Manifest node type name does not match definition")
+            if manifest.get("version") and manifest["version"] != actual_version:
+                _diagnostic(diagnostics, "manifest_version_mismatch", "Manifest version does not match definition")
+            for custom_section in manifest.get("custom_sections", []):
+                if custom_section not in sections:
+                    _diagnostic(
+                        diagnostics,
+                        "missing_section",
+                        "Manifest custom section is missing",
+                        section=custom_section,
+                    )
+            for resource in manifest.get("resources", []):
+                section_name = resource.get("section") if isinstance(resource, dict) else None
+                if not section_name or section_name not in sections:
+                    _diagnostic(
+                        diagnostics,
+                        "missing_resource",
+                        "Manifest embedded resource is missing",
+                        section=section_name,
+                    )
+                    continue
+                expected_sha = resource.get("sha256")
+                if expected_sha:
+                    actual_sha = hashlib.sha256(_section_contents(sections[section_name])).hexdigest()
+                    if actual_sha != expected_sha:
+                        _diagnostic(
+                            diagnostics,
+                            "resource_checksum_mismatch",
+                            "Embedded resource checksum does not match the manifest",
+                            section=section_name,
+                        )
+            if check_dependencies:
+                for dependency in manifest.get("dependencies", []):
+                    if not isinstance(dependency, str) or not dependency.strip():
+                        _diagnostic(diagnostics, "invalid_dependency", "Manifest dependency path is invalid")
+                        continue
+                    expanded = hou.expandString(dependency)
+                    if not Path(expanded).expanduser().exists():
+                        _diagnostic(
+                            diagnostics,
+                            "missing_dependency",
+                            "External HDA dependency does not exist",
+                            dependency=dependency,
+                            expanded_path=expanded,
+                        )
+
+        instantiable = None
+        if instantiate:
+            instantiable = False
+            parent = hou.node(parent_path)
+            if parent is None:
+                _diagnostic(
+                    diagnostics, "parent_not_found", "Validation parent node was not found", parent_path=parent_path
+                )
+            else:
+                instance = None
+                try:
+                    instance = parent.createNode(
+                        actual_name,
+                        node_name="__dcc_mcp_hda_contract__",
+                        run_init_scripts=False,
+                        exact_type_name=True,
+                    )
+                    instance_definition = instance.type().definition()
+                    if instance_definition is None or instance_definition.nodeTypeName() != actual_name:
+                        _diagnostic(
+                            diagnostics,
+                            "instantiated_definition_mismatch",
+                            "Temporary instance did not resolve to the requested exact HDA definition",
+                        )
+                    elif library_path is not None and _path_key(instance_definition.libraryFilePath()) != _path_key(
+                        library_path
+                    ):
+                        _diagnostic(
+                            diagnostics,
+                            "instantiated_library_mismatch",
+                            "Temporary instance resolved to the same node type from a different HDA library",
+                            expected_library=str(library_path),
+                            actual_library=instance_definition.libraryFilePath(),
+                        )
+                    else:
+                        instantiable = True
+                except Exception as exc:  # noqa: BLE001
+                    _diagnostic(diagnostics, "instantiation_failed", "HDA could not be instantiated", details=str(exc))
+                finally:
+                    if instance is not None:
+                        try:
+                            instance.destroy()
+                        except Exception as exc:  # noqa: BLE001
+                            _diagnostic(
+                                diagnostics,
+                                "probe_cleanup_failed",
+                                "Temporary HDA validation node could not be removed",
+                                details=str(exc),
+                            )
+
+        error_count = sum(item["severity"] == "error" for item in diagnostics)
+        warning_count = sum(item["severity"] == "warning" for item in diagnostics)
+        valid = error_count == 0 and instantiable is not False
+        return skill_success(
+            "HDA contract is valid" if valid else "HDA contract is invalid",
+            valid=valid,
+            node_type_name=actual_name,
+            namespace=namespace,
+            asset_name=asset_name,
+            type_version=type_version,
+            definition_version=actual_version,
+            hda_file=str(library_path) if library_path else definition.libraryFilePath(),
+            sections=section_names,
+            interface=interface,
+            manifest=manifest,
+            instantiable=instantiable,
+            diagnostics=diagnostics,
+            error_count=error_count,
+            warning_count=warning_count,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate HDA contract")
+    finally:
+        if installed_for_validation and library_path is not None:
+            try:
+                hou.hda.uninstallFile(str(library_path))
+            except Exception:  # noqa: BLE001
+                pass
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return validate_hda_contract(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
@@ -293,3 +293,251 @@ tools:
       read_only_hint: false
       destructive_hint: false
       idempotent_hint: false
+
+  - name: author_hda_interface
+    description: >-
+      Declaratively author a safe HDA/subnet parameter interface with folders,
+      numeric ranges, toggles, strings, static menus, and native channel
+      promotion. Executable callbacks and menu-generator scripts are rejected.
+    input_schema:
+      type: object
+      required: [node_path, templates]
+      properties:
+        node_path:
+          type: string
+          description: "HDA instance or subnet that owns the parameter interface."
+        templates:
+          type: array
+          minItems: 1
+          description: "Safe declarative parameter templates; folder entries may contain child entries."
+          items:
+            type: object
+            required: [type, name]
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                enum: [folder, float, int, toggle, string, menu]
+              name:
+                type: string
+              label:
+                type: string
+              help:
+                type: string
+              components:
+                type: integer
+                minimum: 1
+                maximum: 4
+                default: 1
+              default:
+                description: "Scalar or component list; menu defaults use a declared token or zero-based index."
+              min:
+                type: number
+              max:
+                type: number
+              min_is_strict:
+                type: boolean
+                default: false
+              max_is_strict:
+                type: boolean
+                default: false
+              items:
+                type: array
+                items:
+                  type: object
+                  required: [token]
+                  additionalProperties: false
+                  properties:
+                    token: {type: string}
+                    label: {type: string}
+              children:
+                type: array
+                items: {type: object}
+              promotion:
+                type: object
+                required: [source_node_path, source_parm]
+                additionalProperties: false
+                properties:
+                  source_node_path: {type: string}
+                  source_parm: {type: string}
+        conflict_policy:
+          type: string
+          enum: [error, replace]
+          default: error
+          description: "Reject existing top-level names, or explicitly replace them."
+    read_only: false
+    destructive: true
+    idempotent: false
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 120
+    source_file: scripts/author_hda_interface.py
+    tool_role: action
+    risk: high
+    search_aliases: [author hda interface, create hda controls, hda parameter template, promote hda control]
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    next-tools:
+      on-success:
+        - houdini_hda__publish_hda_library
+      on-failure:
+        - houdini_parameters__get_parm_templates
+
+  - name: publish_hda_library
+    description: >-
+      Publish an existing HDA definition under an explicit namespace and
+      version, with an explicit conflict policy, icon/help, safe dcc_mcp/
+      metadata sections, dependency manifest, and bounded embedded resources.
+      Event-handler and arbitrary executable sections are not accepted.
+    input_schema:
+      type: object
+      required: [node_path, hda_file_path, namespace, asset_name, version]
+      additionalProperties: false
+      properties:
+        node_path:
+          type: string
+        hda_file_path:
+          type: string
+        namespace:
+          type: string
+        asset_name:
+          type: string
+        version:
+          type: string
+        label:
+          type: string
+        icon:
+          type: string
+          description: "Houdini icon name or search-path reference."
+        help_text:
+          type: string
+          description: "Static embedded Help section text."
+        dependencies:
+          type: array
+          items: {type: string}
+          default: []
+        custom_sections:
+          type: object
+          description: "Static text sections whose names must start with dcc_mcp/."
+          additionalProperties: {type: string}
+        embedded_resources:
+          type: array
+          default: []
+          items:
+            type: object
+            required: [file_path, section_name]
+            additionalProperties: false
+            properties:
+              file_path: {type: string}
+              section_name:
+                type: string
+                description: "Relative name stored below dcc_mcp/resources/."
+        conflict_policy:
+          type: string
+          enum: [error, overwrite]
+          default: error
+        update_contents:
+          type: boolean
+          default: true
+          description: "Publish unlocked instance contents before copying the definition."
+        install:
+          type: boolean
+          default: true
+          description: "Install the published library in the current Houdini session."
+        make_preferred:
+          type: boolean
+          default: false
+          description: "Mark the installed definition preferred; requires install=true."
+    read_only: false
+    destructive: true
+    idempotent: false
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 300
+    source_file: scripts/publish_hda_library.py
+    tool_role: action
+    risk: high
+    search_aliases: [publish hda library, version hda, namespace hda, embed hda resources, hda manifest]
+    produces: ["file:hda"]
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: false
+    next-tools:
+      on-success:
+        - houdini_hda__validate_hda_contract
+      on-failure:
+        - houdini_hda__list_hda_definitions
+
+  - name: validate_hda_contract
+    description: >-
+      Validate an HDA definition's namespace/version, safe parameter interface,
+      required sections, dependency/resource manifest, and exact temporary
+      instantiation. Returns structured diagnostics and removes the probe node.
+    input_schema:
+      type: object
+      required: [node_type_name]
+      additionalProperties: false
+      properties:
+        node_type_name:
+          type: string
+        hda_file:
+          type: string
+          description: "Optional HDA file to inspect and temporarily install for instantiation."
+        expected_version:
+          type: string
+        required_parameters:
+          type: array
+          default: []
+          items:
+            type: object
+            required: [name]
+            additionalProperties: false
+            properties:
+              name: {type: string}
+              type:
+                type: string
+                enum: [folder, float, int, toggle, string, menu]
+        required_sections:
+          type: array
+          items: {type: string}
+          default: []
+        require_namespace:
+          type: boolean
+          default: true
+        require_type_version:
+          type: boolean
+          default: true
+        require_manifest:
+          type: boolean
+          default: false
+        check_dependencies:
+          type: boolean
+          default: true
+        instantiate:
+          type: boolean
+          default: true
+        parent_path:
+          type: string
+          default: /obj
+    read_only: false
+    destructive: false
+    idempotent: true
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 120
+    source_file: scripts/validate_hda_contract.py
+    tool_role: action
+    risk: medium
+    search_aliases: [validate hda contract, check hda interface, verify hda dependencies, test hda instantiation]
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    next-tools:
+      on-success:
+        - houdini_hda__execute_hda
+      on-failure:
+        - houdini_hda_automation__inspect_hda_definition

--- a/tests/test_hda_contract_tools.py
+++ b/tests/test_hda_contract_tools.py
@@ -1,0 +1,386 @@
+"""Mock-HOM tests for declarative HDA authoring, publishing, and validation."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS = Path(__file__).parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-hda" / "scripts"
+
+
+def _load_script(name: str) -> ModuleType:
+    path = _SCRIPTS / name
+    spec = importlib.util.spec_from_file_location("hda_contract_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Template:
+    def __init__(self, name: str, label: str, kind: str, children=(), **settings) -> None:
+        self._name = name
+        self._label = label
+        self._kind = kind
+        self._children = tuple(children)
+        self.settings = settings
+
+    def name(self) -> str:
+        return self._name
+
+    def label(self) -> str:
+        return self._label
+
+    def type(self):
+        return SimpleNamespace(name=lambda: self._kind)
+
+    def numComponents(self) -> int:
+        return int(self.settings.get("num_components", 1))
+
+    def parmTemplates(self):
+        return self._children
+
+    def scriptCallback(self) -> str:
+        return self.settings.get("script_callback", "")
+
+    def itemGeneratorScript(self) -> str:
+        return self.settings.get("item_generator_script", "")
+
+
+class _Group:
+    def __init__(self, entries=()) -> None:
+        self._entries = list(entries)
+
+    def entries(self):
+        return tuple(self._entries)
+
+    def find(self, name):
+        return next((entry for entry in self._entries if entry.name() == name), None)
+
+    def append(self, template) -> None:
+        self._entries.append(template)
+
+    def replace(self, name, template) -> None:
+        index = next(i for i, entry in enumerate(self._entries) if entry.name() == name)
+        self._entries[index] = template
+
+
+def _template_api():
+    def factory(kind):
+        def build(name, label, *args, **kwargs):
+            if kind == "Folder":
+                children = kwargs.pop("parm_templates", args[0] if args else ())
+                return _Template(name, label, kind, children, **kwargs)
+            if kind in {"Float", "Int", "String"}:
+                kwargs["num_components"] = args[0]
+            return _Template(name, label, kind, **kwargs)
+
+        return build
+
+    return {
+        "FloatParmTemplate": factory("Float"),
+        "IntParmTemplate": factory("Int"),
+        "ToggleParmTemplate": factory("Toggle"),
+        "StringParmTemplate": factory("String"),
+        "MenuParmTemplate": factory("Menu"),
+        "FolderParmTemplate": factory("Folder"),
+    }
+
+
+def test_author_hda_interface_builds_safe_templates_and_promotion() -> None:
+    mod = _load_script("author_hda_interface.py")
+    group = _Group()
+    definition = MagicMock()
+    definition.parmTemplateGroup.return_value = group
+    node_type = MagicMock()
+    node_type.definition.return_value = definition
+    target_tuple = MagicMock()
+    node = MagicMock()
+    node.path.return_value = "/obj/planet"
+    node.type.return_value = node_type
+    node.matchesCurrentDefinition.return_value = False
+    node.parmTuple.return_value = target_tuple
+    source_tuple = MagicMock()
+    source_tuple.eval.return_value = (2.5,)
+    source = MagicMock()
+    source.path.return_value = "/obj/planet/noise"
+    source.parmTuple.return_value = source_tuple
+    mock_hou = MagicMock(**_template_api())
+    mock_hou.node.side_effect = lambda path: {"/obj/planet": node, "/obj/planet/noise": source}.get(path)
+
+    specs = [
+        {
+            "type": "folder",
+            "name": "surface",
+            "label": "Surface",
+            "children": [
+                {
+                    "type": "float",
+                    "name": "relief",
+                    "label": "Relief",
+                    "default": 0.25,
+                    "min": 0.0,
+                    "max": 4.0,
+                    "promotion": {"source_node_path": "/obj/planet/noise", "source_parm": "amplitude"},
+                },
+                {"type": "int", "name": "octaves", "label": "Octaves", "default": 5, "min": 1, "max": 12},
+                {"type": "toggle", "name": "clouds", "label": "Clouds", "default": True},
+                {"type": "string", "name": "texture", "label": "Texture", "default": "$HIP/earth.exr"},
+                {
+                    "type": "menu",
+                    "name": "quality",
+                    "label": "Quality",
+                    "items": [{"token": "preview", "label": "Preview"}, {"token": "final", "label": "Final"}],
+                    "default": "final",
+                },
+            ],
+        }
+    ]
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.author_hda_interface("/obj/planet", specs)
+
+    assert result["success"] is True
+    assert result["context"]["parameter_count"] == 6
+    assert result["context"]["promoted"] == [
+        {"name": "relief", "source": "/obj/planet/noise/amplitude", "component_count": 1}
+    ]
+    definition.setParmTemplateGroup.assert_called_once_with(group)
+    assert group.entries()[0].name() == "surface"
+    assert [entry.name() for entry in group.entries()[0].parmTemplates()] == [
+        "relief",
+        "octaves",
+        "clouds",
+        "texture",
+        "quality",
+    ]
+    target_tuple.set.assert_called_once_with((2.5,))
+    source_tuple.set.assert_called_once_with(target_tuple, language=mock_hou.exprLanguage.Hscript)
+
+
+def test_author_hda_interface_rejects_script_fields() -> None:
+    mod = _load_script("author_hda_interface.py")
+    mock_hou = MagicMock(**_template_api())
+    node = MagicMock()
+    mock_hou.node.return_value = node
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.author_hda_interface(
+            "/obj/asset",
+            [{"type": "float", "name": "gain", "label": "Gain", "script_callback": "danger()"}],
+        )
+
+    assert result["success"] is False
+    assert "not allowed" in str(result["error"])
+
+
+def test_author_hda_interface_accepts_one_sided_numeric_ranges() -> None:
+    mod = _load_script("author_hda_interface.py")
+    group = _Group()
+    node = MagicMock()
+    node.path.return_value = "/obj/asset"
+    node.type.return_value.definition.return_value = None
+    node.parmTemplateGroup.return_value = group
+    mock_hou = MagicMock(**_template_api())
+    mock_hou.node.return_value = node
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.author_hda_interface(
+            "/obj/asset",
+            [
+                {"type": "float", "name": "large", "label": "Large", "min": 20.0},
+                {"type": "int", "name": "negative", "label": "Negative", "max": -5},
+            ],
+        )
+
+    assert result["success"] is True
+    node.setParmTemplateGroup.assert_called_once_with(group)
+
+
+def test_publish_hda_library_namespaces_versions_and_embeds_manifest(tmp_path: Path) -> None:
+    mod = _load_script("publish_hda_library.py")
+    resource = tmp_path / "earth_albedo.exr"
+    resource.write_bytes(b"texture")
+    target = tmp_path / "planets.hda"
+    source_definition = MagicMock()
+    source_definition.description.return_value = "Planet"
+    published = MagicMock()
+    published.nodeTypeName.return_value = "studio::planet::1.2.0"
+    source_type = MagicMock()
+    source_type.definition.return_value = source_definition
+    node = MagicMock()
+    node.type.return_value = source_type
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = node
+    mock_hou.hda.fullNodeTypeNameFromComponents.return_value = "studio::planet::1.2.0"
+    mock_hou.hda.definitionsInFile.return_value = [published]
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.publish_hda_library(
+            "/obj/planet",
+            str(target),
+            namespace="studio",
+            asset_name="planet",
+            version="1.2.0",
+            label="Procedural Planet",
+            icon="MISC_digital_asset",
+            help_text="# Procedural Planet",
+            dependencies=["$JOB/textures/stars.exr"],
+            custom_sections={"dcc_mcp/provenance.json": "{}"},
+            embedded_resources=[{"file_path": str(resource), "section_name": "textures/earth_albedo.exr"}],
+            install=False,
+        )
+
+    assert result["success"] is True
+    source_definition.copyToHDAFile.assert_called_once_with(
+        str(target), new_name="studio::planet::1.2.0", new_menu_name="Procedural Planet"
+    )
+    published.setVersion.assert_called_once_with("1.2.0")
+    published.setDescription.assert_called_once_with("Procedural Planet")
+    published.setIcon.assert_called_once_with("MISC_digital_asset")
+    sections = {call.args[0]: call.args[1] for call in published.addSection.call_args_list}
+    assert sections["Help"] == "# Procedural Planet"
+    assert sections["dcc_mcp/provenance.json"] == "{}"
+    assert sections["dcc_mcp/resources/textures/earth_albedo.exr"] == b"texture"
+    manifest = json.loads(sections["dcc_mcp/manifest.json"])
+    assert manifest["node_type_name"] == "studio::planet::1.2.0"
+    assert manifest["dependencies"] == ["$JOB/textures/stars.exr"]
+    assert manifest["resources"][0]["sha256"]
+
+
+def test_publish_hda_library_requires_explicit_overwrite(tmp_path: Path) -> None:
+    mod = _load_script("publish_hda_library.py")
+    target = tmp_path / "planets.hda"
+    target.write_bytes(b"existing")
+    existing = MagicMock()
+    existing.nodeTypeName.return_value = "studio::planet::1.2.0"
+    source_definition = MagicMock()
+    node = MagicMock()
+    node.type.return_value.definition.return_value = source_definition
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = node
+    mock_hou.hda.fullNodeTypeNameFromComponents.return_value = "studio::planet::1.2.0"
+    mock_hou.hda.definitionsInFile.return_value = [existing]
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.publish_hda_library(
+            "/obj/planet",
+            str(target),
+            namespace="studio",
+            asset_name="planet",
+            version="1.2.0",
+            conflict_policy="error",
+            install=False,
+        )
+
+    assert result["success"] is False
+    assert "already exists" in str(result["error"])
+    source_definition.updateFromNode.assert_not_called()
+    source_definition.copyToHDAFile.assert_not_called()
+
+
+def test_validate_hda_contract_checks_definition_interface_dependencies_and_instantiation(tmp_path: Path) -> None:
+    mod = _load_script("validate_hda_contract.py")
+    library = tmp_path / "planets.hda"
+    library.write_bytes(b"hda")
+    dependency = tmp_path / "stars.exr"
+    dependency.write_bytes(b"stars")
+    manifest = {
+        "schema_version": 1,
+        "node_type_name": "studio::planet::1.2.0",
+        "version": "1.2.0",
+        "dependencies": [str(dependency)],
+        "resources": [
+            {
+                "section": "dcc_mcp/resources/earth.exr",
+                "sha256": hashlib.sha256(b"abc").hexdigest(),
+                "size": 3,
+            }
+        ],
+    }
+    manifest_section = MagicMock()
+    manifest_section.contents.return_value = json.dumps(manifest)
+    resource_section = MagicMock()
+    resource_section.contents.return_value = b"abc"
+    definition = MagicMock()
+    definition.nodeTypeName.return_value = "studio::planet::1.2.0"
+    definition.version.return_value = "1.2.0"
+    definition.libraryFilePath.return_value = str(library)
+    definition.sections.return_value = {
+        "Help": MagicMock(),
+        "dcc_mcp/manifest.json": manifest_section,
+        "dcc_mcp/resources/earth.exr": resource_section,
+    }
+    definition.parmTemplateGroup.return_value = _Group([_Template("relief", "Relief", "Float")])
+    instance_type = MagicMock()
+    instance_type.definition.return_value = definition
+    instance = MagicMock()
+    instance.type.return_value = instance_type
+    parent = MagicMock()
+    parent.createNode.return_value = instance
+    mock_hou = MagicMock()
+    mock_hou.hda.definitionsInFile.return_value = [definition]
+    mock_hou.hda.loadedFiles.return_value = []
+    mock_hou.hda.componentsFromFullNodeTypeName.return_value = ("", "studio", "planet", "1.2.0")
+    mock_hou.node.return_value = parent
+    mock_hou.expandString.side_effect = lambda value: value
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.validate_hda_contract(
+            "studio::planet::1.2.0",
+            hda_file=str(library),
+            expected_version="1.2.0",
+            required_parameters=[{"name": "relief", "type": "float"}],
+            required_sections=["Help"],
+        )
+
+    assert result["success"] is True
+    assert result["context"]["valid"] is True
+    assert result["context"]["instantiable"] is True
+    parent.createNode.assert_called_once_with(
+        "studio::planet::1.2.0",
+        node_name="__dcc_mcp_hda_contract__",
+        run_init_scripts=False,
+        exact_type_name=True,
+    )
+    instance.destroy.assert_called_once_with()
+    mock_hou.hda.installFile.assert_called_once_with(str(library))
+    mock_hou.hda.uninstallFile.assert_called_once_with(str(library))
+
+
+def test_validate_hda_contract_reports_callbacks_and_missing_dependency(tmp_path: Path) -> None:
+    mod = _load_script("validate_hda_contract.py")
+    missing = tmp_path / "missing.exr"
+    manifest_section = MagicMock()
+    manifest_section.contents.return_value = json.dumps(
+        {"schema_version": 1, "dependencies": [str(missing)], "resources": []}
+    )
+    definition = MagicMock()
+    definition.nodeTypeName.return_value = "studio::planet::1.2.0"
+    definition.version.return_value = "1.2.0"
+    definition.sections.return_value = {"dcc_mcp/manifest.json": manifest_section}
+    definition.parmTemplateGroup.return_value = _Group(
+        [_Template("unsafe", "Unsafe", "String", script_callback="danger()")]
+    )
+    mock_hou = MagicMock()
+    mock_hou.hda.componentsFromFullNodeTypeName.return_value = ("", "studio", "planet", "1.2.0")
+    mock_hou.nodeTypeCategories.return_value = {
+        "Sop": SimpleNamespace(
+            nodeTypes=lambda: {"studio::planet::1.2.0": SimpleNamespace(definition=lambda: definition)}
+        )
+    }
+    mock_hou.expandString.side_effect = lambda value: value
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.validate_hda_contract("studio::planet::1.2.0", instantiate=False)
+
+    assert result["success"] is True
+    assert result["context"]["valid"] is False
+    codes = {item["code"] for item in result["context"]["diagnostics"]}
+    assert {"unsafe_callback", "missing_dependency"}.issubset(codes)


### PR DESCRIPTION
## Summary

- add safe declarative HDA interfaces for folders, numeric controls, toggles, strings, static menus, ranges, labels, and native parameter promotion
- publish explicitly namespaced and versioned HDA libraries with conflict policy, icon/help metadata, bounded embedded resources, and a deterministic dependency manifest
- validate definition identity, interface safety, version metadata, dependencies, resource checksums, and exact instantiability with structured diagnostics

Executable callbacks, menu-generator scripts, arbitrary event handlers, and unbounded embedded payloads are not accepted by these contracts.

## Validation

- `506 passed, 1 skipped, 3 deselected`
- Ruff lint and format checks
- Python 3.7 syntax compatibility
- standalone skill validation: 31 skills, 0 errors, 0 warnings
- wheel and source distribution build
- isolated Houdini 21 author -> publish -> validate regression with an exact namespaced definition, embedded resource checksum, zero diagnostics, and successful temporary instantiation