### PR TITLE
feat: add read-only Karma stage diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ When adding or changing bundled skills, load the project skill:
 ### pipeline stage (load on demand)
 | Skill | Key tools |
 |-------|-----------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 194 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 195 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 ### pipeline (load on demand)
 | Skill | Tools |
 |-------|-------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |

--- a/llms.txt
+++ b/llms.txt
@@ -68,7 +68,7 @@ server.list_skills()
 - `houdini_import_to_scene__import_to_scene`
 
 ### pipeline (load on demand)
-- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
+- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
 - `houdini_karma__configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output`
 - `houdini_husk__render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
 - `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -29,6 +29,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | HDRI environment lighting | `load_skill("houdini-light-rig")` → `create_hdri_world` → `area_softbox` / `set_render_view_transform` → `get_lighting_summary` |
 | Light rig management | `load_skill("houdini-light-rig")` → `list_light_rigs` → `group_lights` → `set_light_rig_intensity` |
 | Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` → `houdini_render__get_render_job` / `houdini_render__cancel_render_job` |
+| Karma stage preflight | `load_skill("houdini-render")` → `houdini_render__validate_karma_stage(lop_path="/stage/OUT", renderer="karma_xpu")` |
 | Texture bake (AO) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_ambient_occlusion` |
 | Texture bake (lighting) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_lighting` |
 | Transfer high→low maps | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__transfer_maps` |

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -38,7 +38,8 @@ agent can detect and skip cleanly when rendering is unavailable.
   isolated `hython` background job), `get_render_job` (polls and reconciles
   status without blocking the UI), `cancel_render_job` (cancels only jobs
   owned by the current adapter process), `configure_aovs` (add/remove
-  AOVs with 15+ presets), `get_render_stats` (read resolution/samples/renderer/output).
+  AOVs with 15+ presets), `validate_karma_stage` (read-only USD/Karma
+  preflight), `get_render_stats` (read resolution/samples/renderer/output).
 - **`render_layer`:** `create_render_layer` (Solaris RenderProduct or ROP merge),
   `manage_takes` (create/switch/delete/list takes for render layer variants).
 
@@ -57,7 +58,8 @@ agent can detect and skip cleanly when rendering is unavailable.
 
 1. `create_render_layer(name="beauty", parent_path="/stage", purpose="beauty", aovs=["diffuse","specular","normal","depth"])`
 2. `configure_aovs(rop_path="/stage/beauty", aovs=["motionvector","cryptomatte"], action="add")`
-3. `get_render_stats(rop_path="/stage/beauty")` → verify resolution/samples/output
+3. `validate_karma_stage(lop_path="/stage/OUT", renderer="karma_xpu")` → inspect instance and RenderVar diagnostics
+4. `get_render_stats(rop_path="/stage/beauty")` → verify resolution/samples/output
 
 ### Takes
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/validate_karma_stage.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/validate_karma_stage.py
@@ -1,0 +1,181 @@
+"""Validate known Karma stage diagnostics without modifying the USD Stage."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _render_common import get_node  # noqa: E402
+
+_FILTER_PROPERTY = "driver:parameters:aov:karma:filter"
+_VBLUR_PROPERTY = "primvars:karma:object:vblur"
+_RENDER_VISIBILITY_PROPERTY = "primvars:karma:object:rendervisibility"
+_RENDERERS = {"karma_cpu", "karma_xpu"}
+_UNSUPPORTED_FILTER_MODES = {"edge", "idcover", "ocover"}
+
+
+def _diagnostic(code: str, severity: str, prim_path: str, property_name: str, fix_hint: str) -> dict:
+    return {
+        "code": code,
+        "severity": severity,
+        "prim_path": prim_path,
+        "property": property_name,
+        "fix_hint": fix_hint,
+    }
+
+
+def _authored_attribute(prim, property_name: str):
+    attribute = prim.GetAttribute(property_name)
+    if not attribute or not attribute.HasAuthoredValueOpinion() or attribute.Get() is None:
+        return None
+    return attribute
+
+
+def _instance_property_sources(prim, property_name: str):
+    """Yield authored property paths on one native instance and its ancestors."""
+    if not prim.IsActive() or not prim.IsInstance():
+        return
+    current = prim
+    while current:
+        if _authored_attribute(current, property_name):
+            yield str(current.GetPath())
+        current = current.GetParent()
+
+
+def _filter_entries(value):
+    if not isinstance(value, str) or not value.strip():
+        return []
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return []
+    if isinstance(parsed, list) and len(parsed) == 2 and isinstance(parsed[0], str):
+        return [parsed]
+    if isinstance(parsed, list):
+        return [entry for entry in parsed if isinstance(entry, list) and len(entry) == 2]
+    return []
+
+
+def _unsupported_filter_modes(value):
+    modes = set()
+    for name, options in _filter_entries(value):
+        filter_name = str(name).lower()
+        mode = str(options.get("mode", "")).lower() if isinstance(options, dict) else ""
+        if filter_name in {"edge", "edgedetect"}:
+            modes.add("edge")
+        if mode in _UNSUPPORTED_FILTER_MODES:
+            modes.add(mode)
+    return sorted(modes)
+
+
+def _host_version(hou):
+    version = tuple(int(part) for part in hou.applicationVersion()[:3])
+    if len(version) != 3:
+        raise RuntimeError("Houdini did not report a complete host build")
+    return version, ".".join(str(part) for part in version)
+
+
+def validate_karma_stage(lop_path: str, renderer: str = "karma_xpu") -> dict:
+    """Return known Karma diagnostics for a composed LOP USD Stage."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        renderer_name = str(renderer or "").lower()
+        if renderer_name not in _RENDERERS:
+            raise ValueError("renderer must be one of: karma_cpu, karma_xpu")
+
+        node = get_node(hou, lop_path)
+        stage_method = getattr(node, "stage", None)
+        if not callable(stage_method):
+            raise ValueError("Houdini node is not a LOP node: {}".format(lop_path))
+        stage = stage_method()
+        if stage is None:
+            raise ValueError("LOP node returned no composed USD Stage: {}".format(lop_path))
+
+        version, host_build = _host_version(hou)
+        diagnostics = []
+        vblur_sources = set()
+        visibility_sources = set()
+
+        for prim in stage.Traverse():
+            for prim_path in _instance_property_sources(prim, _VBLUR_PROPERTY):
+                if prim_path in vblur_sources:
+                    continue
+                vblur_sources.add(prim_path)
+                diagnostics.append(
+                    _diagnostic(
+                        "KARMA_INSTANCE_VBLUR_PROTOTYPE_ONLY",
+                        "warning",
+                        prim_path,
+                        _VBLUR_PROPERTY,
+                        "After Scene Import, use a Render Geometry Settings LOP to block the inherited vblur "
+                        "opinion and author velocity blur on the prototype instead of the native instance or ancestor.",
+                    )
+                )
+
+            if version[:2] == (21, 0) and version[2] < 762:
+                for prim_path in _instance_property_sources(prim, _RENDER_VISIBILITY_PROPERTY):
+                    if prim_path in visibility_sources:
+                        continue
+                    visibility_sources.add(prim_path)
+                    diagnostics.append(
+                        _diagnostic(
+                            "KARMA_INSTANCE_RENDERVISIBILITY_HOST_DIAGNOSTIC",
+                            "info",
+                            prim_path,
+                            _RENDER_VISIBILITY_PROPERTY,
+                            "This is the known innocuous Houdini 21.0 host diagnostic. It was removed in 21.0.762; "
+                            "on older builds author the property on the prototype when practical.",
+                        )
+                    )
+
+            if not prim.IsActive() or str(prim.GetTypeName()) != "RenderVar":
+                continue
+            attribute = _authored_attribute(prim, _FILTER_PROPERTY)
+            modes = _unsupported_filter_modes(attribute.Get()) if attribute else []
+            if modes:
+                diagnostics.append(
+                    _diagnostic(
+                        "KARMA_UNSUPPORTED_RENDER_VAR_FILTER",
+                        "warning",
+                        str(prim.GetPath()),
+                        _FILTER_PROPERTY,
+                        "Replace {} with a supported filter. For PrimId, keep sourceName=ray:primid and "
+                        'dataType=int while changing only the filter, for example to ["minmax",{{"mode":"min"}}] '
+                        'or ["ubox",{{}}].'.format(", ".join(modes)),
+                    )
+                )
+
+        return skill_success(
+            "Validated Karma USD Stage",
+            lop_path=str(node.path()),
+            renderer=renderer_name,
+            host_build=host_build,
+            valid=not any(item["severity"] == "warning" for item in diagnostics),
+            diagnostics=diagnostics,
+        )
+    except ValueError as exc:
+        return skill_error("Invalid Karma stage validation request", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate Karma USD Stage")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return validate_karma_stage(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -125,6 +125,35 @@ tools:
           type: string
         image_format:
           type: string
+  - name: validate_karma_stage
+    description: >-
+      Read-only preflight of a composed Solaris USD Stage for known Karma
+      instance-property and RenderVar pixel-filter diagnostics. Reports the
+      Houdini host build and actionable fixes without changing the scene.
+    source_file: scripts/validate_karma_stage.py
+    execution: sync
+    affinity: main
+    group: render
+    read_only: true
+    destructive: false
+    idempotent: true
+    tool_role: read_only
+    risk: low
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [lop_path]
+      properties:
+        lop_path:
+          type: string
+          description: Absolute path of the LOP node whose composed USD Stage is validated.
+        renderer:
+          type: string
+          enum: [karma_xpu, karma_cpu]
+          default: karma_xpu
   - name: render_rop
     description: >-
       Render a ROP/output driver and report written files, elapsed time,

--- a/tests/test_karma_stage_validator.py
+++ b/tests/test_karma_stage_validator.py
@@ -1,0 +1,223 @@
+"""Read-only Karma stage validation tests without a Houdini process."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+_SCRIPT = (
+    Path(__file__).parent.parent
+    / "src"
+    / "dcc_mcp_houdini"
+    / "skills"
+    / "houdini-render"
+    / "scripts"
+    / "validate_karma_stage.py"
+)
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("houdini_render_validate_karma_stage", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Attribute:
+    def __init__(self, value, authored: bool = True) -> None:
+        self._value = value
+        self._authored = authored
+
+    def Get(self):
+        return self._value
+
+    def HasAuthoredValueOpinion(self) -> bool:
+        return self._authored
+
+
+class _Prim:
+    def __init__(
+        self,
+        path: str,
+        *,
+        type_name: str = "Xform",
+        parent=None,
+        instance: bool = False,
+        active: bool = True,
+        attributes=None,
+    ) -> None:
+        self._path = path
+        self._type_name = type_name
+        self._parent = parent
+        self._instance = instance
+        self._active = active
+        self._attributes = attributes or {}
+
+    def __bool__(self) -> bool:
+        return True
+
+    def GetPath(self):
+        return self._path
+
+    def GetTypeName(self) -> str:
+        return self._type_name
+
+    def GetParent(self):
+        return self._parent
+
+    def GetAttribute(self, name: str):
+        return self._attributes.get(name)
+
+    def IsInstance(self) -> bool:
+        return self._instance
+
+    def IsActive(self) -> bool:
+        return self._active
+
+
+class _Stage:
+    def __init__(self, prims) -> None:
+        self._prims = prims
+
+    def Traverse(self):
+        return iter(self._prims)
+
+
+class _Node:
+    def __init__(self, stage: _Stage) -> None:
+        self._stage = stage
+
+    def path(self) -> str:
+        return "/stage/OUT"
+
+    def stage(self) -> _Stage:
+        return self._stage
+
+
+def _hou_module(stage: _Stage, build: int) -> ModuleType:
+    module = ModuleType("hou")
+    node = _Node(stage)
+    module.node = lambda path: node if path == "/stage/OUT" else None  # type: ignore[attr-defined]
+    module.applicationVersion = lambda: (21, 0, build)  # type: ignore[attr-defined]
+    return module
+
+
+def _validate(stage: _Stage, build: int = 631) -> dict:
+    module = _load_script()
+    with patch.dict(sys.modules, {"hou": _hou_module(stage, build)}):
+        return module.validate_karma_stage("/stage/OUT")
+
+
+def test_reports_prototype_only_vblur_authored_on_native_instance_ancestor() -> None:
+    world = _Prim(
+        "/World",
+        attributes={"primvars:karma:object:vblur": _Attribute(1)},
+    )
+    instance = _Prim("/World/Tree_1", parent=world, instance=True)
+
+    result = _validate(_Stage([world, instance]))
+
+    assert result["success"] is True
+    assert result["context"]["host_build"] == "21.0.631"
+    diagnostic = result["context"]["diagnostics"][0]
+    assert diagnostic["code"] == "KARMA_INSTANCE_VBLUR_PROTOTYPE_ONLY"
+    assert diagnostic["severity"] == "warning"
+    assert diagnostic["prim_path"] == "/World"
+    assert diagnostic["property"] == "primvars:karma:object:vblur"
+    assert "Render Geometry Settings" in diagnostic["fix_hint"]
+    assert "Scene Import" in diagnostic["fix_hint"]
+
+
+def test_blocked_vblur_opinion_is_not_reported() -> None:
+    instance = _Prim(
+        "/World/Tree_1",
+        instance=True,
+        attributes={"primvars:karma:object:vblur": _Attribute(None)},
+    )
+
+    result = _validate(_Stage([instance]))
+
+    assert result["context"]["diagnostics"] == []
+
+
+def test_reports_unsupported_filters_only_on_active_render_vars() -> None:
+    filter_name = "driver:parameters:aov:karma:filter"
+    render_vars = [
+        _Prim(
+            "/Render/Vars/primid",
+            type_name="RenderVar",
+            attributes={filter_name: _Attribute('["minmax",{"mode":"idcover"}]')},
+        ),
+        _Prim(
+            "/Render/Vars/depth",
+            type_name="RenderVar",
+            attributes={filter_name: _Attribute('["minmax",{"mode":"ocover"}]')},
+        ),
+        _Prim(
+            "/Render/Vars/element",
+            type_name="RenderVar",
+            attributes={filter_name: _Attribute('["minmax",{"mode":"edge"}]')},
+        ),
+        _Prim(
+            "/Render/Vars/inactive",
+            type_name="RenderVar",
+            active=False,
+            attributes={filter_name: _Attribute('["minmax",{"mode":"idcover"}]')},
+        ),
+        _Prim(
+            "/Render/Vars/supported",
+            type_name="RenderVar",
+            attributes={filter_name: _Attribute('["ubox",{}]')},
+        ),
+    ]
+
+    result = _validate(_Stage(render_vars))
+
+    diagnostics = result["context"]["diagnostics"]
+    assert [item["prim_path"] for item in diagnostics] == [
+        "/Render/Vars/primid",
+        "/Render/Vars/depth",
+        "/Render/Vars/element",
+    ]
+    assert {item["code"] for item in diagnostics} == {"KARMA_UNSUPPORTED_RENDER_VAR_FILTER"}
+    assert all("ray:primid" in item["fix_hint"] for item in diagnostics)
+    assert all("dataType=int" in item["fix_hint"] for item in diagnostics)
+    assert all("supported filter" in item["fix_hint"] for item in diagnostics)
+
+
+def test_rendervisibility_is_host_known_before_21_0_762_only() -> None:
+    instance = _Prim(
+        "/World/Rock_1",
+        instance=True,
+        attributes={"primvars:karma:object:rendervisibility": _Attribute("-primary")},
+    )
+    stage = _Stage([instance])
+
+    old_result = _validate(stage, build=631)
+    fixed_result = _validate(stage, build=762)
+
+    old_diagnostics = old_result["context"]["diagnostics"]
+    assert [item["code"] for item in old_diagnostics] == ["KARMA_INSTANCE_RENDERVISIBILITY_HOST_DIAGNOSTIC"]
+    assert old_diagnostics[0]["severity"] == "info"
+    assert "21.0.762" in old_diagnostics[0]["fix_hint"]
+    assert fixed_result["context"]["host_build"] == "21.0.762"
+    assert fixed_result["context"]["diagnostics"] == []
+
+
+def test_rejects_non_lop_nodes_and_unknown_renderers() -> None:
+    module = _load_script()
+    hou = _hou_module(_Stage([]), 631)
+    hou.node = lambda _path: object()  # type: ignore[attr-defined]
+    with patch.dict(sys.modules, {"hou": hou}):
+        non_lop = module.validate_karma_stage("/obj/geo1")
+        unknown_renderer = module.validate_karma_stage("/stage/OUT", renderer="mantra")
+
+    assert non_lop["success"] is False
+    assert "LOP" in non_lop["error"]
+    assert unknown_renderer["success"] is False
+    assert "renderer" in unknown_renderer["error"]


### PR DESCRIPTION
## Summary

- add the read-only `houdini_render__validate_karma_stage` typed tool for composed LOP USD stages
- report prototype-only `primvars:karma:object:vblur` authored on native instances or their ancestors
- flag active RenderVars using unsupported `idcover`, `ocover`, or edge pixel-filter modes with precise PrimId guidance
- classify the Houdini 21.0 instance `rendervisibility` message as an informational host diagnostic before build 762 and suppress it on fixed builds
- keep validation single-pass, dependency-free, and scene read-only

## References

- SideFX Karma geometry/instancing documentation: https://www.sidefx.com/docs/houdini/solaris/kug/geometry.html
- SideFX Houdini 21.0.762 changelog: https://www.sidefx.com/changelog/?body=rendervisibility&version=21.0

## Validation

- `python -m pytest -q` — 504 passed, 1 skipped
- `python -m ruff check src tests tools packaging`
- `python -m ruff format --check src tests tools packaging`
- `python tools/check_py37_syntax.py src tests tools packaging`
- `python tools/lint_skills.py --require-cli --warnings-as-errors` — 31 skills, 0 errors, 0 warnings
- wheel and sdist build; wheel contains the tool script, `tools.yaml`, and `SKILL.md`