### PR TITLE
fix(hda): require explicit library overwrite

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     dcc: houdini
     layer: domain
     stage: authoring
-    version: "1.1.0"
+    version: "1.1.1"
     tags: [houdini, hda, otl, digital-asset, automation]
     search-hint: "install hda, expose controls, author interface, publish versioned hda, validate contract"
     search-aliases: [use hda, install hda, load otl, run digital asset, instantiate hda, execute hda, save hda, create digital asset, promote hda parameters, author hda interface, publish hda, validate hda, update hda definition, sync hda instance]
@@ -65,3 +65,8 @@ press button parms, and cook the node.
 
 `update_hda_definition` updates the current definition. `publish_hda_library`
 requires an explicit namespace, version, and overwrite policy.
+
+`save_node_as_hda` refuses an existing target by default. `overwrite=true`
+explicitly authorizes Houdini to add or replace definitions in that library
+in-place. The write is not atomic; use a new versioned path when an interrupted
+write must leave the previous file intact.

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/save_node_as_hda.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/save_node_as_hda.py
@@ -22,6 +22,7 @@ def save_node_as_hda(
     label: Optional[str] = None,
     version: Optional[str] = None,
     save_as_embedded: bool = False,
+    overwrite: bool = False,
 ) -> dict:
     """Create and save a digital asset from an existing node."""
     try:
@@ -34,6 +35,11 @@ def save_node_as_hda(
         if node is None:
             raise ValueError("Houdini node not found: {}".format(node_path))
         hda_path = validate_hda_path(hda_file_path, must_exist=False)
+        target_existed = hda_path.exists()
+        if target_existed and not overwrite:
+            raise FileExistsError(
+                "HDA file already exists: {}. Set overwrite=true to modify it in place.".format(hda_path)
+            )
         interface = hou.ParmTemplateGroup()
         for parm_tuple in node.parmTuples():
             parms = tuple(parm_tuple)
@@ -60,6 +66,7 @@ def save_node_as_hda(
             hda_file_path=str(hda_path),
             hda_name=hda_name,
             version=version,
+            overwritten=target_existed,
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to save Houdini node as Digital Asset")

--- a/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
@@ -254,7 +254,8 @@ tools:
   - name: save_node_as_hda
     description: >-
       Create a Houdini Digital Asset from an existing node and save it to an
-      HDA file. Mutates the source node type and writes a file.
+      HDA file. Mutates the source node type and writes a file. Existing files
+      are refused unless overwrite is explicitly true.
     input_schema:
       type: object
       required: [node_path, hda_file_path, hda_name]
@@ -278,8 +279,16 @@ tools:
           type: boolean
           default: false
           description: "Save embedded in hip instead of only writing to hda_file_path."
+        overwrite:
+          type: boolean
+          default: false
+          description: >-
+            Allow Houdini to modify the target library in place when it already
+            exists; Houdini may add or replace a definition. This write is not
+            atomic, so use a new versioned path when interruption-safe
+            publication is required.
     read_only: false
-    destructive: false
+    destructive: true
     idempotent: false
     execution: sync
     affinity: main
@@ -291,7 +300,7 @@ tools:
     produces: ["file:hda"]
     annotations:
       read_only_hint: false
-      destructive_hint: false
+      destructive_hint: true
       idempotent_hint: false
 
   - name: author_hda_interface

--- a/tests/test_hda_lifecycle.py
+++ b/tests/test_hda_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import sys
 from pathlib import Path
@@ -178,6 +179,54 @@ def test_save_node_as_hda_persists_promoted_subnet_interface() -> None:
     folder_template.clone.assert_not_called()
     definition.setParmTemplateGroup.assert_called_once_with(promoted_group)
     definition.save.assert_called_once_with(str(Path("/assets/solar.hda")))
+
+
+def test_save_node_as_hda_refuses_existing_library_without_explicit_overwrite(tmp_path: Path) -> None:
+    mod = _load_script("save_node_as_hda.py")
+    hda_path = tmp_path / "solar.hda"
+    hda_path.write_bytes(b"existing-library")
+    before_sha256 = hashlib.sha256(hda_path.read_bytes()).hexdigest()
+    node = MagicMock()
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = node
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.save_node_as_hda(
+            "/obj/solar_asset",
+            str(hda_path),
+            "studio::solar",
+        )
+
+    assert result["success"] is False
+    assert "already exists" in result["error"].lower()
+    assert hashlib.sha256(hda_path.read_bytes()).hexdigest() == before_sha256
+    node.createDigitalAsset.assert_not_called()
+
+
+def test_save_node_as_hda_allows_explicit_in_place_overwrite(tmp_path: Path) -> None:
+    mod = _load_script("save_node_as_hda.py")
+    hda_path = tmp_path / "solar.hda"
+    hda_path.write_bytes(b"existing-library")
+    definition = MagicMock()
+    hda_node = MagicMock()
+    hda_node.type.return_value.definition.return_value = definition
+    node = MagicMock()
+    node.parmTuples.return_value = []
+    node.createDigitalAsset.return_value = hda_node
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = node
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.save_node_as_hda(
+            "/obj/solar_asset",
+            str(hda_path),
+            "studio::solar",
+            overwrite=True,
+        )
+
+    assert result["success"] is True
+    assert result["context"]["overwritten"] is True
+    node.createDigitalAsset.assert_called_once()
 
 
 def test_update_hda_definition_saves_unlocked_contents_bumps_version_and_locks() -> None:


### PR DESCRIPTION
## Summary

- refuse an existing HDA library in `save_node_as_hda` unless `overwrite=true` is explicit
- expose the overwrite contract in the skill schema and mark the tool destructive for its worst-case path
- document that authorized in-place HDA library updates are not atomic
- preserve the pre-existing library bytes and source node when the guard rejects a call

## Validation

- `pytest tests/test_hda_lifecycle.py tests/test_hda_contract_tools.py tests/test_hda_automation_skills.py -q` (29 passed)
- `ruff check` and `ruff format --check`
- Python 3.7 syntax check
- authoritative skill validation (`31` skills, `0` errors, `0` warnings)
- branch wheel exercised in isolated Houdini 21.0.631 hython: create, inspect, instantiate, cook, and validate passed; rejected overwrite preserved the library SHA-256 and source node type; explicit overwrite added a second valid definition