### PR TITLE
Fix headless Hython main-thread dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ server = dcc_mcp_houdini.start_server()
 print(server.mcp_url)  # Exact direct endpoint selected by the OS
 ```
 
+`start_server()` is the interactive Houdini API and uses Houdini's budgeted
+event-loop pump. Headless Hython must keep its owning thread available for HOM
+work; launch the foreground pump instead:
+
+```powershell
+hython -m dcc_mcp_houdini
+```
+
+or call `dcc_mcp_houdini.serve_headless(...)` from a dedicated Hython
+entrypoint. A plain headless `start_server()` fails before tools are registered
+instead of silently executing HOM on an HTTP worker.
+
 Default minimal mode (`DCC_MCP_MINIMAL=1`) loads only:
 
 - `houdini-scripting`

--- a/docs/guide/local-mcp-debug.md
+++ b/docs/guide/local-mcp-debug.md
@@ -82,7 +82,9 @@ Use **`http://127.0.0.1:9765/mcp`** only when a separate gateway process owns th
 hython examples/houdini_bootstrap.py
 ```
 
-Prints `MCP_URL=...` when the server starts in background mode.
+Prints `MCP_URL=...` and then drives the bounded MCP queue on Hython's owning
+thread. Do not replace this foreground bootstrap with `start_server()` plus a
+sleep loop: that loop cannot satisfy main-thread affinity for HOM tools.
 
 ## 6. Quick checklist
 

--- a/examples/houdini_bootstrap.py
+++ b/examples/houdini_bootstrap.py
@@ -8,25 +8,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from dcc_mcp_core.host import BlockingDispatcher
-
-from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
-from dcc_mcp_houdini.server import HoudiniMcpServer
+from dcc_mcp_houdini.server import serve_headless
 
 
 def main(port: Optional[int] = None) -> None:
     """Start the MCP server and block while the headless host pumps jobs."""
-    blocking = BlockingDispatcher()
-    dispatcher = HoudiniCallableDispatcher(blocking)
-    server = HoudiniMcpServer(port=port, dispatcher=dispatcher)
-    server.register_builtin_actions()
-    server.start()
-    server.discover_skills()
-    print(f"MCP_URL={server.mcp_url}", flush=True)
-    try:
-        HoudiniHost(blocking).run_headless()
-    finally:
-        server.stop()
+    serve_headless(
+        port=port,
+        on_started=lambda server: print(f"MCP_URL={server.mcp_url}", flush=True),
+    )
 
 
 if __name__ == "__main__":

--- a/examples/start_server.py
+++ b/examples/start_server.py
@@ -1,8 +1,8 @@
 """Example: start dcc-mcp-houdini inside Houdini.
 
-Run in Houdini's Python Source Editor, or:
+Run in Houdini's Python Source Editor. For headless Hython use:
 
-    hython examples/start_server.py
+    hython examples/houdini_bootstrap.py
 """
 
 from __future__ import annotations
@@ -11,16 +11,5 @@ import dcc_mcp_houdini
 
 print("Starting dcc-mcp-houdini server...")
 server = dcc_mcp_houdini.start_server()
-
 print(f"MCP endpoint: {server.mcp_url}")
 print(f"Loaded skills: {server.loaded_skill_count()}")
-
-try:
-    import time
-
-    while True:
-        time.sleep(1)
-except KeyboardInterrupt:
-    print("\nStopping server...")
-    dcc_mcp_houdini.stop_server()
-    print("Done.")

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -255,6 +255,18 @@ def bootstrap_and_start() -> object:
 
     import dcc_mcp_houdini
 
+    try:
+        import hou
+
+        if not hou.isUIAvailable():
+            print(
+                "dcc-mcp-houdini: headless startup hook skipped; "
+                "run `hython -m dcc_mcp_houdini` for the foreground main-thread pump"
+            )
+            return None
+    except ImportError:
+        pass
+
     gateway_raw = os.environ.get("DCC_MCP_GATEWAY_PORT")
     gateway_port = int(gateway_raw) if gateway_raw and gateway_raw.isdigit() else None
     registry_dir = os.environ.get("DCC_MCP_REGISTRY_DIR") or None

--- a/src/dcc_mcp_houdini/__init__.py
+++ b/src/dcc_mcp_houdini/__init__.py
@@ -85,6 +85,7 @@ from dcc_mcp_houdini.server import (
     HoudiniMcpServer,
     HoudiniServerOptions,
     get_server,
+    serve_headless,
     start_server,
     stop_server,
 )
@@ -147,6 +148,7 @@ __all__ = [
     "require_param",
     "resolve_enable_gateway_failover",
     "resolve_minimal_mode_enabled",
+    "serve_headless",
     "skills_for_stage",
     "start_server",
     "stop_server",

--- a/src/dcc_mcp_houdini/__main__.py
+++ b/src/dcc_mcp_houdini/__main__.py
@@ -1,0 +1,8 @@
+"""Run the foreground Hython MCP server with ``python -m dcc_mcp_houdini``."""
+
+from __future__ import annotations
+
+from dcc_mcp_houdini.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dcc_mcp_houdini/cli.py
+++ b/src/dcc_mcp_houdini/cli.py
@@ -7,7 +7,7 @@ import logging
 import sys
 from typing import Optional
 
-from dcc_mcp_houdini import start_server, stop_server
+from dcc_mcp_houdini import serve_headless
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -23,19 +23,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
 
-    server = start_server(port=args.port, gateway_port=args.gateway_port)
-
-    print(f"Houdini MCP server started: {server.mcp_url}")
-    print("Press Ctrl+C to stop...")
-
     try:
-        import time
 
-        while True:
-            time.sleep(1)
+        def _announce(server) -> None:
+            print(f"Houdini MCP server started: {server.mcp_url}", flush=True)
+            print("Press Ctrl+C to stop...", flush=True)
+
+        serve_headless(port=args.port, gateway_port=args.gateway_port, on_started=_announce)
     except KeyboardInterrupt:
         print("\nShutting down...")
-        stop_server()
 
     return 0
 

--- a/src/dcc_mcp_houdini/dispatcher/__init__.py
+++ b/src/dcc_mcp_houdini/dispatcher/__init__.py
@@ -20,7 +20,8 @@ def create_execution_stack():
 
     Returns:
         ``(dispatcher, host)`` where interactive Houdini receives a started
-        :class:`HoudiniUiPump`, while headless ``hython`` uses inline dispatch.
+        :class:`HoudiniUiPump`, while headless ``hython`` receives an unstarted
+        :class:`HoudiniHost` that its foreground entry point must pump.
     """
     try:
         import hou  # noqa: PLC0415
@@ -30,7 +31,10 @@ def create_execution_stack():
         ui_available = False
 
     if not ui_available:
-        return HoudiniStandaloneDispatcher(), None
+        from dcc_mcp_core.host import BlockingDispatcher
+
+        blocking = BlockingDispatcher()
+        return HoudiniCallableDispatcher(blocking), HoudiniHost(blocking)
 
     dispatcher = HoudiniUiDispatcher()
     host = HoudiniUiPump(dispatcher)

--- a/src/dcc_mcp_houdini/host.py
+++ b/src/dcc_mcp_houdini/host.py
@@ -199,6 +199,59 @@ class HoudiniCallableDispatcher:
         handle = self._dispatcher.post(_invoke)
         return handle.wait(timeout_hint_secs)
 
+    def submit_async_callable(
+        self,
+        request_id: str,
+        task: Callable[[], Any],
+        *,
+        job_id: Optional[str] = None,
+        progress_token: Optional[str] = None,
+        on_complete: Optional[Callable[[dict], None]] = None,
+        affinity: str = "main",
+        timeout_ms: Optional[int] = None,
+    ) -> dict:
+        """Queue a readiness/lifecycle probe without executing off-thread."""
+        _ = (progress_token, timeout_ms)
+
+        def _invoke() -> dict:
+            try:
+                result = {
+                    "request_id": request_id,
+                    "job_id": job_id,
+                    "affinity": affinity,
+                    "success": True,
+                    "status": "completed",
+                    "output": task(),
+                    "error": None,
+                }
+            except Exception as exc:  # noqa: BLE001 - preserve dispatcher result contract
+                result = {
+                    "request_id": request_id,
+                    "job_id": job_id,
+                    "affinity": affinity,
+                    "success": False,
+                    "status": "failed",
+                    "output": None,
+                    "error": str(exc),
+                }
+            if on_complete is not None:
+                try:
+                    on_complete(result)
+                except Exception as exc:  # noqa: BLE001 - isolate lifecycle observers
+                    logger.warning("Houdini headless completion callback failed: %s", exc)
+            return result
+
+        self._dispatcher.post(_invoke)
+        return {
+            "request_id": request_id,
+            "job_id": job_id,
+            "affinity": affinity,
+            "success": True,
+            "status": "queued",
+            "output": None,
+            "error": None,
+        }
+
     def tick(self, max_jobs: int):
         """Drain queued callables from Houdini's main thread."""
         return self._dispatcher.tick(max_jobs)
@@ -315,6 +368,11 @@ class HoudiniHost(HostAdapter):
             return not bool(hou.isUIAvailable())
         except ImportError:
             return True
+
+    def run_headless(self, stop_event: Optional[threading.Event] = None) -> None:
+        """Pump on Hython's owning thread until shutdown is requested."""
+        self._tick_thread_ident = threading.get_ident()
+        super().run_headless(stop_event=stop_event)
 
     def attach_tick(self, tick_fn: TickFn) -> None:
         """Register ``tick_fn`` with ``hou.ui.addEventLoopCallback``."""

--- a/src/dcc_mcp_houdini/server.py
+++ b/src/dcc_mcp_houdini/server.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from dcc_mcp_core import DccServerOptions, HostExecutionBridge, MinimalModeConfig
 from dcc_mcp_core.server_base import DccServerBase
@@ -160,7 +161,7 @@ class HoudiniMcpServer(DccServerBase):
         super().__init__(options=options.to_core_options())
 
         self._extra_skill_paths: List[str] = list(options.extra_skill_paths or [])
-        self._houdini_dispatcher = self._dcc_dispatcher
+        self._houdini_dispatcher = options.dispatcher or self._dcc_dispatcher
         self._houdini_host: Any = None
         self.readiness: Any = None
 
@@ -584,6 +585,75 @@ _server_instance: Optional[HoudiniMcpServer] = None
 _host_instance: Any = None
 
 
+def _start_server_with_stack(
+    *,
+    dispatcher: Any,
+    host: Any,
+    port: Optional[int] = None,
+    extra_skill_paths: Optional[List[str]] = None,
+    register_builtins: bool = True,
+    include_bundled: bool = True,
+    enable_hot_reload: bool = False,
+    gateway_port: Optional[int] = None,
+    registry_dir: Optional[str] = None,
+    dcc_version: Optional[str] = None,
+    scene: Optional[str] = None,
+    enable_gateway_failover: Optional[bool] = None,
+    metrics_enabled: Optional[bool] = None,
+    job_storage_path: Optional[str] = None,
+    enable_workflows: Optional[bool] = None,
+    wait_ready: bool = True,
+    readiness_timeout_secs: Optional[int] = None,
+) -> HoudiniMcpServer:
+    """Start the process singleton using an already-selected host stack."""
+    global _server_instance, _host_instance  # noqa: PLW0603
+
+    if _server_instance is not None and _server_instance.is_running:
+        return _server_instance
+
+    _host_instance = host
+    try:
+        _server_instance = HoudiniMcpServer(
+            port=port,
+            extra_skill_paths=extra_skill_paths,
+            gateway_port=gateway_port,
+            registry_dir=registry_dir,
+            dcc_version=dcc_version,
+            scene=scene,
+            enable_gateway_failover=enable_gateway_failover,
+            metrics_enabled=metrics_enabled,
+            job_storage_path=job_storage_path,
+            enable_workflows=enable_workflows,
+            dispatcher=dispatcher,
+        )
+        if host is not None:
+            _server_instance.attach_host(host)
+
+        if register_builtins:
+            _server_instance.register_builtin_actions(include_bundled=include_bundled)
+        if enable_hot_reload:
+            _server_instance.enable_hot_reload()
+
+        _server_instance.start()
+
+        if wait_ready:
+            from dcc_mcp_houdini._readiness import resolve_readiness_timeout_secs, wait_until_ready
+
+            wait_until_ready(_server_instance, timeout=resolve_readiness_timeout_secs(readiness_timeout_secs) or 30)
+
+        logger.info("[%s] MCP server listening on %s", _DCC_NAME, _server_instance.mcp_url)
+        return _server_instance
+    except Exception:
+        if _server_instance is not None:
+            try:
+                _server_instance.stop()
+            except Exception:  # noqa: BLE001 - preserve the startup error
+                pass
+        _server_instance = None
+        _host_instance = None
+        raise
+
+
 def start_server(
     port: Optional[int] = None,
     extra_skill_paths: Optional[List[str]] = None,
@@ -601,20 +671,33 @@ def start_server(
     wait_ready: bool = True,
     readiness_timeout_secs: Optional[int] = None,
 ) -> HoudiniMcpServer:
-    """Start the Houdini MCP server (creates a process-level singleton)."""
-    global _server_instance, _host_instance  # noqa: PLW0603
+    """Start an interactive Houdini server driven by the UI event loop.
 
+    Headless Hython has no native event loop that can safely own HOM calls.
+    Use :func:`serve_headless` so the calling thread becomes the cooperative
+    queue pump instead of executing tools on an HTTP worker.
+    """
     if _server_instance is not None and _server_instance.is_running:
         return _server_instance
 
     from dcc_mcp_houdini.dispatcher import create_execution_stack
+    from dcc_mcp_houdini.host import HoudiniHost
 
     dispatcher, host = create_execution_stack()
-    _host_instance = host
-
-    _server_instance = HoudiniMcpServer(
+    if isinstance(host, HoudiniHost):
+        host.stop()
+        raise RuntimeError(
+            "Headless Hython cannot use start_server(); use serve_headless() "
+            "or the dcc-mcp-houdini CLI so HOM tools run on Hython's owning thread"
+        )
+    return _start_server_with_stack(
+        dispatcher=dispatcher,
+        host=host,
         port=port,
         extra_skill_paths=extra_skill_paths,
+        register_builtins=register_builtins,
+        include_bundled=include_bundled,
+        enable_hot_reload=enable_hot_reload,
         gateway_port=gateway_port,
         registry_dir=registry_dir,
         dcc_version=dcc_version,
@@ -623,25 +706,66 @@ def start_server(
         metrics_enabled=metrics_enabled,
         job_storage_path=job_storage_path,
         enable_workflows=enable_workflows,
-        dispatcher=dispatcher,
+        wait_ready=wait_ready,
+        readiness_timeout_secs=readiness_timeout_secs,
     )
-    if host is not None:
-        _server_instance.attach_host(host)
 
-    if register_builtins:
-        _server_instance.register_builtin_actions(include_bundled=include_bundled)
-    if enable_hot_reload:
-        _server_instance.enable_hot_reload()
 
-    _server_instance.start()
+def serve_headless(
+    port: Optional[int] = None,
+    extra_skill_paths: Optional[List[str]] = None,
+    register_builtins: bool = True,
+    include_bundled: bool = True,
+    enable_hot_reload: bool = False,
+    gateway_port: Optional[int] = None,
+    registry_dir: Optional[str] = None,
+    dcc_version: Optional[str] = None,
+    scene: Optional[str] = None,
+    enable_gateway_failover: Optional[bool] = None,
+    metrics_enabled: Optional[bool] = None,
+    job_storage_path: Optional[str] = None,
+    enable_workflows: Optional[bool] = None,
+    stop_event: Optional[threading.Event] = None,
+    on_started: Optional[Callable[[HoudiniMcpServer], None]] = None,
+) -> None:
+    """Serve headless Hython while pumping MCP jobs on the calling thread."""
+    if _server_instance is not None and _server_instance.is_running:
+        raise RuntimeError("A Houdini MCP server is already running in this process")
 
-    if wait_ready:
-        from dcc_mcp_houdini._readiness import resolve_readiness_timeout_secs, wait_until_ready
+    from dcc_mcp_houdini.dispatcher import create_execution_stack
+    from dcc_mcp_houdini.host import HoudiniHost
 
-        wait_until_ready(_server_instance, timeout=resolve_readiness_timeout_secs(readiness_timeout_secs) or 30)
+    dispatcher, host = create_execution_stack()
+    if not isinstance(host, HoudiniHost):
+        raise RuntimeError("serve_headless() requires Hython without the Houdini UI; use start_server() in the GUI")
 
-    logger.info("[%s] MCP server listening on %s", _DCC_NAME, _server_instance.mcp_url)
-    return _server_instance
+    server = _start_server_with_stack(
+        dispatcher=dispatcher,
+        host=host,
+        port=port,
+        extra_skill_paths=extra_skill_paths,
+        register_builtins=register_builtins,
+        include_bundled=include_bundled,
+        enable_hot_reload=enable_hot_reload,
+        gateway_port=gateway_port,
+        registry_dir=registry_dir,
+        dcc_version=dcc_version,
+        scene=scene,
+        enable_gateway_failover=enable_gateway_failover,
+        metrics_enabled=metrics_enabled,
+        job_storage_path=job_storage_path,
+        enable_workflows=enable_workflows,
+        wait_ready=False,
+    )
+    try:
+        if on_started is not None:
+            on_started(server)
+        host.run_headless(stop_event=stop_event)
+    finally:
+        if get_server() is server:
+            stop_server()
+        else:
+            server.stop()
 
 
 def stop_server() -> None:
@@ -649,9 +773,11 @@ def stop_server() -> None:
     global _server_instance, _host_instance  # noqa: PLW0603
     if _server_instance is None:
         return
-    _server_instance.stop()
-    _server_instance = None
-    _host_instance = None
+    try:
+        _server_instance.stop()
+    finally:
+        _server_instance = None
+        _host_instance = None
 
 
 def get_server() -> Optional[HoudiniMcpServer]:

--- a/tests/test_headless_server.py
+++ b/tests/test_headless_server.py
@@ -1,0 +1,165 @@
+"""Headless Hython server lifecycle regressions.
+
+Metadata-only checks cannot prove that HOM work reaches Hython's owning
+thread.  These tests therefore cross the real MCP HTTP boundary and require a
+main-affinity tool to report the same thread that entered the foreground pump.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import urllib.request
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _post_mcp(url: str, payload: dict) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return json.loads(response.read())
+
+
+def test_headless_stack_is_an_unstarted_foreground_pump() -> None:
+    from dcc_mcp_houdini.dispatcher import create_execution_stack
+    from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
+
+    hou = SimpleNamespace(isUIAvailable=lambda: False)
+    with patch.dict(sys.modules, {"hou": hou}):
+        dispatcher, host = create_execution_stack()
+
+    assert isinstance(dispatcher, HoudiniCallableDispatcher)
+    assert isinstance(host, HoudiniHost)
+    assert host.is_running is False
+
+
+def test_start_server_rejects_headless_mode_before_server_construction(monkeypatch, tmp_path) -> None:
+    import dcc_mcp_houdini.server as server_module
+
+    hou = SimpleNamespace(isUIAvailable=lambda: False)
+    constructed = []
+
+    class UnexpectedServer:
+        def __init__(self, *args, **kwargs) -> None:
+            constructed.append((args, kwargs))
+
+    monkeypatch.setattr(server_module, "HoudiniMcpServer", UnexpectedServer)
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    with patch.dict(sys.modules, {"hou": hou}):
+        with pytest.raises(RuntimeError, match="serve_headless"):
+            server_module.start_server(wait_ready=False)
+
+    assert constructed == []
+
+
+def test_serve_headless_runs_real_main_affinity_on_owning_thread(monkeypatch, tmp_path) -> None:
+    from dcc_mcp_houdini.server import serve_headless
+
+    monkeypatch.setenv("MCP_LOG_LEVEL", "WARN")
+    monkeypatch.setenv("DCC_MCP_LOG_LEVEL", "WARN")
+    monkeypatch.setenv("DCC_MCP_GATEWAY_PORT", "0")
+    monkeypatch.setenv("DCC_MCP_REGISTRY_DIR", str(tmp_path / "registry"))
+    monkeypatch.setenv("DCC_MCP_MINIMAL", "1")
+
+    owner_thread = threading.get_ident()
+    stop_event = threading.Event()
+    client_errors = []
+    client_threads = []
+    observations = {}
+    hou = SimpleNamespace(isUIAvailable=lambda: False)
+
+    def on_started(server) -> None:
+        observations["url"] = server.mcp_url
+
+        def client() -> None:
+            try:
+                listed = _post_mcp(
+                    server.mcp_url,
+                    {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                )
+                observations["listed"] = {tool["name"] for tool in listed["result"]["tools"]}
+                observations["loaded"] = _post_mcp(
+                    server.mcp_url,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "load_skill",
+                            "arguments": {"skill_name": "houdini-scripting"},
+                        },
+                    },
+                )
+                called = _post_mcp(
+                    server.mcp_url,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "execute_python",
+                            "arguments": {
+                                "code": "import threading\nresult = threading.get_ident()",
+                            },
+                        },
+                    },
+                )
+                observations["called"] = called
+            except BaseException as exc:  # noqa: BLE001 - forward client-thread failures
+                client_errors.append(exc)
+            finally:
+                stop_event.set()
+
+        thread = threading.Thread(target=client, name="headless-mcp-client", daemon=True)
+        client_threads.append(thread)
+        thread.start()
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        serve_headless(
+            gateway_port=0,
+            registry_dir=str(tmp_path / "registry"),
+            stop_event=stop_event,
+            on_started=on_started,
+        )
+
+    client_threads[0].join(timeout=1)
+    assert client_errors == []
+    assert client_threads[0].is_alive() is False
+    assert observations["listed"]
+    assert observations["loaded"]["result"]["isError"] is False
+    called = observations["called"]
+    assert called["result"]["isError"] is False
+    assert called["result"]["structuredContent"]["context"]["result"] == str(owner_thread)
+
+    from dcc_mcp_houdini.server import get_server
+
+    assert get_server() is None
+
+
+def test_headless_dispatch_wait_times_out_and_shutdown_cancels_pending_work() -> None:
+    from dcc_mcp_core.host import DispatchError
+
+    from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
+
+    dispatcher = HoudiniCallableDispatcher()
+    host = HoudiniHost(dispatcher.host_dispatcher)
+    executed = []
+
+    with pytest.raises(DispatchError):
+        dispatcher.dispatch_callable(
+            lambda: executed.append(True),
+            timeout_hint_secs=0.01,
+        )
+
+    assert dispatcher.host_dispatcher.has_pending() is True
+    host.stop()
+    assert dispatcher.is_shutdown() is True
+    assert executed == []

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -103,6 +103,8 @@ def test_assemble_houdini_package_without_network(monkeypatch: pytest.MonkeyPatc
     assert 'os.environ.get("DCC_MCP_REGISTRY_DIR")' in bootstrap
     assert "registry_dir=registry_dir" in bootstrap
     assert 'os.environ.get("DCC_MCP_BACKGROUND_RENDER") == "1"' in bootstrap
+    assert "not hou.isUIAvailable()" in bootstrap
+    assert "hython -m dcc_mcp_houdini" in bootstrap
     assert '[string]$PackagesDir = ""' in install_ps1
     assert "$env:DCC_MCP_HOUDINI_PACKAGES_DIR" in install_ps1
     assert "${DCC_MCP_HOUDINI_PACKAGES_DIR:-$HOME/houdini$HOUDINI_VERSION/packages}" in install_sh

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -75,11 +75,12 @@ def test_houdini_ui_dispatcher_bridge_attaches_http_queue() -> None:
 
 def test_create_execution_stack_without_hou() -> None:
     from dcc_mcp_houdini.dispatcher import create_execution_stack
-    from dcc_mcp_houdini.dispatcher.standalone import HoudiniStandaloneDispatcher
+    from dcc_mcp_houdini.host import HoudiniCallableDispatcher, HoudiniHost
 
     dispatcher, host = create_execution_stack()
-    assert isinstance(dispatcher, HoudiniStandaloneDispatcher)
-    assert host is None
+    assert isinstance(dispatcher, HoudiniCallableDispatcher)
+    assert isinstance(host, HoudiniHost)
+    assert host.is_running is False
 
 
 def test_wait_until_ready_uses_urllib(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- restore a Rust-backed host queue for headless Hython and drive it cooperatively on Hython's owning thread
- keep interactive Houdini on the existing budgeted event-loop pump and reject unsafe headless `start_server()` launches before tool registration
- add a foreground `serve_headless()`/module CLI contract, update quick-install startup behavior, and document the two launch modes

## Why
A metadata-only headless server could initialize and discover skills without wiring a `DeferredExecutor`. Main-affinity tools were therefore unavailable, and an inline fallback would violate HOM's owner-thread requirement.

## Validation
- 529 unit tests passed, 1 skipped
- 3 packaging tests passed
- Ruff check and format check passed
- Python 3.7 syntax check passed
- skill validation passed with 31 skills, 0 errors, 0 warnings
- wheel/sdist build and Twine checks passed
- real Hython 21.0.631 MCP smoke: `tools/list`, `load_skill`, and `execute_python`; the tool-reported thread ID matched the foreground pump owner thread