### PR TITLE
feat(animation): add bounded loop contract validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,13 +93,13 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
-| `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
+| `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
 | `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 195 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 196 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
-| `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
+| `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
 | `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |

--- a/llms.txt
+++ b/llms.txt
@@ -71,7 +71,7 @@ server.list_skills()
 - `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
 - `houdini_karma__configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output`
 - `houdini_husk__render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
-- `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`
+- `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`
 - `houdini_hda_automation__scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain`
 - `houdini_pipeline__set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package`
 - `houdini_dev__attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action`

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -35,6 +35,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Transfer high→low maps | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__transfer_maps` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
 | Animate & bake | `load_skill("houdini-animation")` → `houdini_animation__set_timeline` → `houdini_animation__set_keyframe` → `houdini_animation__get_keyframes` → `houdini_animation__bake_channels` / `houdini_animation__cache_simulation` |
+| Validate an animation loop | `load_skill("houdini-animation")` → `houdini_animation__validate_loop_contract` (unique playback samples; periodic seam uses virtual `end+step`) |
 | Lookdev & shader networks | `load_skill("houdini-lookdev")` → `houdini_lookdev__list_materials` → `houdini_lookdev__get_material_parms` → `houdini_lookdev__set_material_parms` → `houdini_lookdev__save_preset` / `houdini_lookdev__load_preset` |
 | Material library & presets | `load_skill("houdini-material-library")` → `houdini_material_library__list_material_presets` → `houdini_material_library__save_material_preset` / `houdini_material_library__load_material_preset` → `houdini_material_library__assign_texture` |
 | Inspect textures & colors | `load_skill("houdini-material-library")` → `houdini_material_library__list_images` → `houdini_material_library__list_color_spaces` → `houdini_material_library__reload_image` |

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -3,8 +3,9 @@ name: houdini-animation
 description: >-
   Pipeline skill — typed timeline, keyframe, channel, and cache-baking tools.
   Query/set time, FPS and ranges; set/get/delete/list keyframes; inspect
-  channels and expressions; export/import channel JSON; bake channels and
-  trigger bounded simulation/cache renders. The canonical timeline API.
+  channels and expressions; validate bounded transform-loop continuity;
+  export/import channel JSON; bake channels and trigger bounded
+  simulation/cache renders. The canonical timeline API.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
@@ -14,8 +15,8 @@ metadata:
     layer: domain
     stage: pipeline
     version: "1.0.0"
-    tags: [houdini, animation, keyframe, channel, timeline, fps, bake, simulation, cache, pipeline]
-    search-hint: "keyframe channel timeline frame range fps set time animation bake simulation cache expression"
+    tags: [houdini, animation, keyframe, channel, timeline, loop, seam, validation, fps, bake, simulation, cache, pipeline]
+    search-hint: "keyframe channel timeline frame range fps animation loop seam continuity validate bake simulation cache expression"
     tools: tools.yaml
 ---
 
@@ -33,6 +34,9 @@ Typed animation tools for agents. All tools are `affinity: main`.
   (destructive).
 - **`channels`:** `list_animated_parms`, `get_channel_info`, `export_channels`,
   `import_channels` (JSON round-trip).
+- **`validation`:** `validate_loop_contract` — bounded, read-only OBJ world-
+  transform continuity checks with driver summaries. It never inspects or cooks
+  geometry and restores the original frame in `finally`.
 - **`bake`** (async): `bake_channels` (per-frame sample → constant keys, hard
   frame cap), `cache_simulation` (render a filecache/DOP/geometry ROP, report
   a background job in interactive Houdini or `written_files` + `elapsed_secs`
@@ -44,8 +48,32 @@ Typed animation tools for agents. All tools are `affinity: main`.
 2. `set_keyframe(node_path="/obj/geo1", parm_name="tx", frame=1, value=0)`
 3. `set_keyframe(node_path="/obj/geo1", parm_name="tx", frame=48, value=10)`
 4. `get_keyframes("/obj/geo1", "tx")` → verify two keys
-5. `export_channels("/obj/geo1", ["tx"], "/tmp/tx.json")` → `import_channels` to retarget
-6. `bake_channels("/obj/geo1", ["tx"], frame_range=[1,48])` to flatten expressions
+5. `validate_loop_contract(["/obj/geo1"], 1, 48)` → verify the periodic seam
+6. `export_channels("/obj/geo1", ["tx"], "/tmp/tx.json")` → `import_channels` to retarget
+7. `bake_channels("/obj/geo1", ["tx"], frame_range=[1,48])` to flatten expressions
+
+## Loop range contract
+
+`validate_loop_contract` treats `[start_frame, end_frame]` as **N unique
+playback samples**. For the default step of one frame it temporarily samples
+`start`, `start+1`, `start+2`, `end-1`, `end`, and the virtual continuation
+`end+1`.
+
+- `endpoint_duplicate_delta` reports `end` vs `start` for diagnosing assets
+  authored with a duplicated endpoint; it is informational and does not decide
+  pass/fail.
+- `duplicate_endpoint_hold_risk` becomes true when that duplicated endpoint is
+  within transform tolerances but the first linear or angular step is
+  nontrivial. This diagnostic stays false for static nodes and is not a gate.
+- `periodic_delta` compares virtual `end+1` vs `start` and drives positional,
+  angular, scale, and matrix continuity checks.
+- Velocity residuals compare the `end → end+1` step with `start → start+1`;
+  acceleration residuals compare the neighboring three-sample stencils.
+
+This avoids the one-frame hold caused by requiring `end == start` in a range
+whose endpoints are both played. Supply `tolerances` to override the documented
+defaults; requests remain bounded to 64 unique `/obj` paths and six transform
+samples per resolved node.
 
 `cache_simulation` is `async` with a 1-hour timeout hint. Interactive Houdini
 defaults to isolated `hython`; poll its `job_id` with

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/validate_loop_contract.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/validate_loop_contract.py
@@ -1,0 +1,630 @@
+"""Validate a bounded OBJ animation loop without inspecting geometry."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_MAX_NODES = 64
+_MAX_NODE_PATH_LENGTH = 512
+_MAX_ABS_FRAME = 1_000_000.0
+_MAX_SAMPLE_STEP = 1_000.0
+_TRANSFORM_PARMS = ("tx", "ty", "tz", "rx", "ry", "rz", "sx", "sy", "sz")
+_DEFAULT_TOLERANCES = {
+    "matrix_max_abs": 1.0e-4,
+    "translation": 1.0e-4,
+    "angular_degrees": 0.1,
+    "scale": 1.0e-4,
+    "linear_velocity": 1.0e-3,
+    "angular_velocity_degrees": 0.5,
+    "linear_acceleration": 1.0e-2,
+    "angular_acceleration_degrees": 2.0,
+}
+
+
+def _finite_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("{} must be a finite number".format(label))
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("{} must be a finite number".format(label))
+    return number
+
+
+def _validate_request(
+    node_paths: Any,
+    start_frame: Any,
+    end_frame: Any,
+    sample_step: Any,
+    tolerances: Any,
+    max_expression_chars: Any,
+) -> Tuple[List[str], float, float, float, Dict[str, float], int]:
+    if not isinstance(node_paths, list) or not node_paths:
+        raise ValueError("node_paths must contain between 1 and 64 OBJ node paths")
+    if len(node_paths) > _MAX_NODES:
+        raise ValueError("node_paths accepts at most 64 paths")
+
+    validated_paths = []
+    seen = set()
+    for node_path in node_paths:
+        if not isinstance(node_path, str) or not node_path.startswith("/obj/"):
+            raise ValueError("Every node path must be under /obj")
+        if len(node_path) > _MAX_NODE_PATH_LENGTH or any(character.isspace() for character in node_path):
+            raise ValueError("OBJ node paths must be at most 512 characters and contain no whitespace")
+        if node_path in seen:
+            raise ValueError("node_paths must be unique")
+        seen.add(node_path)
+        validated_paths.append(node_path)
+
+    start = _finite_number(start_frame, "start_frame")
+    end = _finite_number(end_frame, "end_frame")
+    step = _finite_number(sample_step, "sample_step")
+    if abs(start) > _MAX_ABS_FRAME or abs(end) > _MAX_ABS_FRAME:
+        raise ValueError("start_frame and end_frame are bounded to +/-1000000")
+    if step <= 0.0 or step > _MAX_SAMPLE_STEP:
+        raise ValueError("sample_step must be greater than zero and at most 1000")
+    if abs(end + step) > _MAX_ABS_FRAME:
+        raise ValueError("The virtual end_frame + sample_step sample is bounded to +/-1000000")
+    if end <= start:
+        raise ValueError("end_frame must be greater than start_frame")
+    if end - start < (4.0 * step) - 1.0e-9:
+        raise ValueError("The loop range must span at least four sample steps")
+
+    if isinstance(max_expression_chars, bool) or not isinstance(max_expression_chars, int):
+        raise ValueError("max_expression_chars must be an integer")
+    if max_expression_chars < 0 or max_expression_chars > 512:
+        raise ValueError("max_expression_chars must be between 0 and 512")
+
+    merged_tolerances = dict(_DEFAULT_TOLERANCES)
+    if tolerances is not None:
+        if not isinstance(tolerances, dict):
+            raise ValueError("tolerances must be an object")
+        unknown = sorted(set(tolerances) - set(_DEFAULT_TOLERANCES))
+        if unknown:
+            raise ValueError("Unknown tolerance keys: {}".format(", ".join(unknown)))
+        for name, value in tolerances.items():
+            number = _finite_number(value, "tolerances.{}".format(name))
+            if number < 0.0:
+                raise ValueError("tolerances.{} must be non-negative".format(name))
+            merged_tolerances[name] = number
+
+    return validated_paths, start, end, step, merged_tolerances, max_expression_chars
+
+
+def _sample_frames(start: float, end: float, step: float) -> List[float]:
+    candidates = [start, start + step, start + (2.0 * step), end - step, end, end + step]
+    frames = []
+    for candidate in candidates:
+        if not frames or all(abs(candidate - existing) > 1.0e-9 for existing in frames):
+            frames.append(float(candidate))
+    return frames
+
+
+def _float_tuple(values: Iterable[Any], expected: int, label: str) -> Tuple[float, ...]:
+    result = tuple(float(value) for value in values)
+    if len(result) != expected:
+        raise ValueError("{} returned {} values; expected {}".format(label, len(result), expected))
+    return result
+
+
+def _vector_sub(left: Sequence[float], right: Sequence[float]) -> Tuple[float, ...]:
+    return tuple(a - b for a, b in zip(left, right))
+
+
+def _vector_scale(vector: Sequence[float], scale: float) -> Tuple[float, ...]:
+    return tuple(value * scale for value in vector)
+
+
+def _vector_norm(vector: Sequence[float]) -> float:
+    return math.sqrt(sum(value * value for value in vector))
+
+
+def _max_abs_delta(left: Sequence[float], right: Sequence[float]) -> float:
+    return max(abs(a - b) for a, b in zip(left, right))
+
+
+def _normalize_quaternion(quaternion: Sequence[float]) -> Tuple[float, float, float, float]:
+    length = _vector_norm(quaternion)
+    if not math.isfinite(length) or length <= 1.0e-12:
+        raise ValueError("Rotation matrix produced an invalid orientation")
+    return tuple(value / length for value in quaternion)  # type: ignore[return-value]
+
+
+def _matrix3_quaternion(values: Sequence[float]) -> Tuple[float, float, float, float]:
+    """Convert Houdini's row-vector 3x3 matrix to a normalized quaternion."""
+    matrix = _float_tuple(values, 9, "extractRotationMatrix3")
+    # Quaternion conversion formulas conventionally use column vectors, so
+    # transpose Houdini's row-vector matrix while unpacking it.
+    m00, m10, m20, m01, m11, m21, m02, m12, m22 = matrix
+    trace = m00 + m11 + m22
+    if trace > 0.0:
+        scale = math.sqrt(trace + 1.0) * 2.0
+        quaternion = (0.25 * scale, (m21 - m12) / scale, (m02 - m20) / scale, (m10 - m01) / scale)
+    elif m00 > m11 and m00 > m22:
+        scale = math.sqrt(max(0.0, 1.0 + m00 - m11 - m22)) * 2.0
+        quaternion = ((m21 - m12) / scale, 0.25 * scale, (m01 + m10) / scale, (m02 + m20) / scale)
+    elif m11 > m22:
+        scale = math.sqrt(max(0.0, 1.0 + m11 - m00 - m22)) * 2.0
+        quaternion = ((m02 - m20) / scale, (m01 + m10) / scale, 0.25 * scale, (m12 + m21) / scale)
+    else:
+        scale = math.sqrt(max(0.0, 1.0 + m22 - m00 - m11)) * 2.0
+        quaternion = ((m10 - m01) / scale, (m02 + m20) / scale, (m12 + m21) / scale, 0.25 * scale)
+    return _normalize_quaternion(quaternion)
+
+
+def _quaternion_multiply(left: Sequence[float], right: Sequence[float]) -> Tuple[float, float, float, float]:
+    lw, lx, ly, lz = left
+    rw, rx, ry, rz = right
+    return (
+        (lw * rw) - (lx * rx) - (ly * ry) - (lz * rz),
+        (lw * rx) + (lx * rw) + (ly * rz) - (lz * ry),
+        (lw * ry) - (lx * rz) + (ly * rw) + (lz * rx),
+        (lw * rz) + (lx * ry) - (ly * rx) + (lz * rw),
+    )
+
+
+def _angular_delta_vector_degrees(start: Sequence[float], end: Sequence[float]) -> Tuple[float, float, float]:
+    start_q = _normalize_quaternion(start)
+    end_q = _normalize_quaternion(end)
+    if sum(a * b for a, b in zip(start_q, end_q)) < 0.0:
+        end_q = tuple(-value for value in end_q)
+    relative = _normalize_quaternion(_quaternion_multiply(end_q, (start_q[0], -start_q[1], -start_q[2], -start_q[3])))
+    if relative[0] < 0.0:
+        relative = tuple(-value for value in relative)
+    sine_half = _vector_norm(relative[1:])
+    if sine_half <= 1.0e-12:
+        return (0.0, 0.0, 0.0)
+    angle_degrees = math.degrees(2.0 * math.atan2(sine_half, max(0.0, relative[0])))
+    return tuple((component / sine_half) * angle_degrees for component in relative[1:])  # type: ignore[return-value]
+
+
+def _json_number(value: float) -> Optional[float]:
+    return float(value) if math.isfinite(value) else None
+
+
+def _json_vector(values: Sequence[float]) -> List[Optional[float]]:
+    return [_json_number(value) for value in values]
+
+
+def _snapshot(node: Any) -> Dict[str, Any]:
+    matrix = node.worldTransform()
+    matrix_values = _float_tuple(matrix.asTuple(), 16, "worldTransform")
+    translation = _float_tuple(matrix.extractTranslates(), 3, "extractTranslates")
+    rotation_euler = _float_tuple(matrix.extractRotates(), 3, "extractRotates")
+    scale = _float_tuple(matrix.extractScales(), 3, "extractScales")
+    rotation_matrix = matrix.extractRotationMatrix3()
+    orientation = _matrix3_quaternion(rotation_matrix.asTuple())
+    finite = all(
+        math.isfinite(value)
+        for values in (matrix_values, translation, rotation_euler, scale, orientation)
+        for value in values
+    )
+    return {
+        "matrix": matrix_values,
+        "translation": translation,
+        "rotation_euler_degrees": rotation_euler,
+        "scale": scale,
+        "orientation": orientation,
+        "finite": finite,
+    }
+
+
+def _expression_summary(parm: Any, max_chars: int) -> Tuple[Optional[str], Optional[str], bool]:
+    try:
+        expression = str(parm.expression())
+    except Exception:  # noqa: BLE001 - HOM raises when no expression exists
+        return None, None, False
+    language = None
+    try:
+        expression_language = parm.expressionLanguage()
+        language = expression_language.name() if hasattr(expression_language, "name") else str(expression_language)
+    except Exception:  # noqa: BLE001
+        language = None
+    truncated = len(expression) > max_chars
+    return expression[:max_chars], language, truncated
+
+
+def _keyframe_summary(parm: Any) -> Tuple[int, Optional[float], Optional[float]]:
+    try:
+        keyframes = list(parm.keyframes())
+    except Exception:  # noqa: BLE001
+        return 0, None, None
+    frames = []
+    for keyframe in keyframes:
+        try:
+            frames.append(float(keyframe.frame()))
+        except Exception:  # noqa: BLE001
+            continue
+    return len(keyframes), min(frames) if frames else None, max(frames) if frames else None
+
+
+def _driver_summary(node: Any, max_expression_chars: int) -> Dict[str, Any]:
+    counts = {"expression": 0, "keyframes": 0, "static": 0, "time_dependent": 0}
+    parameters = []
+    for parm_name in _TRANSFORM_PARMS:
+        parm = node.parm(parm_name)
+        if parm is None:
+            continue
+        expression, language, truncated = _expression_summary(parm, max_expression_chars)
+        keyframe_count, first_keyframe, last_keyframe = _keyframe_summary(parm)
+        try:
+            time_dependent = bool(parm.isTimeDependent())
+        except Exception:  # noqa: BLE001
+            time_dependent = False
+        if expression is not None:
+            driver = "expression"
+        elif keyframe_count:
+            driver = "keyframes"
+        elif time_dependent:
+            driver = "time_dependent"
+        else:
+            driver = "static"
+        counts[driver] += 1
+        parameters.append(
+            {
+                "name": parm_name,
+                "driver": driver,
+                "expression_preview": expression,
+                "expression_language": language,
+                "expression_truncated": truncated,
+                "keyframe_count": keyframe_count,
+                "first_keyframe": first_keyframe,
+                "last_keyframe": last_keyframe,
+                "time_dependent": time_dependent,
+            }
+        )
+    return {"counts": counts, "parameters": parameters}
+
+
+def _public_endpoint(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "translation": _json_vector(snapshot["translation"]),
+        "rotation_euler_degrees": _json_vector(snapshot["rotation_euler_degrees"]),
+        "scale": _json_vector(snapshot["scale"]),
+    }
+
+
+def _empty_transform_delta() -> Dict[str, None]:
+    return {
+        "matrix_max_abs": None,
+        "translation_distance": None,
+        "angular_degrees": None,
+        "scale_max_abs": None,
+    }
+
+
+def _failed_metrics() -> Tuple[Dict[str, None], Dict[str, None], Dict[str, Any], Dict[str, Any]]:
+    endpoint_duplicate = _empty_transform_delta()
+    periodic = _empty_transform_delta()
+    velocity = {
+        "linear_vector_per_second": None,
+        "linear_magnitude_per_second": None,
+        "angular_vector_degrees_per_second": None,
+        "angular_magnitude_degrees_per_second": None,
+    }
+    acceleration = {
+        "linear_vector_per_second2": None,
+        "linear_magnitude_per_second2": None,
+        "angular_vector_degrees_per_second2": None,
+        "angular_magnitude_degrees_per_second2": None,
+    }
+    return endpoint_duplicate, periodic, velocity, acceleration
+
+
+def _evaluate_node(
+    node_path: str,
+    snapshots: Dict[float, Dict[str, Any]],
+    frames: Sequence[float],
+    fps: float,
+    step: float,
+    tolerances: Dict[str, float],
+    drivers: Dict[str, Any],
+    errors: List[str],
+) -> Dict[str, Any]:
+    finite = not errors and len(snapshots) == len(frames) and all(snapshot["finite"] for snapshot in snapshots.values())
+    checks = {"finite": finite}
+    if not finite:
+        endpoint_duplicate, periodic, velocity, acceleration = _failed_metrics()
+        checks.update(
+            {
+                "periodic_matrix": False,
+                "periodic_translation": False,
+                "periodic_angular": False,
+                "periodic_scale": False,
+                "linear_velocity": False,
+                "angular_velocity": False,
+                "linear_acceleration": False,
+                "angular_acceleration": False,
+            }
+        )
+        return {
+            "node_path": node_path,
+            "resolved": True,
+            "finite": False,
+            "passed": False,
+            "duplicate_endpoint_hold_risk": False,
+            "endpoints": None,
+            "endpoint_duplicate_delta": endpoint_duplicate,
+            "periodic_delta": periodic,
+            "velocity_residuals": velocity,
+            "acceleration_residuals": acceleration,
+            "drivers": drivers,
+            "checks": checks,
+            "errors": errors or ["One or more transform samples were non-finite"],
+        }
+
+    start, start_one, start_two = (snapshots[frames[index]] for index in (0, 1, 2))
+    end_one, end, periodic_next = (snapshots[frames[index]] for index in (-3, -2, -1))
+    seconds_per_step = step / fps
+
+    endpoint_translation_delta = _vector_sub(end["translation"], start["translation"])
+    endpoint_angular_delta = _angular_delta_vector_degrees(start["orientation"], end["orientation"])
+    endpoint_duplicate = {
+        "matrix_max_abs": _max_abs_delta(start["matrix"], end["matrix"]),
+        "translation_distance": _vector_norm(endpoint_translation_delta),
+        "angular_degrees": _vector_norm(endpoint_angular_delta),
+        "scale_max_abs": _max_abs_delta(start["scale"], end["scale"]),
+    }
+    periodic_translation_delta = _vector_sub(periodic_next["translation"], start["translation"])
+    periodic_angular_delta = _angular_delta_vector_degrees(start["orientation"], periodic_next["orientation"])
+    periodic = {
+        "matrix_max_abs": _max_abs_delta(start["matrix"], periodic_next["matrix"]),
+        "translation_distance": _vector_norm(periodic_translation_delta),
+        "angular_degrees": _vector_norm(periodic_angular_delta),
+        "scale_max_abs": _max_abs_delta(start["scale"], periodic_next["scale"]),
+    }
+    first_step_translation = _vector_norm(_vector_sub(start_one["translation"], start["translation"]))
+    first_step_angular = _vector_norm(_angular_delta_vector_degrees(start["orientation"], start_one["orientation"]))
+    endpoint_is_duplicate = (
+        endpoint_duplicate["matrix_max_abs"] <= tolerances["matrix_max_abs"]
+        and endpoint_duplicate["translation_distance"] <= tolerances["translation"]
+        and endpoint_duplicate["angular_degrees"] <= tolerances["angular_degrees"]
+        and endpoint_duplicate["scale_max_abs"] <= tolerances["scale"]
+    )
+    duplicate_endpoint_hold_risk = endpoint_is_duplicate and (
+        first_step_translation > tolerances["translation"] or first_step_angular > tolerances["angular_degrees"]
+    )
+
+    start_linear_velocity = _vector_scale(
+        _vector_sub(start_one["translation"], start["translation"]), 1.0 / seconds_per_step
+    )
+    end_linear_velocity = _vector_scale(
+        _vector_sub(periodic_next["translation"], end["translation"]), 1.0 / seconds_per_step
+    )
+    linear_velocity_residual = _vector_sub(end_linear_velocity, start_linear_velocity)
+    start_angular_velocity = _vector_scale(
+        _angular_delta_vector_degrees(start["orientation"], start_one["orientation"]), 1.0 / seconds_per_step
+    )
+    end_angular_velocity = _vector_scale(
+        _angular_delta_vector_degrees(end["orientation"], periodic_next["orientation"]), 1.0 / seconds_per_step
+    )
+    angular_velocity_residual = _vector_sub(end_angular_velocity, start_angular_velocity)
+
+    next_linear_velocity = _vector_scale(
+        _vector_sub(start_two["translation"], start_one["translation"]), 1.0 / seconds_per_step
+    )
+    previous_linear_velocity = _vector_scale(
+        _vector_sub(end["translation"], end_one["translation"]), 1.0 / seconds_per_step
+    )
+    start_linear_acceleration = _vector_scale(
+        _vector_sub(next_linear_velocity, start_linear_velocity), 1.0 / seconds_per_step
+    )
+    end_linear_acceleration = _vector_scale(
+        _vector_sub(end_linear_velocity, previous_linear_velocity), 1.0 / seconds_per_step
+    )
+    linear_acceleration_residual = _vector_sub(end_linear_acceleration, start_linear_acceleration)
+
+    next_angular_velocity = _vector_scale(
+        _angular_delta_vector_degrees(start_one["orientation"], start_two["orientation"]), 1.0 / seconds_per_step
+    )
+    previous_angular_velocity = _vector_scale(
+        _angular_delta_vector_degrees(end_one["orientation"], end["orientation"]), 1.0 / seconds_per_step
+    )
+    start_angular_acceleration = _vector_scale(
+        _vector_sub(next_angular_velocity, start_angular_velocity), 1.0 / seconds_per_step
+    )
+    end_angular_acceleration = _vector_scale(
+        _vector_sub(end_angular_velocity, previous_angular_velocity), 1.0 / seconds_per_step
+    )
+    angular_acceleration_residual = _vector_sub(end_angular_acceleration, start_angular_acceleration)
+
+    velocity = {
+        "linear_vector_per_second": list(linear_velocity_residual),
+        "linear_magnitude_per_second": _vector_norm(linear_velocity_residual),
+        "angular_vector_degrees_per_second": list(angular_velocity_residual),
+        "angular_magnitude_degrees_per_second": _vector_norm(angular_velocity_residual),
+    }
+    acceleration = {
+        "linear_vector_per_second2": list(linear_acceleration_residual),
+        "linear_magnitude_per_second2": _vector_norm(linear_acceleration_residual),
+        "angular_vector_degrees_per_second2": list(angular_acceleration_residual),
+        "angular_magnitude_degrees_per_second2": _vector_norm(angular_acceleration_residual),
+    }
+    checks.update(
+        {
+            "periodic_matrix": periodic["matrix_max_abs"] <= tolerances["matrix_max_abs"],
+            "periodic_translation": periodic["translation_distance"] <= tolerances["translation"],
+            "periodic_angular": periodic["angular_degrees"] <= tolerances["angular_degrees"],
+            "periodic_scale": periodic["scale_max_abs"] <= tolerances["scale"],
+            "linear_velocity": velocity["linear_magnitude_per_second"] <= tolerances["linear_velocity"],
+            "angular_velocity": velocity["angular_magnitude_degrees_per_second"]
+            <= tolerances["angular_velocity_degrees"],
+            "linear_acceleration": acceleration["linear_magnitude_per_second2"] <= tolerances["linear_acceleration"],
+            "angular_acceleration": acceleration["angular_magnitude_degrees_per_second2"]
+            <= tolerances["angular_acceleration_degrees"],
+        }
+    )
+    return {
+        "node_path": node_path,
+        "resolved": True,
+        "finite": True,
+        "passed": all(checks.values()),
+        "duplicate_endpoint_hold_risk": duplicate_endpoint_hold_risk,
+        "first_step_motion": {
+            "translation_distance": first_step_translation,
+            "angular_degrees": first_step_angular,
+        },
+        "endpoints": {
+            "start": _public_endpoint(start),
+            "end": _public_endpoint(end),
+            "virtual_next": _public_endpoint(periodic_next),
+        },
+        "endpoint_duplicate_delta": endpoint_duplicate,
+        "periodic_delta": periodic,
+        "velocity_residuals": velocity,
+        "acceleration_residuals": acceleration,
+        "drivers": drivers,
+        "checks": checks,
+        "errors": errors,
+    }
+
+
+def _unresolved_diagnostic(node_path: str, error: str) -> Dict[str, Any]:
+    endpoint_duplicate, periodic, velocity, acceleration = _failed_metrics()
+    checks = {
+        "finite": False,
+        "periodic_matrix": False,
+        "periodic_translation": False,
+        "periodic_angular": False,
+        "periodic_scale": False,
+        "linear_velocity": False,
+        "angular_velocity": False,
+        "linear_acceleration": False,
+        "angular_acceleration": False,
+    }
+    return {
+        "node_path": node_path,
+        "resolved": False,
+        "finite": False,
+        "passed": False,
+        "duplicate_endpoint_hold_risk": False,
+        "endpoints": None,
+        "endpoint_duplicate_delta": endpoint_duplicate,
+        "periodic_delta": periodic,
+        "velocity_residuals": velocity,
+        "acceleration_residuals": acceleration,
+        "drivers": {"counts": {"expression": 0, "keyframes": 0, "static": 0, "time_dependent": 0}, "parameters": []},
+        "checks": checks,
+        "errors": [error],
+    }
+
+
+def validate_loop_contract(
+    node_paths: List[str],
+    start_frame: float,
+    end_frame: float,
+    sample_step: float = 1.0,
+    tolerances: Optional[Dict[str, float]] = None,
+    max_expression_chars: int = 160,
+) -> dict:
+    """Validate transform continuity around the seam of a bounded OBJ loop."""
+    try:
+        paths, start, end, step, merged_tolerances, expression_limit = _validate_request(
+            node_paths, start_frame, end_frame, sample_step, tolerances, max_expression_chars
+        )
+    except ValueError as exc:
+        return skill_error("Invalid loop validation request", str(exc))
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    original_frame = None
+    restore_error = None
+    execution_error = None
+    diagnostics_by_path = {}
+    frames = _sample_frames(start, end, step)
+    try:
+        original_frame = float(hou.frame())
+        fps = float(hou.fps())
+        if not math.isfinite(fps) or fps <= 0.0:
+            raise ValueError("Houdini FPS must be a positive finite number")
+
+        resolved = []
+        for node_path in paths:
+            node = hou.node(node_path)
+            if node is None:
+                diagnostics_by_path[node_path] = _unresolved_diagnostic(node_path, "Houdini node not found")
+                continue
+            try:
+                if node.type().category() != hou.objNodeTypeCategory():
+                    diagnostics_by_path[node_path] = _unresolved_diagnostic(node_path, "Node is not an OBJ node")
+                    continue
+            except Exception as exc:  # noqa: BLE001
+                diagnostics_by_path[node_path] = _unresolved_diagnostic(
+                    node_path, "Could not verify OBJ category: {}".format(exc)
+                )
+                continue
+            resolved.append(
+                {
+                    "path": node_path,
+                    "node": node,
+                    "snapshots": {},
+                    "errors": [],
+                    "drivers": _driver_summary(node, expression_limit),
+                }
+            )
+
+        for frame in frames:
+            hou.setFrame(frame)
+            for entry in resolved:
+                try:
+                    entry["snapshots"][frame] = _snapshot(entry["node"])
+                except Exception as exc:  # noqa: BLE001
+                    entry["errors"].append("Frame {}: {}".format(frame, exc))
+
+        for entry in resolved:
+            diagnostics_by_path[entry["path"]] = _evaluate_node(
+                entry["path"],
+                entry["snapshots"],
+                frames,
+                fps,
+                step,
+                merged_tolerances,
+                entry["drivers"],
+                entry["errors"],
+            )
+    except Exception as exc:  # noqa: BLE001
+        execution_error = exc
+    finally:
+        if original_frame is not None:
+            try:
+                hou.setFrame(original_frame)
+            except Exception as exc:  # noqa: BLE001
+                restore_error = exc
+
+    if restore_error is not None:
+        return skill_error("Failed to restore the original Houdini frame", str(restore_error))
+    if execution_error is not None:
+        return skill_exception(execution_error, message="Failed to validate animation loop")
+
+    diagnostics = [diagnostics_by_path[node_path] for node_path in paths]
+    passed = all(diagnostic["passed"] for diagnostic in diagnostics)
+    return skill_success(
+        "Animation loop contract passed" if passed else "Animation loop contract failed",
+        passed=passed,
+        node_count=len(paths),
+        sample_frames=frames,
+        sample_step=step,
+        range_semantics="[start_frame, end_frame] contains unique playback samples; end_frame + sample_step is the virtual periodic sample",
+        virtual_periodic_frame=end + step,
+        fps=fps,
+        original_frame=original_frame,
+        restored_frame=True,
+        tolerances=merged_tolerances,
+        nodes=diagnostics,
+    )
+
+
+@skill_entry
+def main(**kwargs: Any) -> dict:
+    return validate_loop_contract(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
@@ -144,6 +144,70 @@ tools:
       properties:
         node_path:
           type: string
+  - name: validate_loop_contract
+    description: >-
+      Bounded, read-only OBJ animation-loop validation for a playback range of
+      unique samples. Temporarily reads the first three frames plus end-step,
+      end, and virtual end+step; restores the original frame; and reports both
+      end-vs-start duplicate and end+step-vs-start periodic deltas, plus
+      velocity/acceleration residuals, without inspecting or cooking geometry.
+    source_file: scripts/validate_loop_contract.py
+    execution: sync
+    affinity: main
+    group: validation
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_paths, start_frame, end_frame]
+      properties:
+        node_paths:
+          type: array
+          description: Unique OBJ node paths to validate; geometry is never inspected.
+          items:
+            type: string
+            pattern: '^/obj/\S+$'
+            maxLength: 512
+          minItems: 1
+          maxItems: 64
+          uniqueItems: true
+        start_frame:
+          type: number
+          minimum: -1000000
+          maximum: 1000000
+        end_frame:
+          type: number
+          description: Last unique playback sample; the validator also reads end_frame + sample_step.
+          minimum: -1000000
+          maximum: 1000000
+        sample_step:
+          type: number
+          exclusiveMinimum: 0
+          maximum: 1000
+          default: 1.0
+        tolerances:
+          type: object
+          additionalProperties: false
+          properties:
+            matrix_max_abs: {type: number, minimum: 0, default: 0.0001}
+            translation: {type: number, minimum: 0, default: 0.0001}
+            angular_degrees: {type: number, minimum: 0, default: 0.1}
+            scale: {type: number, minimum: 0, default: 0.0001}
+            linear_velocity: {type: number, minimum: 0, default: 0.001}
+            angular_velocity_degrees: {type: number, minimum: 0, default: 0.5}
+            linear_acceleration: {type: number, minimum: 0, default: 0.01}
+            angular_acceleration_degrees: {type: number, minimum: 0, default: 2.0}
+        max_expression_chars:
+          type: integer
+          minimum: 0
+          maximum: 512
+          default: 160
   - name: get_channel_info
     description: >-
       Inspect a parameter channel: expression, language, keyframe count, time

--- a/tests/test_animation_loop_validator.py
+++ b/tests/test_animation_loop_validator.py
@@ -1,0 +1,442 @@
+"""Loop-contract tests for the bounded, read-only Houdini animation validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+import urllib.request
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from unittest.mock import patch
+
+import pytest
+import yaml
+from dcc_mcp_core import McpHttpConfig, create_skill_server
+from dcc_mcp_core.host import QueueDispatcher, StandaloneHost
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+_SKILL_ROOT = _SKILLS_ROOT / "houdini-animation"
+
+
+def _load_validator() -> ModuleType:
+    path = _SKILL_ROOT / "scripts" / "validate_loop_contract.py"
+    spec = importlib.util.spec_from_file_location("anim_validate_loop_contract", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Matrix3:
+    def __init__(self, values: Sequence[float]) -> None:
+        self._values = tuple(values)
+
+    def asTuple(self) -> Tuple[float, ...]:
+        return self._values
+
+
+class _Matrix4:
+    def __init__(
+        self,
+        translate: Sequence[float] = (0.0, 0.0, 0.0),
+        rotate_z: float = 0.0,
+        scale: Sequence[float] = (1.0, 1.0, 1.0),
+        matrix_override: Optional[Sequence[float]] = None,
+    ) -> None:
+        self._translate = tuple(float(value) for value in translate)
+        self._rotate = (0.0, 0.0, float(rotate_z))
+        self._scale = tuple(float(value) for value in scale)
+        angle = math.radians(float(rotate_z))
+        cosine = math.cos(angle)
+        sine = math.sin(angle)
+        self._rotation = (cosine, sine, 0.0, -sine, cosine, 0.0, 0.0, 0.0, 1.0)
+        self._matrix = (
+            tuple(matrix_override)
+            if matrix_override is not None
+            else (
+                cosine * self._scale[0],
+                sine * self._scale[0],
+                0.0,
+                0.0,
+                -sine * self._scale[1],
+                cosine * self._scale[1],
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                self._scale[2],
+                0.0,
+                self._translate[0],
+                self._translate[1],
+                self._translate[2],
+                1.0,
+            )
+        )
+
+    def asTuple(self) -> Tuple[float, ...]:
+        return self._matrix
+
+    def extractTranslates(self) -> Tuple[float, float, float]:
+        return self._translate
+
+    def extractRotates(self) -> Tuple[float, float, float]:
+        return self._rotate
+
+    def extractScales(self) -> Tuple[float, float, float]:
+        return self._scale
+
+    def extractRotationMatrix3(self) -> _Matrix3:
+        return _Matrix3(self._rotation)
+
+
+class _Keyframe:
+    def __init__(self, frame: float) -> None:
+        self._frame = frame
+
+    def frame(self) -> float:
+        return self._frame
+
+
+class _Language:
+    def name(self) -> str:
+        return "Hscript"
+
+
+class _Parm:
+    def __init__(
+        self,
+        name: str,
+        expression: Optional[str] = None,
+        keyframes: Iterable[float] = (),
+        time_dependent: bool = False,
+    ) -> None:
+        self._name = name
+        self._expression = expression
+        self._keyframes = [_Keyframe(frame) for frame in keyframes]
+        self._time_dependent = time_dependent
+
+    def name(self) -> str:
+        return self._name
+
+    def expression(self) -> str:
+        if self._expression is None:
+            raise RuntimeError("no expression")
+        return self._expression
+
+    def expressionLanguage(self) -> _Language:
+        return _Language()
+
+    def keyframes(self) -> List[_Keyframe]:
+        return list(self._keyframes)
+
+    def isTimeDependent(self) -> bool:
+        return self._time_dependent
+
+
+class _NodeType:
+    def category(self) -> str:
+        return "obj"
+
+
+class _ObjNode:
+    def __init__(self, path: str, hou: "_Hou", transforms: Dict[float, _Matrix4], parms: Iterable[_Parm] = ()):
+        self._path = path
+        self._hou = hou
+        self._transforms = transforms
+        self._parms = {parm.name(): parm for parm in parms}
+
+    def path(self) -> str:
+        return self._path
+
+    def type(self) -> _NodeType:
+        return _NodeType()
+
+    def worldTransform(self) -> _Matrix4:
+        return self._transforms[self._hou.current_frame]
+
+    def parm(self, name: str) -> Optional[_Parm]:
+        return self._parms.get(name)
+
+    def geometry(self) -> None:
+        raise AssertionError("loop validation must not inspect or cook geometry")
+
+    def cook(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("loop validation must not cook nodes")
+
+
+class _Hou:
+    def __init__(self, original_frame: float = 42.0, fps: float = 24.0) -> None:
+        self.current_frame = original_frame
+        self._fps = fps
+        self.nodes: Dict[str, _ObjNode] = {}
+        self.set_frame_calls: List[float] = []
+
+    def frame(self) -> float:
+        return self.current_frame
+
+    def setFrame(self, frame: float) -> None:
+        self.current_frame = float(frame)
+        self.set_frame_calls.append(float(frame))
+
+    def fps(self) -> float:
+        return self._fps
+
+    def node(self, path: str) -> Optional[_ObjNode]:
+        return self.nodes.get(path)
+
+    def objNodeTypeCategory(self) -> str:
+        return "obj"
+
+
+def _constant_transforms(frames: Iterable[float], matrix: Optional[_Matrix4] = None) -> Dict[float, _Matrix4]:
+    value = matrix or _Matrix4()
+    return {float(frame): value for frame in frames}
+
+
+def test_validate_loop_contract_passes_closed_transform_and_restores_frame() -> None:
+    module = _load_validator()
+    hou = _Hou(original_frame=42.0)
+    frames = (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+    parms = [
+        _Parm("tx", expression="$F % 4", time_dependent=True),
+        _Parm("ry", keyframes=(1.0, 5.0), time_dependent=True),
+        _Parm("sx"),
+    ]
+    hou.nodes["/obj/planet"] = _ObjNode("/obj/planet", hou, _constant_transforms(frames), parms)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(["/obj/planet"], 1, 5)
+
+    assert result["success"] is True
+    context = result["context"]
+    assert context["passed"] is True
+    assert context["sample_frames"] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    assert context["virtual_periodic_frame"] == 6.0
+    assert context["original_frame"] == 42.0
+    assert context["restored_frame"] is True
+    assert hou.current_frame == 42.0
+    assert hou.set_frame_calls[-1] == 42.0
+    diagnostic = context["nodes"][0]
+    assert diagnostic["passed"] is True
+    assert diagnostic["duplicate_endpoint_hold_risk"] is False
+    assert diagnostic["endpoint_duplicate_delta"]["translation_distance"] == 0.0
+    assert diagnostic["periodic_delta"]["translation_distance"] == 0.0
+    assert diagnostic["velocity_residuals"]["linear_magnitude_per_second"] == 0.0
+    assert diagnostic["acceleration_residuals"]["angular_magnitude_degrees_per_second2"] == 0.0
+    assert diagnostic["drivers"]["counts"] == {
+        "expression": 1,
+        "keyframes": 1,
+        "static": 1,
+        "time_dependent": 0,
+    }
+
+
+def test_validate_loop_contract_reports_seam_and_derivative_failures() -> None:
+    module = _load_validator()
+    hou = _Hou()
+    transforms = {
+        1.0: _Matrix4((0, 0, 0), rotate_z=0, scale=(1, 1, 1)),
+        2.0: _Matrix4((1, 0, 0), rotate_z=10, scale=(1, 1, 1)),
+        3.0: _Matrix4((4, 0, 0), rotate_z=30, scale=(1, 1, 1)),
+        9.0: _Matrix4((8, 0, 0), rotate_z=80, scale=(2, 1, 1)),
+        10.0: _Matrix4((10, 0, 0), rotate_z=90, scale=(2, 1, 1)),
+        11.0: _Matrix4((15, 0, 0), rotate_z=120, scale=(2, 1, 1)),
+    }
+    hou.nodes["/obj/bad_loop"] = _ObjNode("/obj/bad_loop", hou, transforms)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(["/obj/bad_loop"], 1, 10)
+
+    assert result["success"] is True
+    diagnostic = result["context"]["nodes"][0]
+    assert result["context"]["passed"] is False
+    assert diagnostic["passed"] is False
+    assert diagnostic["endpoint_duplicate_delta"]["translation_distance"] == pytest.approx(10.0)
+    assert diagnostic["periodic_delta"]["translation_distance"] == pytest.approx(15.0)
+    assert diagnostic["periodic_delta"]["angular_degrees"] == pytest.approx(120.0)
+    assert diagnostic["periodic_delta"]["scale_max_abs"] == pytest.approx(1.0)
+    assert diagnostic["velocity_residuals"]["linear_magnitude_per_second"] > 0
+    assert diagnostic["acceleration_residuals"]["linear_magnitude_per_second2"] > 0
+    assert hou.current_frame == 42.0
+
+
+def test_validate_loop_contract_uses_shortest_angular_arc() -> None:
+    module = _load_validator()
+    hou = _Hou()
+    transforms = {}
+    for frame in (1.0, 2.0, 3.0):
+        transforms[frame] = _Matrix4(rotate_z=179.0)
+    for frame in (9.0, 10.0, 11.0):
+        transforms[frame] = _Matrix4(rotate_z=-179.0)
+    hou.nodes["/obj/wrapped"] = _ObjNode("/obj/wrapped", hou, transforms)
+    relaxed = {
+        "matrix_max_abs": 10.0,
+        "translation": 1.0,
+        "angular_degrees": 3.0,
+        "scale": 1.0,
+        "linear_velocity": 1.0,
+        "angular_velocity_degrees": 1.0,
+        "linear_acceleration": 1.0,
+        "angular_acceleration_degrees": 1.0,
+    }
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(["/obj/wrapped"], 1, 10, tolerances=relaxed)
+
+    diagnostic = result["context"]["nodes"][0]
+    assert diagnostic["periodic_delta"]["angular_degrees"] == pytest.approx(2.0)
+    assert diagnostic["checks"]["periodic_angular"] is True
+
+
+def test_validate_loop_contract_treats_range_as_unique_periodic_samples() -> None:
+    module = _load_validator()
+    hou = _Hou()
+    transforms = {float(frame): _Matrix4(rotate_z=(frame - 1) * 72.0) for frame in (1, 2, 3, 4, 5, 6)}
+    hou.nodes["/obj/unique_samples"] = _ObjNode("/obj/unique_samples", hou, transforms)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(["/obj/unique_samples"], 1, 5)
+
+    diagnostic = result["context"]["nodes"][0]
+    assert result["context"]["passed"] is True
+    assert diagnostic["endpoint_duplicate_delta"]["angular_degrees"] == pytest.approx(72.0)
+    assert diagnostic["periodic_delta"]["angular_degrees"] == pytest.approx(0.0)
+    assert diagnostic["velocity_residuals"]["angular_magnitude_degrees_per_second"] == pytest.approx(0.0)
+    assert diagnostic["acceleration_residuals"]["angular_magnitude_degrees_per_second2"] == pytest.approx(
+        0.0, abs=1.0e-9
+    )
+
+
+def test_validate_loop_contract_flags_duplicate_endpoint_hold_without_failing_static_nodes() -> None:
+    module = _load_validator()
+    hou = _Hou()
+    moving = {float(frame): _Matrix4(rotate_z=(frame - 1) * 90.0) for frame in (1, 2, 3, 4, 5, 6)}
+    hou.nodes["/obj/moving"] = _ObjNode("/obj/moving", hou, moving)
+    hou.nodes["/obj/static"] = _ObjNode("/obj/static", hou, _constant_transforms((1.0, 2.0, 3.0, 4.0, 5.0, 6.0)))
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(["/obj/moving", "/obj/static"], 1, 5)
+
+    moving_diagnostic, static_diagnostic = result["context"]["nodes"]
+    assert moving_diagnostic["endpoint_duplicate_delta"]["angular_degrees"] == pytest.approx(0.0)
+    assert moving_diagnostic["first_step_motion"]["angular_degrees"] == pytest.approx(90.0)
+    assert moving_diagnostic["duplicate_endpoint_hold_risk"] is True
+    assert static_diagnostic["duplicate_endpoint_hold_risk"] is False
+
+
+def test_validate_loop_contract_marks_non_finite_samples_and_restores_frame() -> None:
+    module = _load_validator()
+    hou = _Hou(original_frame=17.0)
+    transforms = _constant_transforms((1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+    transforms[6.0] = _Matrix4(
+        translate=(float("nan"), 0, 0),
+        matrix_override=(float("nan"),) + (0.0,) * 15,
+    )
+    hou.nodes["/obj/nonfinite"] = _ObjNode("/obj/nonfinite", hou, transforms)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(["/obj/nonfinite"], 1, 5)
+
+    assert result["success"] is True
+    diagnostic = result["context"]["nodes"][0]
+    assert diagnostic["finite"] is False
+    assert diagnostic["passed"] is False
+    assert diagnostic["checks"]["finite"] is False
+    assert hou.current_frame == 17.0
+
+
+@pytest.mark.parametrize(
+    "node_paths,start,end,error_fragment",
+    [
+        (["/stage/world"], 1, 5, "under /obj"),
+        (["/obj/a"] * 65, 1, 5, "at most 64"),
+        (["/obj/a"], -1_000_001, 5, "bounded"),
+        (["/obj/a"], 999_995, 1_000_000, "virtual"),
+        (["/obj/a"], 1, 4, "at least four sample steps"),
+    ],
+)
+def test_validate_loop_contract_rejects_unbounded_requests(
+    node_paths: List[str], start: float, end: float, error_fragment: str
+) -> None:
+    module = _load_validator()
+    hou = _Hou()
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = module.validate_loop_contract(node_paths, start, end)
+    assert result["success"] is False
+    assert error_fragment in result["error"]
+    assert hou.set_frame_calls == []
+
+
+def _post_mcp(url: str, payload: dict) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return json.loads(response.read())
+
+
+def test_loop_validator_discovery_load_and_call_path(monkeypatch, tmp_path: Path) -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    metadata = next(tool for tool in tools if tool["name"] == "validate_loop_contract")
+    assert metadata["source_file"] == "scripts/validate_loop_contract.py"
+    assert metadata["execution"] == "sync"
+    assert metadata["affinity"] == "main"
+    assert metadata["read_only"] is True
+    assert metadata["destructive"] is False
+    assert metadata["idempotent"] is True
+
+    monkeypatch.setenv("MCP_LOG_LEVEL", "WARN")
+    monkeypatch.setenv("DCC_MCP_LOG_LEVEL", "WARN")
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    config = McpHttpConfig(port=0, server_name="houdini-animation-loop-test")
+    config.gateway_port = 0
+    dispatcher = QueueDispatcher()
+    host = StandaloneHost(dispatcher)
+    calls = []
+
+    def executor(script_path: str, params: dict, **call_metadata: Any) -> dict:
+        calls.append({"script_path": script_path, "params": params, **call_metadata})
+        return {"success": True, "message": "captured", "context": {"passed": True}}
+
+    server = create_skill_server("houdini", config)
+    server.attach_dispatcher(dispatcher)
+    server.set_in_process_executor(executor)
+    assert server.discover(extra_paths=[str(_SKILLS_ROOT)]) >= 1
+    loaded = server.load_skill("houdini-animation")
+    assert "houdini_animation__validate_loop_contract" in loaded
+
+    host.start()
+    handle = server.start()
+    try:
+        listed = _post_mcp(handle.mcp_url(), {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        listed_tools = {tool["name"]: tool for tool in listed["result"]["tools"]}
+        assert listed_tools["validate_loop_contract"]["annotations"]["readOnlyHint"] is True
+
+        arguments = {"node_paths": ["/obj/planet"], "start_frame": 1, "end_frame": 5}
+        called = _post_mcp(
+            handle.mcp_url(),
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "validate_loop_contract", "arguments": arguments},
+            },
+        )
+        assert called["result"]["isError"] is False
+        assert called["result"]["structuredContent"]["context"]["passed"] is True
+    finally:
+        handle.shutdown()
+        host.stop()
+
+    assert len(calls) == 1
+    assert calls[0]["params"] == arguments
+    assert calls[0]["action_name"] == "houdini_animation__validate_loop_contract"
+    assert calls[0]["thread_affinity"] == "main"
+    assert calls[0]["execution"] == "sync"


### PR DESCRIPTION
## Summary
- add `validate_loop_contract`, a bounded read-only main-affinity validator for OBJ world-transform animation loops
- treat `[start_frame, end_frame]` as unique playback samples and use virtual `end_frame + sample_step` for authoritative periodic seam checks
- report endpoint-duplicate and periodic transform deltas, linear/angular velocity and acceleration residuals, transform driver summaries, and a diagnostic-only duplicate-endpoint hold risk
- restore the original frame in `finally`; avoid geometry inspection, geometry cooking, and scene writes

## Contract
- accepts 1-64 unique `/obj` node paths and bounded frame/sample-step values
- samples exactly six neighboring transform frames per resolved node
- preserves validation failures as structured per-node diagnostics while execution remains successful
- exposes explicit source, sync execution, main affinity, safety annotations, and a closed input schema

## Validation
- `pytest tests -q`: 525 passed, 1 skipped, 3 deselected
- `pytest tests/test_packaging.py -m packaging -q`: 3 passed
- Ruff check and format check passed
- bundled skill validator passed with 31 skills, 0 errors, 0 warnings
- Python 3.7 syntax check passed
- wheel and sdist build passed; Twine checks passed