### PR TITLE
feat: add typed MaterialX PBR authoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-geometry` | `create_primitive`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
 | `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
-| `houdini-materials` | `create_material`, `assign_material` |
+| `houdini-materials` | `create_material`, `assign_material`, `build_materialx_pbr`, `validate_materialx_pbr` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
 | `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `author_hda_interface`, `publish_hda_library`, `validate_hda_contract`, `update_hda_definition`, `sync_hda_instance` |
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
@@ -99,7 +99,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 196 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 198 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-geometry` | `create_primitive`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
 | `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
-| `houdini-materials` | `create_material`, `assign_material` |
+| `houdini-materials` | `create_material`, `assign_material`, `build_materialx_pbr`, `validate_materialx_pbr` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |
 | `houdini-hda` | `install_hda_file`, `list_hda_definitions`, `execute_hda`, `save_node_as_hda`, `promote_hda_parameters`, `author_hda_interface`, `publish_hda_library`, `validate_hda_contract`, `update_hda_definition`, `sync_hda_instance` |
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -34,6 +34,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Texture bake (lighting) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_lighting` |
 | Transfer high→low maps | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__transfer_maps` |
 | Create and assign material | `load_skill("houdini-materials")` → `houdini_materials__create_material` → `houdini_materials__assign_material` |
+| Build MaterialX PBR | `load_skill("houdini-materials")` → `houdini_materials__build_materialx_pbr` → `houdini_materials__validate_materialx_pbr` → `houdini_materials__assign_material` |
 | Animate & bake | `load_skill("houdini-animation")` → `houdini_animation__set_timeline` → `houdini_animation__set_keyframe` → `houdini_animation__get_keyframes` → `houdini_animation__bake_channels` / `houdini_animation__cache_simulation` |
 | Validate an animation loop | `load_skill("houdini-animation")` → `houdini_animation__validate_loop_contract` (unique playback samples; periodic seam uses virtual `end+step`) |
 | Lookdev & shader networks | `load_skill("houdini-lookdev")` → `houdini_lookdev__list_materials` → `houdini_lookdev__get_material_parms` → `houdini_lookdev__set_material_parms` → `houdini_lookdev__save_preset` / `houdini_lookdev__load_preset` |

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: houdini-materials
 description: >-
-  Authoring skill - create Houdini material nodes and assign them to renderable
-  nodes through typed HOM operations. Use when building lookdev/material
-  workflows. Not for generic node graph edits.
+  Authoring skill - create and assign Houdini materials, including typed
+  MaterialX PBR networks for Karma. Use when building lookdev/material
+  workflows from color, roughness, metallic, normal, or displacement maps. Not
+  for generic node graph edits.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
 allowed-tools: Bash Read Write Edit
@@ -13,11 +14,13 @@ metadata:
     layer: domain
     stage: authoring
     version: "1.0.0"
-    tags: [houdini, materials, lookdev, shader, assignment, authoring]
-    search-hint: "create material, assign material, shader node, lookdev"
-    search-aliases: [create material, make shader, add material, assign material, set material, principled shader, apply material to object]
+    tags: [houdini, materials, lookdev, shader, materialx, pbr, karma, displacement, assignment, authoring]
+    search-hint: "create material, assign material, MaterialX PBR, Karma shader, texture maps, normal, displacement, lookdev"
+    search-aliases: [create material, make shader, add material, assign material, set material, principled shader, materialx standard surface, pbr textures, karma material, normal map, displacement map, apply material to object]
     example-prompts:
       - "Create a red principled shader and assign it to /obj/geo1"
+      - "Build a Karma MaterialX PBR material from color, roughness, normal, and displacement textures"
+      - "Validate that /mat/planet has its MaterialX PBR channels connected"
       - "Make a new material in /mat"
       - "Assign the clay material to the selected object"
     intent: "Create Houdini material/shader nodes and assign them to renderable nodes."
@@ -43,4 +46,10 @@ metadata:
 
 Typed material authoring for Houdini scenes. Use `create_material` for material
 network nodes and `assign_material` for renderable OBJ/SOP nodes with a material
-path parameter.
+path parameter. Use `build_materialx_pbr` for a complete MaterialX Builder with
+standard-surface, normal-map, and displacement outputs, then call
+`validate_materialx_pbr` before assignment or rendering.
+
+`build_materialx_pbr` treats base color as color data and roughness, metallic,
+normal, and displacement as raw data by default. It removes the newly created
+subnet if any node or connection fails; it never replaces an existing material.

--- a/src/dcc_mcp_houdini/skills/houdini-materials/scripts/build_materialx_pbr.py
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/scripts/build_materialx_pbr.py
@@ -1,0 +1,162 @@
+"""Build a standard MaterialX PBR material network."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _material_common import get_node, hou_import_error, node_summary
+
+
+def _set_value(node: Any, name: str, value: Any) -> None:
+    if isinstance(value, (list, tuple)):
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is not None:
+            parm_tuple.set(tuple(value))
+            return
+    parm = node.parm(name)
+    if parm is None:
+        raise ValueError("Parameter {!r} not found on {}".format(name, node.path()))
+    parm.set(value)
+
+
+def _connect(target: Any, input_name: str, source: Any) -> None:
+    names = list(target.inputNames())
+    try:
+        index = names.index(input_name)
+    except ValueError:
+        raise ValueError("Input {!r} not found on {}".format(input_name, target.path())) from None
+    target.setInput(index, source, 0)
+
+
+def _image(builder: Any, name: str, file_path: str, signature: str, color_space: str) -> Any:
+    image = builder.createNode("mtlximage", node_name=name)
+    _set_value(image, "signature", signature)
+    _set_value(image, "file", file_path)
+    _set_value(image, "filecolorspace", color_space)
+    return image
+
+
+def build_materialx_pbr(
+    parent_path: str = "/mat",
+    material_name: str = "materialx_pbr",
+    base_color: Sequence[float] = (0.18, 0.18, 0.18),
+    roughness: float = 0.5,
+    metallic: float = 0.0,
+    base_color_texture: Optional[str] = None,
+    roughness_texture: Optional[str] = None,
+    metallic_texture: Optional[str] = None,
+    normal_texture: Optional[str] = None,
+    displacement_texture: Optional[str] = None,
+    normal_scale: float = 1.0,
+    displacement_scale: float = 0.01,
+    base_color_space: str = "srgb_texture",
+    data_color_space: str = "Raw",
+) -> dict:
+    """Create and wire a Karma-compatible MaterialX standard-surface material."""
+    try:
+        import hou  # noqa: PLC0415
+        import voptoolutils  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    material = None
+    try:
+        parent = get_node(hou, parent_path)
+        material = parent.createNode("subnet", node_name=material_name)
+        voptoolutils._setupMtlXBuilderSubnet(material, "kma")
+
+        surface = material.node("mtlxstandard_surface")
+        if surface is None:
+            surface = material.createNode("mtlxstandard_surface", node_name="standard_surface")
+        else:
+            surface.setName("standard_surface", unique_name=True)
+        _set_value(surface, "base_color", base_color)
+        _set_value(surface, "specular_roughness", roughness)
+        _set_value(surface, "metalness", metallic)
+
+        surface_output = material.node("surface_output")
+        displacement_output = material.node("displacement_output")
+        if surface_output is None or displacement_output is None:
+            raise RuntimeError("MaterialX builder outputs were not created")
+        surface_output.setInput(0, surface, 0)
+
+        channels: Dict[str, str] = {}
+        texture_specs: Tuple[Tuple[str, Optional[str], str, str], ...] = (
+            ("base_color", base_color_texture, "color3", base_color_space),
+            ("roughness", roughness_texture, "float", data_color_space),
+            ("metallic", metallic_texture, "float", data_color_space),
+        )
+        input_names = {
+            "base_color": "base_color",
+            "roughness": "specular_roughness",
+            "metallic": "metalness",
+        }
+        for channel, file_path, signature, color_space in texture_specs:
+            if not file_path:
+                continue
+            image = _image(material, channel + "_texture", file_path, signature, color_space)
+            _connect(surface, input_names[channel], image)
+            channels[channel] = image.path()
+
+        if normal_texture:
+            normal_image = _image(material, "normal_texture", normal_texture, "color3", data_color_space)
+            normal_map = material.createNode("mtlxnormalmap", node_name="normal_map")
+            _set_value(normal_map, "scale", normal_scale)
+            _connect(normal_map, "in", normal_image)
+            _connect(surface, "normal", normal_map)
+            channels["normal"] = normal_image.path()
+
+        displacement = material.node("mtlxdisplacement")
+        if displacement is None:
+            displacement = material.createNode("mtlxdisplacement", node_name="displacement")
+        else:
+            displacement.setName("displacement", unique_name=True)
+        if displacement_texture:
+            displacement_image = _image(
+                material,
+                "displacement_texture",
+                displacement_texture,
+                "float",
+                data_color_space,
+            )
+            _set_value(displacement, "scale", displacement_scale)
+            _connect(displacement, "displacement", displacement_image)
+            displacement_output.setInput(0, displacement, 0)
+            channels["displacement"] = displacement_image.path()
+
+        material.setUserData("dcc_mcp_material_schema", "materialx_pbr_v1")
+        material.setUserData("dcc_mcp_material_channels", ",".join(sorted(channels)))
+        material.layoutChildren()
+        return skill_success(
+            "Built MaterialX PBR material",
+            valid=True,
+            material=node_summary(material),
+            standard_surface=surface.path(),
+            channels=channels,
+        )
+    except Exception as exc:
+        if material is not None:
+            try:
+                material.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to build MaterialX PBR material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return build_materialx_pbr(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-materials/scripts/validate_materialx_pbr.py
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/scripts/validate_materialx_pbr.py
@@ -1,0 +1,102 @@
+"""Validate a MaterialX PBR material network without mutating it."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+from _material_common import get_node, hou_import_error, node_summary
+
+_CHANNELS = ("base_color", "roughness", "metallic", "normal", "displacement")
+
+
+def _input_source(node: Any, input_name: str) -> Optional[Any]:
+    names = list(node.inputNames())
+    if input_name not in names:
+        return None
+    index = names.index(input_name)
+    inputs = list(node.inputs())
+    return inputs[index] if index < len(inputs) else None
+
+
+def validate_materialx_pbr(material_path: str, required_channels: Optional[Sequence[str]] = None) -> dict:
+    """Inspect the standard surface, outputs, and requested texture channels."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    try:
+        material = get_node(hou, material_path)
+        issues = []
+        if material.userData("dcc_mcp_material_schema") != "materialx_pbr_v1":
+            issues.append("Material is not marked as a dcc-mcp MaterialX PBR network")
+
+        surface = material.node("standard_surface")
+        surface_output = material.node("surface_output")
+        displacement_output = material.node("displacement_output")
+        if surface is None or not surface.type().name().startswith("mtlxstandard_surface"):
+            issues.append("Missing MaterialX standard surface")
+        surface_source = None
+        if surface_output is not None and surface_output.inputs():
+            surface_source = surface_output.inputs()[0]
+        if surface is None or surface_source is None or surface_source.path() != surface.path():
+            issues.append("Standard surface is not connected to the surface output")
+
+        channels: Dict[str, str] = {}
+        if surface is not None:
+            for channel, input_name in (
+                ("base_color", "base_color"),
+                ("roughness", "specular_roughness"),
+                ("metallic", "metalness"),
+            ):
+                source = _input_source(surface, input_name)
+                if source is not None:
+                    channels[channel] = source.path()
+
+            normal_map = _input_source(surface, "normal")
+            if normal_map is not None:
+                normal_source = _input_source(normal_map, "in")
+                if normal_source is not None:
+                    channels["normal"] = normal_source.path()
+
+        if displacement_output is not None and displacement_output.inputs():
+            displacement = displacement_output.inputs()[0]
+            if displacement is not None:
+                displacement_source = _input_source(displacement, "displacement")
+                if displacement_source is not None:
+                    channels["displacement"] = displacement_source.path()
+
+        for channel in required_channels or ():
+            if channel not in _CHANNELS:
+                issues.append("Unsupported required channel: {}".format(channel))
+            elif channel not in channels:
+                issues.append("Required channel is not connected: {}".format(channel))
+
+        return skill_success(
+            "Validated MaterialX PBR material",
+            valid=not issues,
+            material=node_summary(material),
+            channels=channels,
+            issues=issues,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to validate MaterialX PBR material")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return validate_materialx_pbr(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-materials/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/tools.yaml
@@ -86,3 +86,140 @@ tools:
     next-tools:
       on-failure:
         - houdini_scene__get_node_info
+
+  - name: build_materialx_pbr
+    description: >-
+      Build a Karma-compatible MaterialX standard-surface material with typed
+      base-color, roughness, metallic, normal, and displacement connections.
+      Removes the partial subnet if authoring fails.
+    source_file: scripts/build_materialx_pbr.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 30
+    input_schema:
+      type: object
+      additionalProperties: false
+      properties:
+        parent_path:
+          type: string
+          default: "/mat"
+          description: Material network that receives the MaterialX builder.
+        material_name:
+          type: string
+          default: "materialx_pbr"
+          minLength: 1
+        base_color:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          default: [0.18, 0.18, 0.18]
+        roughness:
+          type: number
+          minimum: 0.0
+          maximum: 1.0
+          default: 0.5
+        metallic:
+          type: number
+          minimum: 0.0
+          maximum: 1.0
+          default: 0.0
+        base_color_texture:
+          type: string
+          description: Optional color texture path; read with base_color_space.
+        roughness_texture:
+          type: string
+          description: Optional scalar roughness texture path.
+        metallic_texture:
+          type: string
+          description: Optional scalar metallic texture path.
+        normal_texture:
+          type: string
+          description: Optional tangent-space normal texture path.
+        displacement_texture:
+          type: string
+          description: Optional scalar height/displacement texture path.
+        normal_scale:
+          type: number
+          default: 1.0
+        displacement_scale:
+          type: number
+          default: 0.01
+        base_color_space:
+          type: string
+          default: "srgb_texture"
+          description: MaterialX image color space for base color.
+        data_color_space:
+          type: string
+          default: "Raw"
+          description: MaterialX image color space for non-color data maps.
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success: {type: boolean}
+        message: {type: string}
+        context: {type: object}
+    read_only: false
+    destructive: false
+    idempotent: false
+    tool_role: action
+    risk: medium
+    search_aliases: [build materialx pbr, create karma material, wire pbr textures, materialx standard surface]
+    produces: [material]
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+      open_world_hint: true
+    next-tools:
+      on-success:
+        - houdini_materials__validate_materialx_pbr
+        - houdini_materials__assign_material
+      on-failure:
+        - houdini_scene__list_child_nodes
+
+  - name: validate_materialx_pbr
+    description: >-
+      Inspect a dcc-mcp MaterialX PBR material and report whether its standard
+      surface, outputs, and required texture channels are connected. Read-only.
+    source_file: scripts/validate_materialx_pbr.py
+    execution: sync
+    affinity: main
+    timeout_hint_secs: 15
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [material_path]
+      properties:
+        material_path:
+          type: string
+          minLength: 1
+        required_channels:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum: [base_color, roughness, metallic, normal, displacement]
+    output_schema:
+      type: object
+      additionalProperties: true
+      required: [success]
+      properties:
+        success: {type: boolean}
+        message: {type: string}
+        context: {type: object}
+    read_only: true
+    destructive: false
+    idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [validate materialx, inspect pbr material, check shader channels, verify karma material]
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    next-tools:
+      on-failure:
+        - houdini_scene__get_node_info

--- a/tests/test_materialx_pbr_skill.py
+++ b/tests/test_materialx_pbr_skill.py
@@ -1,0 +1,219 @@
+"""Behavior tests for typed MaterialX PBR authoring."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+_SCRIPTS = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills" / "houdini-materials" / "scripts"
+
+
+def _load_script(name: str) -> ModuleType:
+    path = _SCRIPTS / name
+    spec = importlib.util.spec_from_file_location("materialx_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Type:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
+class _Parm:
+    def __init__(self) -> None:
+        self.value = None
+
+    def set(self, value) -> None:
+        self.value = value
+
+    def evalAsString(self) -> str:
+        return str(self.value or "")
+
+
+_INPUTS = {
+    "mtlxstandard_surface": ["base_color", "metalness", "specular_roughness", "normal"],
+    "mtlxnormalmap": ["in", "scale"],
+    "mtlxdisplacement": ["displacement", "scale"],
+    "subnetconnector": ["suboutput"],
+}
+
+
+class _Node:
+    def __init__(self, path: str, node_type: str) -> None:
+        self._path = path
+        self._type = node_type
+        self._children = {}
+        self._inputs = []
+        self._parms = {}
+        self._user_data = {}
+        self.destroyed = False
+
+    def path(self) -> str:
+        return self._path
+
+    def name(self) -> str:
+        return self._path.rsplit("/", 1)[-1]
+
+    def type(self) -> _Type:
+        return _Type(self._type)
+
+    def inputNames(self):
+        return _INPUTS.get(self._type, [])
+
+    def inputs(self):
+        return list(self._inputs)
+
+    def setInput(self, index: int, source, _output_index: int = 0) -> None:
+        while len(self._inputs) <= index:
+            self._inputs.append(None)
+        self._inputs[index] = source
+
+    def parm(self, name: str) -> _Parm:
+        return self._parms.setdefault(name, _Parm())
+
+    def parmTuple(self, name: str) -> _Parm:
+        return self._parms.setdefault(name, _Parm())
+
+    def setUserData(self, name: str, value: str) -> None:
+        self._user_data[name] = value
+
+    def userData(self, name: str):
+        return self._user_data.get(name)
+
+    def createNode(self, node_type: str, node_name: str, **_kwargs):
+        child = _Node(self._path + "/" + node_name, node_type)
+        self._children[node_name] = child
+        return child
+
+    def node(self, name: str):
+        return self._children.get(name)
+
+    def children(self):
+        return list(self._children.values())
+
+    def layoutChildren(self) -> None:
+        pass
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+def _materialx_setup(builder: _Node, _prefix: str) -> None:
+    builder._children["surface_output"] = _Node(builder.path() + "/surface_output", "subnetconnector")
+    builder._children["displacement_output"] = _Node(builder.path() + "/displacement_output", "subnetconnector")
+
+
+def test_build_materialx_pbr_connects_requested_channels() -> None:
+    mod = _load_script("build_materialx_pbr.py")
+    parent = _Node("/mat", "matnet")
+    hou = SimpleNamespace(node=lambda path: parent if path == "/mat" else None)
+    voptoolutils = SimpleNamespace(_setupMtlXBuilderSubnet=_materialx_setup)
+
+    with patch.dict(sys.modules, {"hou": hou, "voptoolutils": voptoolutils}):
+        result = mod.build_materialx_pbr(
+            material_name="planet",
+            base_color_texture="planet_basecolor.exr",
+            roughness_texture="planet_roughness.exr",
+            metallic_texture="planet_metallic.exr",
+            normal_texture="planet_normal.exr",
+            displacement_texture="planet_height.exr",
+        )
+
+    assert result["success"] is True
+    assert result["context"]["valid"] is True
+    assert set(result["context"]["channels"]) == {
+        "base_color",
+        "roughness",
+        "metallic",
+        "normal",
+        "displacement",
+    }
+    material = parent.node("planet")
+    surface = material.node("standard_surface")
+    assert material.node("surface_output").inputs()[0] is surface
+    assert material.node("displacement_output").inputs()[0] is material.node("displacement")
+    assert surface.inputs()[0] is material.node("base_color_texture")
+    assert surface.inputs()[1] is material.node("metallic_texture")
+    assert surface.inputs()[2] is material.node("roughness_texture")
+    assert surface.inputs()[3] is material.node("normal_map")
+
+
+def test_validate_materialx_pbr_reads_back_required_channels() -> None:
+    build_mod = _load_script("build_materialx_pbr.py")
+    validate_mod = _load_script("validate_materialx_pbr.py")
+    parent = _Node("/mat", "matnet")
+
+    def node(path: str):
+        if path == "/mat":
+            return parent
+        if path.startswith("/mat/"):
+            return parent.node(path.rsplit("/", 1)[-1])
+        return None
+
+    hou = SimpleNamespace(node=node)
+    voptoolutils = SimpleNamespace(_setupMtlXBuilderSubnet=_materialx_setup)
+    with patch.dict(sys.modules, {"hou": hou, "voptoolutils": voptoolutils}):
+        built = build_mod.build_materialx_pbr(
+            material_name="planet",
+            base_color_texture="planet_basecolor.exr",
+            normal_texture="planet_normal.exr",
+            displacement_texture="planet_height.exr",
+        )
+        material = parent.node("planet")
+        surface = material.node("standard_surface")
+        material.node("surface_output")._inputs[0] = _Node(surface.path(), surface.type().name())
+        result = validate_mod.validate_materialx_pbr(
+            built["context"]["material"]["path"],
+            required_channels=["base_color", "normal", "displacement"],
+        )
+
+    assert result["success"] is True
+    assert result["context"]["valid"] is True
+    assert result["context"]["issues"] == []
+    assert set(result["context"]["channels"]) == {"base_color", "normal", "displacement"}
+
+
+def test_build_materialx_pbr_removes_partial_material_on_failure() -> None:
+    mod = _load_script("build_materialx_pbr.py")
+    parent = _Node("/mat", "matnet")
+    hou = SimpleNamespace(node=lambda path: parent if path == "/mat" else None)
+
+    def fail_setup(_builder, _prefix: str) -> None:
+        raise RuntimeError("builder setup failed")
+
+    voptoolutils = SimpleNamespace(_setupMtlXBuilderSubnet=fail_setup)
+    with patch.dict(sys.modules, {"hou": hou, "voptoolutils": voptoolutils}):
+        result = mod.build_materialx_pbr(material_name="broken")
+
+    assert result["success"] is False
+    assert parent.node("broken").destroyed is True
+
+
+def test_validate_materialx_pbr_reports_disconnected_surface() -> None:
+    build_mod = _load_script("build_materialx_pbr.py")
+    validate_mod = _load_script("validate_materialx_pbr.py")
+    parent = _Node("/mat", "matnet")
+
+    def node(path: str):
+        return parent if path == "/mat" else parent.node(path.rsplit("/", 1)[-1])
+
+    hou = SimpleNamespace(node=node)
+    voptoolutils = SimpleNamespace(_setupMtlXBuilderSubnet=_materialx_setup)
+    with patch.dict(sys.modules, {"hou": hou, "voptoolutils": voptoolutils}):
+        build_mod.build_materialx_pbr(material_name="broken_output")
+        parent.node("broken_output").node("surface_output")._inputs[0] = None
+        result = validate_mod.validate_materialx_pbr("/mat/broken_output")
+
+    assert result["success"] is True
+    assert result["context"]["valid"] is False
+    assert result["context"]["issues"] == ["Standard surface is not connected to the surface output"]


### PR DESCRIPTION
## Summary

- add `build_materialx_pbr` to create a Karma-compatible MaterialX Builder with typed base color, roughness, metallic, normal, and displacement inputs
- reuse Houdini's official builder outputs and default Standard Surface/Displacement nodes, with rollback when authoring fails
- add read-only `validate_materialx_pbr` for surface/output and required-channel verification
- update skill discovery metadata, task chains, and bundled tool documentation

## Validation

- `535 passed, 1 skipped` in a clean Python 3.12 environment with released `dcc-mcp-core 0.19.55`
- Ruff check and format pass
- all 31 bundled skills pass warnings-as-errors validation
- Python 3.7 syntax check passes
- wheel and sdist build successfully
- Houdini 21.0.631 headless smoke creates, validates, saves, reloads, and revalidates a real MaterialX PBR network
- real MCP `load_skill` and main-affinity calls pass for both new tools
