### PR TITLE
feat(render): support production Mantra pass authoring

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -37,11 +37,13 @@ agent can detect and skip cleanly when rendering is unavailable.
   (reports `unsupported` fields per ROP type), `render_rop` (foreground or
   isolated `hython` background job), `get_render_job` (polls and reconciles
   status without blocking the UI), `cancel_render_job` (cancels only jobs
-  owned by the current adapter process), `configure_aovs` (add/remove
-  AOVs with 15+ presets), `validate_karma_stage` (read-only USD/Karma
+  owned by the current adapter process), `configure_aovs` (add/remove Solaris
+  RenderVars or native Mantra auxiliary planes with renderer-correct processing),
+  `validate_karma_stage` (read-only USD/Karma
   preflight), `get_render_stats` (read resolution/samples/renderer/output).
-- **`render_layer`:** `create_render_layer` (Solaris RenderProduct or ROP merge),
-  `manage_takes` (create/switch/delete/list takes for render layer variants).
+- **`render_layer`:** `create_render_layer` (Solaris RenderProduct or cloned
+  Mantra ifd ROP with its own output and object masks), `manage_takes`
+  (take lifecycle plus parameter-tuple overrides for render variants).
 
 ## Tracer-bullet flow
 
@@ -56,16 +58,20 @@ agent can detect and skip cleanly when rendering is unavailable.
 
 ### Render Layers & AOVs
 
-1. `create_render_layer(name="beauty", parent_path="/stage", purpose="beauty", aovs=["diffuse","specular","normal","depth"])`
-2. `configure_aovs(rop_path="/stage/beauty", aovs=["motionvector","cryptomatte"], action="add")`
-3. `validate_karma_stage(lop_path="/stage/OUT", renderer="karma_xpu")` → inspect instance and RenderVar diagnostics
-4. `get_render_stats(rop_path="/stage/beauty")` → verify resolution/samples/output
+1. For Solaris, `create_render_layer(name="beauty", parent_path="/stage", purpose="beauty", aovs=["diffuse","specular","normal","depth"])`.
+2. For Mantra, clone a real pass with an output distinct from its source:
+   `create_render_layer(name="solar_fx", parent_path="/out", source_rop_path="/out/mantra1", output_path="/tmp/solar_fx.$F4.exr", candidate_objects="/obj/sun_fx", exclude_objects="/obj/labels", aovs=["emission","depth"])`.
+3. `configure_aovs(rop_path="/out/solar_fx", aovs=["normal","depth","normal"], action="add")` adds only missing Mantra planes; `action="remove"` removes matching preset/source/channel planes and compacts the multiparm.
+4. `validate_karma_stage(lop_path="/stage/OUT", renderer="karma_xpu")` → inspect instance and RenderVar diagnostics.
+5. `get_render_stats(rop_path="/out/solar_fx")` → verify resolution/samples/output.
 
 ### Takes
 
 1. `manage_takes(action="create", take_name="lighting_variant_a")`
-2. `manage_takes(action="switch", take_name="lighting_variant_a")`
-3. `manage_takes(action="list")` → review all takes
+2. `manage_takes(action="add_override", take_name="lighting_variant_a", node_path="/out/solar_fx", parm_name="vm_picture")` → add the parameter tuple while restoring the previously current take.
+3. `manage_takes(action="remove_override", take_name="lighting_variant_a", node_path="/out/solar_fx", parm_name="vm_picture")` → remove it with the same restoration guarantee.
+4. `manage_takes(action="switch", take_name="lighting_variant_a")`
+5. `manage_takes(action="list")` → review all takes
 
 Interactive Houdini defaults to an isolated process; poll
 `get_render_job(job_id)` and use `cancel_render_job(job_id)` to stop a job

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/configure_aovs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/configure_aovs.py
@@ -33,6 +33,184 @@ AOV_PRESETS = {
     "worldpos": {"source": "worldpos", "type": "vector"},
 }
 
+MANTRA_AOV_PRESETS = {
+    "diffuse": {"source": "lpe:C<RD>.*L", "type": "vector", "channel": "diffuse"},
+    "specular": {"source": "lpe:C<RG>.*[LO]", "type": "vector", "channel": "specular"},
+    "transmission": {"source": "lpe:C<TG>.*[LO]", "type": "vector", "channel": "transmission"},
+    "normal": {
+        "source": "N",
+        "type": "unitvector",
+        "channel": "normal",
+        "quantize": "float",
+        "pixel_filter": "minmax omedian",
+    },
+    "depth": {
+        "source": "Pz",
+        "type": "float",
+        "channel": "depth",
+        "quantize": "float",
+        "pixel_filter": "minmax omedian",
+    },
+    "motionvector": {
+        "source": "motion_vector",
+        "type": "vector",
+        "channel": "motionvector",
+        "quantize": "float",
+        "pixel_filter": "minmax omedian",
+    },
+    "albedo": {"source": "export_basecolor", "type": "vector", "channel": "albedo"},
+    "opacity": {"source": "Of", "type": "vector", "channel": "opacity"},
+    "emission": {
+        "source": "all_emission",
+        "type": "vector",
+        "channel": "emission",
+        "sample_filter": "fullopacity",
+    },
+    "volume": {
+        "source": "lpe:CV.*L",
+        "type": "vector",
+        "channel": "volume",
+        "sample_filter": "fullopacity",
+    },
+    "objectid": {
+        "source": "Op_Id",
+        "type": "float",
+        "channel": "objectid",
+        "quantize": "float",
+    },
+    "materialid": {
+        "source": "Material_Id",
+        "type": "float",
+        "channel": "materialid",
+        "quantize": "float",
+    },
+    "uv": {"source": "uv", "type": "vector", "channel": "uv", "quantize": "float"},
+    "worldpos": {
+        "source": "P",
+        "type": "vector",
+        "channel": "worldpos",
+        "quantize": "float",
+        "pixel_filter": "minmax omedian",
+    },
+}
+
+
+def _configure_mantra_aovs(node, aovs: List[str], action: str) -> tuple:
+    count_parm = node.parm("vm_numaux")
+    if count_parm is None:
+        return [], list(dict.fromkeys(aovs))
+
+    count = int(count_parm.eval())
+    planes = []
+    existing = set()
+    for index in range(1, count + 1):
+        source_parm = node.parm("vm_variable_plane{}".format(index))
+        channel_parm = node.parm("vm_channel_plane{}".format(index))
+        source = str(source_parm.eval()) if source_parm is not None else ""
+        channel = str(channel_parm.eval()) if channel_parm is not None else ""
+        planes.append({"index": index, "source": source, "channel": channel})
+        existing.update(value.lower() for value in (source, channel) if value)
+
+    if action == "remove":
+        configured = []
+        unsupported = []
+        removed_indices = set()
+        seen = set()
+        for requested_name in aovs:
+            name = str(requested_name).strip().lower()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            preset = MANTRA_AOV_PRESETS.get(name, {})
+            matches = {
+                value
+                for value in (
+                    name,
+                    str(preset.get("source", "")).lower(),
+                    str(preset.get("channel", "")).lower(),
+                )
+                if value
+            }
+            matching_planes = [
+                item
+                for item in planes
+                if {value for value in (item["source"].lower(), item["channel"].lower()) if value} & matches
+            ]
+            if not matching_planes:
+                unsupported.append(requested_name)
+                continue
+            new_matches = [item for item in matching_planes if item["index"] not in removed_indices]
+            if not new_matches:
+                continue
+            removed_indices.update(item["index"] for item in new_matches)
+            plane = new_matches[0]
+            configured.append(
+                {
+                    "name": name,
+                    "action": "removed",
+                    "source": plane["source"],
+                    "channel": plane["channel"],
+                }
+            )
+        for index in sorted(removed_indices, reverse=True):
+            count_parm.removeMultiParmInstance(index - 1)
+        return configured, unsupported
+
+    if action != "add":
+        return [], list(dict.fromkeys(aovs))
+
+    initial_count = count
+    configured = []
+    unsupported = []
+    seen = set()
+    for requested_name in aovs:
+        name = str(requested_name).strip().lower()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        preset = MANTRA_AOV_PRESETS.get(name)
+        if preset is None:
+            unsupported.append(requested_name)
+            continue
+        if preset["source"].lower() in existing or preset["channel"].lower() in existing:
+            continue
+
+        index = count + 1
+        count_parm.set(index)
+        plane_values = {
+            "source": preset["source"],
+            "type": preset["type"],
+            "channel": preset["channel"],
+            "quantize": preset.get("quantize", "half"),
+            "pixel_filter": preset.get("pixel_filter", ""),
+            "sample_filter": preset.get("sample_filter", "alpha"),
+        }
+        plane_parms = {
+            key: node.parm(pattern.format(index))
+            for key, pattern in (
+                ("source", "vm_variable_plane{}"),
+                ("type", "vm_vextype_plane{}"),
+                ("channel", "vm_channel_plane{}"),
+                ("quantize", "vm_quantize_plane{}"),
+                ("pixel_filter", "vm_pfilter_plane{}"),
+                ("sample_filter", "vm_sfilter_plane{}"),
+            )
+        }
+        if any(parm is None for parm in plane_parms.values()):
+            count_parm.set(count)
+            unsupported.append(requested_name)
+            continue
+        try:
+            for key, parm in plane_parms.items():
+                parm.set(plane_values[key])
+        except Exception:
+            count_parm.set(initial_count)
+            raise
+        count = index
+        existing.update((preset["source"].lower(), preset["channel"].lower()))
+        configured.append({"name": name, "action": "added", "index": index, **plane_values})
+    return configured, unsupported
+
 
 def configure_aovs(
     rop_path: str,
@@ -46,6 +224,12 @@ def configure_aovs(
         return skill_error("Houdini not available", "hou could not be imported")
 
     try:
+        if action not in ("add", "remove"):
+            return skill_error(
+                "Invalid action",
+                "action must be 'add' or 'remove'",
+                action=action,
+            )
         node = get_node(hou, rop_path)
         is_solaris = rop_path.startswith("/stage")
         configured: list = []
@@ -75,20 +259,7 @@ def configure_aovs(
                         }
                     )
         else:
-            # Traditional ROP: attempt extra image planes
-            for aov_name in aovs:
-                preset = AOV_PRESETS.get(aov_name.lower(), {"source": aov_name, "type": "raw"})
-                aov_key = "vm_numaux" if action == "add" else None
-                if aov_key and set_first_parm(node, (aov_key,), 1):
-                    configured.append(
-                        {
-                            "name": aov_name,
-                            "action": "hint_enabled",
-                            "note": "AOV enabled via vm_numaux; configure in ROP UI for exact plane names",
-                        }
-                    )
-                else:
-                    unsupported.append(aov_name)
+            configured, unsupported = _configure_mantra_aovs(node, aovs, action)
 
         return skill_success(
             "Configured AOVs",

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/create_render_layer.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/create_render_layer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -12,7 +13,17 @@ _SCRIPT_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 
-from _render_common import get_node, node_summary, set_first_parm  # noqa: E402
+from _render_common import eval_first_parm, get_node, node_summary, set_first_parm  # noqa: E402
+
+
+def _normalized_output_samples(hou, output_path: str) -> set:
+    frame = float(hou.frame())
+    samples = set()
+    for sample_frame in (frame, frame + 1.0):
+        expanded = hou.text.expandStringAtFrame(output_path, sample_frame)
+        absolute = hou.text.abspath(expanded)
+        samples.add(os.path.normcase(os.path.normpath(hou.text.normpath(absolute))))
+    return samples
 
 
 def create_render_layer(
@@ -20,6 +31,13 @@ def create_render_layer(
     parent_path: str = "/stage",
     aovs: Optional[list] = None,
     purpose: str = "beauty",
+    source_rop_path: Optional[str] = None,
+    output_path: Optional[str] = None,
+    candidate_objects: Optional[str] = None,
+    force_objects: Optional[str] = None,
+    matte_objects: Optional[str] = None,
+    exclude_objects: Optional[str] = None,
+    phantom_objects: Optional[str] = None,
 ) -> dict:
     """Create a render layer (RenderVar / RenderProduct) under *parent_path*."""
     try:
@@ -52,16 +70,92 @@ def create_render_layer(
                 aovs=created_aovs,
                 context="solaris",
             )
-        else:
-            # Traditional: create a ROP network or merge node
-            layer = parent.createNode("merge", node_name=name)
+
+        if not source_rop_path:
+            return skill_error(
+                "Missing source_rop_path",
+                "source_rop_path is required when creating a traditional ROP render layer",
+            )
+        if not output_path or not output_path.strip():
+            return skill_error(
+                "Missing output_path",
+                "output_path is required so the cloned ROP cannot overwrite its source output",
+            )
+        if not name or "/" in name or "\\" in name:
+            return skill_error("Invalid layer name", "name must be a non-empty Houdini node name")
+        if parent.node(name) is not None:
+            return skill_error(
+                "Render layer already exists",
+                "A node named '{}' already exists under '{}'".format(name, parent_path),
+            )
+
+        source = get_node(hou, source_rop_path)
+        source_type = source.type().name().split("::", 1)[0]
+        if source_type != "ifd":
+            return skill_error(
+                "Unsupported source ROP",
+                "source_rop_path must reference a Mantra ifd ROP",
+                source_rop_path=source_rop_path,
+                source_type=source_type,
+            )
+        source_output = eval_first_parm(source, ("vm_picture",), preserve_string=True)
+        if source_output is not None and _normalized_output_samples(hou, output_path) & _normalized_output_samples(
+            hou, str(source_output)
+        ):
+            return skill_error(
+                "Output path is not dedicated",
+                "output_path must differ from the source Mantra ROP output",
+                source_rop_path=source_rop_path,
+                output_path=output_path,
+            )
+
+        layer = source.copyTo(parent)
+        try:
+            layer.setName(name, unique_name=False)
+            requested_parms = {
+                "vm_picture": output_path,
+                "vobject": candidate_objects,
+                "forceobject": force_objects,
+                "matte_objects": matte_objects,
+                "excludeobject": exclude_objects,
+                "phantom_objects": phantom_objects,
+            }
+            missing = [
+                parm_name
+                for parm_name, value in requested_parms.items()
+                if value is not None and set_first_parm(layer, (parm_name,), value) is None
+            ]
+            if missing:
+                raise ValueError("Cloned Mantra ROP is missing required parameters: {}".format(", ".join(missing)))
+
+            configured_aovs = []
+            unsupported_aovs = []
+            if aovs:
+                from configure_aovs import _configure_mantra_aovs  # noqa: PLC0415
+
+                configured_aovs, unsupported_aovs = _configure_mantra_aovs(layer, aovs, "add")
+                if unsupported_aovs:
+                    raise ValueError(
+                        "Unsupported Mantra AOVs: {}".format(", ".join(str(name) for name in unsupported_aovs))
+                    )
             return skill_success(
-                "Created render layer placeholder (ROP)",
+                "Created render layer (Mantra ROP)",
                 node=node_summary(layer),
                 purpose=purpose,
                 context="rop",
-                hint="Use houdini_nodes to add ROP drivers inside this network",
+                source_rop_path=source_rop_path,
+                output_path=output_path,
+                masks={
+                    key: value for key, value in requested_parms.items() if key != "vm_picture" and value is not None
+                },
+                aovs=configured_aovs,
+                unsupported_aovs=unsupported_aovs,
             )
+        except Exception:
+            destroy = getattr(layer, "destroy", None)
+            if callable(destroy):
+                destroy()
+            raise
     except Exception as exc:
         return skill_exception(exc, message="Failed to create render layer")
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/manage_takes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/manage_takes.py
@@ -16,8 +16,10 @@ if _SCRIPT_DIR not in sys.path:
 def manage_takes(
     action: str = "list",
     take_name: Optional[str] = None,
+    node_path: Optional[str] = None,
+    parm_name: Optional[str] = None,
 ) -> dict:
-    """Create, switch, delete, or list takes in the current Houdini session."""
+    """Manage takes and their parameter-tuple overrides."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
@@ -53,12 +55,65 @@ def manage_takes(
                     "A take named '{}' already exists".format(take_name),
                     take_name=take_name,
                 )
-            takes.createTake(take_name)
+            takes.rootTake().addChildTake(take_name)
             return skill_success(
                 "Created take",
                 take_name=take_name,
                 current_take=current.name(),
             )
+
+        if action in ("add_override", "remove_override"):
+            if not take_name:
+                return skill_error("Missing take_name", "take_name is required for action={}".format(action))
+            target = takes.findTake(take_name)
+            if not target:
+                return skill_error(
+                    "Take not found",
+                    "Take '{}' does not exist".format(take_name),
+                    take_name=take_name,
+                )
+            if target.parent() is None:
+                return skill_error("Invalid take", "Parameter overrides require a child take")
+            if not node_path or not parm_name:
+                return skill_error(
+                    "Missing parameter",
+                    "node_path and parm_name are required for action={}".format(action),
+                )
+            node = hou.node(node_path)
+            if node is None:
+                return skill_error("Node not found", "Houdini node not found: {}".format(node_path))
+            parm_tuple = node.parmTuple(parm_name)
+            if parm_tuple is None:
+                parm = node.parm(parm_name)
+                tuple_method = getattr(parm, "tuple", None)
+                parm_tuple = tuple_method() if callable(tuple_method) else None
+            if parm_tuple is None:
+                return skill_error(
+                    "Parameter not found",
+                    "Parameter tuple '{}' was not found on '{}'".format(parm_name, node_path),
+                )
+
+            changed = False
+            takes.setCurrentTake(target)
+            try:
+                included = target.hasParmTuple(parm_tuple)
+                if action == "add_override" and not included:
+                    target.addParmTuple(parm_tuple)
+                    changed = True
+                elif action == "remove_override" and included:
+                    target.removeParmTuple(parm_tuple)
+                    changed = True
+                return skill_success(
+                    "Updated take parameter override",
+                    action=action,
+                    take_name=take_name,
+                    node_path=node_path,
+                    parm_name=parm_name,
+                    changed=changed,
+                )
+            finally:
+                if takes.currentTake() != current:
+                    takes.setCurrentTake(current)
 
         if action == "switch":
             if not take_name:
@@ -101,7 +156,7 @@ def manage_takes(
 
         return skill_error(
             "Unknown action",
-            "Action must be one of: list, create, switch, delete",
+            "Action must be one of: list, create, switch, delete, add_override, remove_override",
             action=action,
         )
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -97,12 +97,12 @@ tools:
     affinity: main
     group: render
     read_only: false
-    destructive: false
-    idempotent: true
+    destructive: true
+    idempotent: false
     annotations:
       read_only_hint: false
-      destructive_hint: false
-      idempotent_hint: true
+      destructive_hint: true
+      idempotent_hint: false
     input_schema:
       type: object
       required: [rop_path]
@@ -239,8 +239,9 @@ tools:
           type: string
   - name: create_render_layer
     description: >-
-      Create a render layer (Render Product in Solaris /stage or merge in ROP
-      context) with optional AOVs. Supports Solaris and traditional networks.
+      Create a Solaris Render Product, or clone a Mantra ifd ROP into a real
+      render layer with a required dedicated output, optional object masks,
+      and AOV planes. The source Mantra ROP remains unchanged.
     source_file: scripts/create_render_layer.py
     execution: sync
     affinity: main
@@ -261,54 +262,94 @@ tools:
         parent_path:
           type: string
           default: /stage
+          description: >-
+            Parent network for the new layer. Paths under /stage create a
+            Solaris Render Product; other paths require a Mantra source ROP.
         aovs:
           type: array
           items: {type: string}
+          description: >-
+            Optional RenderVars for Solaris or deduplicated Mantra auxiliary
+            planes on the cloned ROP.
         purpose:
           type: string
           default: beauty
+          description: Solaris Render Product purpose; returned as layer metadata for Mantra.
+        source_rop_path:
+          type: string
+          description: >-
+            Required outside /stage. Absolute path of the Mantra ifd ROP to
+            clone; the source node is not modified.
+        output_path:
+          type: string
+          description: >-
+            Required outside /stage. Dedicated vm_picture path for the cloned
+            ROP; choose a path distinct from the source layer output.
+        candidate_objects:
+          type: string
+          description: Optional Mantra candidate-object mask written to vobject.
+        force_objects:
+          type: string
+          description: Optional Mantra forced-object mask written to forceobject.
+        matte_objects:
+          type: string
+          description: Optional Mantra matte-object mask written to matte_objects.
+        exclude_objects:
+          type: string
+          description: Optional Mantra exclusion mask written to excludeobject.
+        phantom_objects:
+          type: string
+          description: Optional Mantra phantom-object mask written to phantom_objects.
   - name: configure_aovs
     description: >-
-      Add or remove AOVs (diffuse, specular, normal, depth, motionvector, etc.)
-      on a ROP or Solaris render product. Supports 15+ preset AOV types.
+      Add or remove AOVs on a Solaris Render Product or Mantra ROP. Mantra
+      edits the native auxiliary-plane multiparm, deduplicates requested and
+      existing planes on add, writes native quantization and filter settings,
+      and compacts the multiparm on remove.
     source_file: scripts/configure_aovs.py
     execution: sync
     affinity: main
     group: render
     read_only: false
-    destructive: false
-    idempotent: true
+    destructive: true
+    idempotent: false
     annotations:
       read_only_hint: false
-      destructive_hint: false
-      idempotent_hint: true
+      destructive_hint: true
+      idempotent_hint: false
     input_schema:
       type: object
       required: [rop_path, aovs]
       properties:
         rop_path:
           type: string
+          description: Absolute path of the Solaris Render Product or Mantra ROP.
         aovs:
           type: array
           items: {type: string}
+          description: >-
+            AOV preset names or Solaris RenderVar names. Unsupported Mantra
+            names are returned without changing the existing planes.
         action:
           type: string
           enum: [add, remove]
           default: add
+          description: Add missing planes or remove matching planes by preset/source/channel.
   - name: manage_takes
     description: >-
-      Create, switch, delete, or list takes. Takes isolate parameter overrides
-      for render layer / lighting variant workflows.
+      Create, switch, delete, or list takes, and add or remove a parameter
+      tuple override on a child take. Override actions restore the previously
+      current take even when the update fails.
     source_file: scripts/manage_takes.py
     execution: sync
     affinity: main
     group: render_layer
     read_only: false
-    destructive: false
+    destructive: true
     idempotent: false
     annotations:
       read_only_hint: false
-      destructive_hint: false
+      destructive_hint: true
       idempotent_hint: false
     input_schema:
       type: object
@@ -316,9 +357,16 @@ tools:
       properties:
         action:
           type: string
-          enum: [list, create, switch, delete]
+          enum: [list, create, switch, delete, add_override, remove_override]
         take_name:
           type: string
+          description: Required for every action except list.
+        node_path:
+          type: string
+          description: Absolute Houdini node path required for override actions.
+        parm_name:
+          type: string
+          description: Parameter or parameter-tuple name required for override actions.
   - name: get_render_stats
     description: >-
       Read render statistics (resolution, samples, renderer, output, frame

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -70,6 +70,228 @@ def _scalar_parm(value):
     return parm
 
 
+class _FakeMantraParm:
+    def __init__(self, owner, name):
+        self._owner = owner
+        self._name = name
+
+    def eval(self):
+        return self._owner.values[self._name]
+
+    def unexpandedString(self):
+        return str(self._owner.values[self._name])
+
+    def set(self, value):
+        if self._name in self._owner.set_failures:
+            raise RuntimeError("cannot set {}".format(self._name))
+        if self._name == "vm_numaux":
+            self._owner.resize_aux(int(value))
+        else:
+            self._owner.values[self._name] = value
+
+    def removeMultiParmInstance(self, index):
+        self._owner.remove_aux(index)
+
+    def multiParmStartOffset(self):
+        return 1
+
+
+class _FakeMantraRop:
+    _AUX_DEFAULTS = {
+        "vm_variable_plane{}": "",
+        "vm_vextype_plane{}": "vector",
+        "vm_channel_plane{}": "",
+        "vm_quantize_plane{}": "half",
+        "vm_pfilter_plane{}": "",
+        "vm_sfilter_plane{}": "alpha",
+    }
+
+    def __init__(self, path="/out/mantra1"):
+        self._path = path
+        self._parent = None
+        self.set_failures = set()
+        self.values = {
+            "vm_numaux": 0,
+            "vm_picture": "",
+            "vobject": "*",
+            "forceobject": "",
+            "matte_objects": "",
+            "excludeobject": "",
+            "phantom_objects": "",
+        }
+
+    def path(self):
+        return self._path
+
+    def name(self):
+        return self._path.rsplit("/", 1)[-1]
+
+    def setName(self, name, unique_name=False):
+        del unique_name
+        old_name = self.name()
+        self._path = self._path.rsplit("/", 1)[0] + "/" + name
+        if self._parent is not None:
+            self._parent.children.pop(old_name, None)
+            self._parent.children[name] = self
+
+    def copyTo(self, parent):
+        clone_name = self.name()
+        suffix = 1
+        while parent.node(clone_name) is not None:
+            clone_name = "{}{}".format(self.name(), suffix)
+            suffix += 1
+        clone = _FakeMantraRop(parent.path() + "/" + clone_name)
+        clone.values = dict(self.values)
+        clone.set_failures = set(self.set_failures)
+        parent.add(clone)
+        return clone
+
+    def destroy(self):
+        if self._parent is not None:
+            self._parent.children.pop(self.name(), None)
+            self._parent = None
+
+    def type(self):
+        node_type = MagicMock()
+        node_type.name.return_value = "ifd"
+        return node_type
+
+    def parm(self, name):
+        return _FakeMantraParm(self, name) if name in self.values else None
+
+    def parmTuple(self, _name):
+        return None
+
+    def resize_aux(self, count):
+        previous = self.values["vm_numaux"]
+        for index in range(previous + 1, count + 1):
+            for pattern, default in self._AUX_DEFAULTS.items():
+                self.values[pattern.format(index)] = default
+        for index in range(count + 1, previous + 1):
+            for pattern in self._AUX_DEFAULTS:
+                self.values.pop(pattern.format(index), None)
+        self.values["vm_numaux"] = count
+
+    def remove_aux(self, index):
+        planes = [
+            {pattern: self.values[pattern.format(plane_index)] for pattern in self._AUX_DEFAULTS}
+            for plane_index in range(1, self.values["vm_numaux"] + 1)
+        ]
+        planes.pop(index)
+        self.resize_aux(0)
+        self.resize_aux(len(planes))
+        for plane_index, plane in enumerate(planes, 1):
+            for pattern, value in plane.items():
+                self.values[pattern.format(plane_index)] = value
+
+    def aux_planes(self):
+        return [
+            {
+                "variable": self.values["vm_variable_plane{}".format(index)],
+                "type": self.values["vm_vextype_plane{}".format(index)],
+                "channel": self.values["vm_channel_plane{}".format(index)],
+            }
+            for index in range(1, self.values["vm_numaux"] + 1)
+        ]
+
+
+class _FakeOutNetwork:
+    def __init__(self):
+        self.children = {}
+
+    def path(self):
+        return "/out"
+
+    def name(self):
+        return "out"
+
+    def type(self):
+        node_type = MagicMock()
+        node_type.name.return_value = "ropnet"
+        return node_type
+
+    def add(self, node):
+        node._parent = self
+        self.children[node.name()] = node
+
+    def node(self, name):
+        return self.children.get(name)
+
+
+def _fake_hou_for_out(out, hip_dir="C:/show/shot"):
+    mock_hou = MagicMock()
+    mock_hou.node.side_effect = lambda path: out if path == "/out" else out.node(path.rsplit("/", 1)[-1])
+    mock_hou.frame.return_value = 1.0
+    mock_hou.text.expandStringAtFrame.side_effect = lambda path, frame: path.replace("$HIP", hip_dir).replace(
+        "$F4", "{:04d}".format(int(frame))
+    )
+    mock_hou.text.abspath.side_effect = lambda path: (
+        path if path.startswith("/") or ":" in path[:3] else "{}/{}".format(hip_dir, path)
+    )
+    mock_hou.text.normpath.side_effect = lambda path: path.replace("\\", "/")
+    return mock_hou
+
+
+class _FakeTake:
+    def __init__(self, takes, name, parent=None):
+        self._takes = takes
+        self._name = name
+        self._parent = parent
+        self._overrides = set()
+
+    def name(self):
+        return self._name
+
+    def parent(self):
+        return self._parent
+
+    def nodes(self):
+        return ()
+
+    def addChildTake(self, name):
+        return self._takes.add(name, parent=self)
+
+    def hasParmTuple(self, parm_tuple):
+        return parm_tuple in self._overrides
+
+    def addParmTuple(self, parm_tuple):
+        if self._takes.currentTake() is not self:
+            raise RuntimeError("take is not current")
+        self._overrides.add(parm_tuple)
+
+    def removeParmTuple(self, parm_tuple):
+        if self._takes.currentTake() is not self:
+            raise RuntimeError("take is not current")
+        self._overrides.discard(parm_tuple)
+
+
+class _FakeTakes:
+    def __init__(self):
+        self._root = _FakeTake(self, "main")
+        self._current = self._root
+        self._takes = {"main": self._root}
+
+    def currentTake(self):
+        return self._current
+
+    def setCurrentTake(self, take):
+        self._current = take
+
+    def rootTake(self):
+        return self._root
+
+    def findTake(self, name):
+        return self._takes.get(name)
+
+    def takes(self):
+        return tuple(self._takes.values())
+
+    def add(self, name, parent=None):
+        take = _FakeTake(self, name, parent or self._root)
+        self._takes[name] = take
+        return take
+
+
 def _run_render_worker(
     tmp_path,
     frame_range,
@@ -386,6 +608,345 @@ class TestRenderSettings:
         camera_parm.set.assert_called_once_with("/obj/cam1")
         assert result["context"]["applied"]["camera"] == "/obj/cam1"
         assert "output_path" in result["context"]["unsupported"]
+
+
+class TestRenderPassAuthoring:
+    def test_mantra_component_presets_use_complete_light_path_expressions(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+
+        assert mod.MANTRA_AOV_PRESETS["diffuse"]["source"] == "lpe:C<RD>.*L"
+        assert mod.MANTRA_AOV_PRESETS["specular"]["source"] == "lpe:C<RG>.*[LO]"
+        assert mod.MANTRA_AOV_PRESETS["transmission"]["source"] == "lpe:C<TG>.*[LO]"
+        assert mod.MANTRA_AOV_PRESETS["volume"]["source"] == "lpe:CV.*L"
+
+    def test_configure_aovs_adds_real_mantra_planes_and_deduplicates(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["normal", "depth", "normal"])
+            repeated = mod.configure_aovs("/out/mantra1", ["normal", "depth"])
+
+        assert result["success"] is True
+        assert [item["name"] for item in result["context"]["configured"]] == ["normal", "depth"]
+        assert result["context"]["unsupported"] == []
+        assert repeated["context"]["configured"] == []
+        assert repeated["context"]["unsupported"] == []
+        assert rop.aux_planes() == [
+            {"variable": "N", "type": "unitvector", "channel": "normal"},
+            {"variable": "Pz", "type": "float", "channel": "depth"},
+        ]
+
+    def test_configure_aovs_applies_h21_plane_processing_contract(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["normal", "emission"])
+
+        assert result["success"] is True
+        assert rop.values["vm_quantize_plane1"] == "float"
+        assert rop.values["vm_pfilter_plane1"] == "minmax omedian"
+        assert rop.values["vm_sfilter_plane1"] == "alpha"
+        assert rop.values["vm_quantize_plane2"] == "half"
+        assert rop.values["vm_pfilter_plane2"] == ""
+        assert rop.values["vm_sfilter_plane2"] == "fullopacity"
+
+    def test_configure_aovs_removes_named_mantra_plane_and_compacts(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            mod.configure_aovs("/out/mantra1", ["normal", "depth", "worldpos"])
+            result = mod.configure_aovs("/out/mantra1", ["depth", "missing", "depth"], action="remove")
+
+        assert result["success"] is True
+        assert result["context"]["configured"] == [
+            {"name": "depth", "action": "removed", "source": "Pz", "channel": "depth"}
+        ]
+        assert result["context"]["unsupported"] == ["missing"]
+        assert rop.aux_planes() == [
+            {"variable": "N", "type": "unitvector", "channel": "normal"},
+            {"variable": "P", "type": "vector", "channel": "worldpos"},
+        ]
+
+    def test_configure_aovs_remove_clears_all_matching_planes(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        rop.resize_aux(2)
+        rop.values.update(
+            {
+                "vm_variable_plane1": "N",
+                "vm_channel_plane1": "normal",
+                "vm_variable_plane2": "N",
+                "vm_channel_plane2": "normal_copy",
+            }
+        )
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["normal"], action="remove")
+
+        assert result["success"] is True
+        assert rop.aux_planes() == []
+
+    def test_configure_aovs_unknown_remove_never_matches_empty_plane_field(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        rop.resize_aux(1)
+        rop.values["vm_variable_plane1"] = "custom_export"
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["missing"], action="remove")
+
+        assert result["success"] is True
+        assert result["context"]["unsupported"] == ["missing"]
+        assert rop.values["vm_numaux"] == 1
+
+    def test_configure_aovs_rolls_back_new_plane_when_parameter_write_fails(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        rop.set_failures.add("vm_channel_plane1")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["normal"])
+
+        assert result["success"] is False
+        assert rop.values["vm_numaux"] == 0
+
+    def test_configure_aovs_rolls_back_all_planes_when_later_write_fails(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        rop.set_failures.add("vm_channel_plane2")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["normal", "depth"])
+
+        assert result["success"] is False
+        assert rop.values["vm_numaux"] == 0
+
+    def test_configure_aovs_rejects_unknown_action_without_mutation(self) -> None:
+        mod = _load_script("houdini-render", "configure_aovs.py")
+        rop = _FakeMantraRop()
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.configure_aovs("/out/mantra1", ["normal"], action="replace")
+
+        assert result["success"] is False
+        assert rop.values["vm_numaux"] == 0
+
+    def test_create_render_layer_clones_mantra_with_masks_and_output(self) -> None:
+        mod = _load_script("houdini-render", "create_render_layer.py")
+        out = _FakeOutNetwork()
+        source = _FakeMantraRop("/out/mantra_base")
+        source.values["vm_picture"] = "/renders/base.$F4.exr"
+        out.add(source)
+        mock_hou = _fake_hou_for_out(out)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_render_layer(
+                "solar_fx",
+                parent_path="/out",
+                source_rop_path="/out/mantra_base",
+                output_path="/renders/solar_fx.$F4.exr",
+                candidate_objects="/obj/SolarFX*",
+                force_objects="/obj/SunCorona",
+                matte_objects="/obj/planets/*",
+                exclude_objects="/obj/labels/*",
+                phantom_objects="/obj/holdouts/*",
+                aovs=["normal", "depth"],
+            )
+
+        assert result["success"] is True
+        layer = out.node("solar_fx")
+        assert layer is not None
+        assert layer.values["vm_picture"] == "/renders/solar_fx.$F4.exr"
+        assert layer.values["vobject"] == "/obj/SolarFX*"
+        assert layer.values["forceobject"] == "/obj/SunCorona"
+        assert layer.values["matte_objects"] == "/obj/planets/*"
+        assert layer.values["excludeobject"] == "/obj/labels/*"
+        assert layer.values["phantom_objects"] == "/obj/holdouts/*"
+        assert layer.aux_planes() == [
+            {"variable": "N", "type": "unitvector", "channel": "normal"},
+            {"variable": "Pz", "type": "float", "channel": "depth"},
+        ]
+        assert source.values["vm_picture"] == "/renders/base.$F4.exr"
+        assert result["context"]["node"]["type"] == "ifd"
+
+    def test_create_render_layer_removes_partial_clone_when_required_parm_is_missing(self) -> None:
+        mod = _load_script("houdini-render", "create_render_layer.py")
+        out = _FakeOutNetwork()
+        source = _FakeMantraRop("/out/mantra_base")
+        source.values.pop("matte_objects")
+        out.add(source)
+        mock_hou = _fake_hou_for_out(out)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_render_layer(
+                "solar_fx",
+                parent_path="/out",
+                source_rop_path="/out/mantra_base",
+                output_path="/renders/solar_fx.$F4.exr",
+                matte_objects="/obj/planets/*",
+            )
+
+        assert result["success"] is False
+        assert out.node("solar_fx") is None
+        assert out.node("mantra_base") is source
+
+    def test_create_render_layer_rejects_missing_output_before_cloning(self) -> None:
+        mod = _load_script("houdini-render", "create_render_layer.py")
+        out = _FakeOutNetwork()
+        source = _FakeMantraRop("/out/mantra_base")
+        out.add(source)
+        mock_hou = _fake_hou_for_out(out)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_render_layer(
+                "solar_fx",
+                parent_path="/out",
+                source_rop_path="/out/mantra_base",
+            )
+
+        assert result["success"] is False
+        assert set(out.children) == {"mantra_base"}
+
+    def test_create_render_layer_rejects_source_output_path_before_cloning(self) -> None:
+        mod = _load_script("houdini-render", "create_render_layer.py")
+        out = _FakeOutNetwork()
+        source = _FakeMantraRop("/out/mantra_base")
+        source.values["vm_picture"] = "/renders/shared.$F4.exr"
+        out.add(source)
+        mock_hou = _fake_hou_for_out(out)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_render_layer(
+                "solar_fx",
+                parent_path="/out",
+                source_rop_path="/out/mantra_base",
+                output_path="/renders/shared.$F4.exr",
+            )
+
+        assert result["success"] is False
+        assert set(out.children) == {"mantra_base"}
+
+    def test_create_render_layer_rejects_expanded_variable_alias_before_cloning(self) -> None:
+        mod = _load_script("houdini-render", "create_render_layer.py")
+        out = _FakeOutNetwork()
+        source = _FakeMantraRop("/out/mantra_base")
+        source.values["vm_picture"] = "$HIP/render/shared.$F4.exr"
+        out.add(source)
+        mock_hou = _fake_hou_for_out(out)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_render_layer(
+                "solar_fx",
+                parent_path="/out",
+                source_rop_path="/out/mantra_base",
+                output_path="C:/show/shot/render/shared.$F4.exr",
+            )
+
+        assert result["success"] is False
+        assert set(out.children) == {"mantra_base"}
+
+    def test_create_render_layer_removes_clone_when_requested_aov_is_unsupported(self) -> None:
+        mod = _load_script("houdini-render", "create_render_layer.py")
+        out = _FakeOutNetwork()
+        source = _FakeMantraRop("/out/mantra_base")
+        out.add(source)
+        mock_hou = _fake_hou_for_out(out)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_render_layer(
+                "solar_fx",
+                parent_path="/out",
+                source_rop_path="/out/mantra_base",
+                output_path="/renders/solar_fx.$F4.exr",
+                aovs=["normal", "cryptomatte"],
+            )
+
+        assert result["success"] is False
+        assert set(out.children) == {"mantra_base"}
+
+    def test_manage_takes_create_uses_root_child_take_api(self) -> None:
+        mod = _load_script("houdini-render", "manage_takes.py")
+        takes = _FakeTakes()
+        mock_hou = MagicMock()
+        mock_hou.takes = takes
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.manage_takes("create", take_name="solar_fx")
+
+        assert result["success"] is True
+        assert takes.findTake("solar_fx").parent() is takes.rootTake()
+        assert takes.currentTake() is takes.rootTake()
+
+    def test_manage_takes_adds_and_removes_override_without_changing_current_take(self) -> None:
+        mod = _load_script("houdini-render", "manage_takes.py")
+        takes = _FakeTakes()
+        variant = takes.add("solar_fx")
+        parm_tuple = MagicMock()
+        node = _node("/out/mantra1", "mantra1", "ifd")
+        node.parmTuple.return_value = parm_tuple
+        mock_hou = MagicMock()
+        mock_hou.takes = takes
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            added = mod.manage_takes(
+                "add_override",
+                take_name="solar_fx",
+                node_path="/out/mantra1",
+                parm_name="vm_picture",
+            )
+            removed = mod.manage_takes(
+                "remove_override",
+                take_name="solar_fx",
+                node_path="/out/mantra1",
+                parm_name="vm_picture",
+            )
+
+        assert added["success"] is True
+        assert removed["success"] is True
+        assert variant.hasParmTuple(parm_tuple) is False
+        assert takes.currentTake().name() == "main"
+
+    def test_manage_takes_restores_current_take_when_override_update_fails(self) -> None:
+        mod = _load_script("houdini-render", "manage_takes.py")
+        takes = _FakeTakes()
+        variant = takes.add("solar_fx")
+        variant.addParmTuple = MagicMock(side_effect=RuntimeError("write failed"))
+        node = _node("/out/mantra1", "mantra1", "ifd")
+        node.parmTuple.return_value = MagicMock()
+        mock_hou = MagicMock()
+        mock_hou.takes = takes
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.manage_takes(
+                "add_override",
+                take_name="solar_fx",
+                node_path="/out/mantra1",
+                parm_name="vm_picture",
+            )
+
+        assert result["success"] is False
+        assert takes.currentTake() is takes.rootTake()
 
 
 class TestRenderExecution:


### PR DESCRIPTION
## Summary

- author native Mantra auxiliary image planes with renderer-specific processing and transactional edits
- clone validated ifd render passes with dedicated outputs, object masks, and AOVs
- manage take parameter overrides while restoring the caller's current take

## Validation

- 553 passed, 1 skipped, 3 deselected
- 67 focused render/camera/light tests passed
- isolated Houdini 21.0.631 HOM smoke passed without saving or rendering
- Ruff, format, Python 3.7 syntax, skill CLI validation, and package build passed