### PR TITLE
fix(render): isolate headless background HIP snapshots

### DIFF
--- a/docs/adr/0001-isolate-long-running-houdini-jobs.md
+++ b/docs/adr/0001-isolate-long-running-houdini-jobs.md
@@ -33,9 +33,10 @@ adapter instance.
 - Persist job status for observation, but never treat a persisted PID as process ownership evidence.
 - Reject interactive isolated launch when the HIP is unsaved or has unsaved
   changes; never auto-save the user's GUI scene. For explicit headless isolated
-  launch, require an existing HIP and save its current state before spawning the
-  worker because Houdini 21 may retain a dirty flag after a successful headless
-  save. Reject the launch when that save fails.
+  launch, require an existing HIP and capture its current state with an owned
+  temporary `saveAsBackup()` snapshot. Never overwrite or rename the source HIP.
+  The worker restores the source name for `$HIP` resolution after loading the
+  snapshot, then removes the snapshot. Reject the launch when capture fails.
 - Derive output completion and ETA while polling from expected file signatures;
   do not send a callback to the interactive process for every frame.
 - Return bounded poll summaries by default. Full expected-output snapshots,
@@ -59,8 +60,9 @@ adapter instance.
 
 - Jobs started by an adapter instance cannot be cancelled after that instance restarts.
 - Process-tree termination remains platform-specific (`taskkill /T` on Windows, process groups on POSIX).
-- Explicit headless isolated launch saves the current HIP before spawning its
-  worker; normal headless execution remains foreground and does not add a save.
+- Explicit headless isolated launch briefly consumes enough temporary storage
+  for one HIP snapshot; normal headless execution remains foreground and does
+  not add a snapshot.
 - Poll progress is output-file progress, so jobs without a discoverable output
   pattern report unknown progress/ETA.
 - ROP chains use execution/cook errors as their completion contract. They may
@@ -83,6 +85,7 @@ adapter instance.
 - https://www.sidefx.com/docs/houdini/hwebserver/index.html
 - https://www.sidefx.com/docs/houdini/hwebserver/apiFunction.html
 - https://www.sidefx.com/docs/houdini/hom/hou/ui.html
+- https://www.sidefx.com/docs/houdini/hom/hou/hipFile.html
 - https://www.sidefx.com/docs/houdini/hom/rpc
 - https://www.sidefx.com/docs/hengine/_h_a_p_i__sessions.html
 - https://www.sidefx.com/docs/houdini/ref/henginesessionsync.html

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -27,27 +27,52 @@ def _hython_executable() -> Path:
     return executable
 
 
-def _validate_saved_hip(hou: Any) -> Path:
+def _validate_saved_hip(hou: Any) -> tuple:
     hip_path = Path(hou.hipFile.path())
     if not hip_path.is_file():
         raise ValueError("Background rendering requires the current HIP file to be saved")
-    if hou.isUIAvailable():
+    is_ui_available = bool(hou.isUIAvailable())
+    if is_ui_available:
         has_unsaved_changes = getattr(hou.hipFile, "hasUnsavedChanges", None)
         if callable(has_unsaved_changes) and has_unsaved_changes() is True:
             raise ValueError("Background rendering rejects unsaved changes; save the HIP file explicitly first")
-        return hip_path
+    return hip_path, is_ui_available
 
-    # Houdini 21.0.631 hython may keep hasUnsavedChanges() true after save, so
-    # persist the current state explicitly instead of trusting that flag or
-    # launching a worker against an older disk snapshot.
+
+def _save_owned_hip_snapshot(hou: Any, job_dir: Path) -> Path:
+    """Save a headless copy without changing or overwriting the current HIP."""
+    backup_dir = hou.getenv("HOUDINI_BACKUP_DIR")
+    snapshot_path = None
+    hou.putenv("HOUDINI_BACKUP_DIR", str(job_dir))
     try:
-        hou.hipFile.save()
+        snapshot_path = Path(hou.hipFile.saveAsBackup())
     except Exception as exc:
-        raise ValueError("Headless background rendering failed to save the current HIP file") from exc
-    hip_path = Path(hou.hipFile.path())
-    if not hip_path.is_file():
-        raise ValueError("Headless background rendering did not produce a saved HIP file")
-    return hip_path
+        raise ValueError("Headless background rendering failed to create an isolated HIP snapshot") from exc
+    finally:
+        if backup_dir is None:
+            hou.unsetenv("HOUDINI_BACKUP_DIR")
+        else:
+            hou.putenv("HOUDINI_BACKUP_DIR", backup_dir)
+    if snapshot_path.resolve().parent != job_dir.resolve() or not snapshot_path.is_file():
+        raise ValueError("Headless background rendering did not produce an owned HIP snapshot")
+    return snapshot_path
+
+
+def _remove_owned_hip_snapshot(status_path: Path, status: Dict[str, Any]) -> bool:
+    """Remove only a snapshot located directly inside this job's directory."""
+    if status.get("hip_snapshot_owned") is not True:
+        return False
+    snapshot_value = status.get("hip_path")
+    if not snapshot_value:
+        return False
+    snapshot_path = Path(str(snapshot_value))
+    if snapshot_path.resolve().parent != status_path.parent.resolve():
+        return False
+    try:
+        snapshot_path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
 
 
 def launch_background_render(
@@ -59,18 +84,34 @@ def launch_background_render(
     job_kind: str = "render",
 ) -> Dict[str, Any]:
     """Launch one saved ROP job in an isolated hython process."""
-    hip_path = _validate_saved_hip(hou)
+    source_hip_path, is_ui_available = _validate_saved_hip(hou)
     executable = _hython_executable()
     initial, status_path = _isolated_jobs.create_job(
         {
             "job_kind": job_kind,
-            "hip_path": str(hip_path),
+            "hip_path": str(source_hip_path),
             "rop_path": rop_path,
             "frame_range": frame_range,
             "output_pattern": output_pattern,
             "ignore_inputs": bool(ignore_inputs),
         }
     )
+    hip_path = source_hip_path
+    if not is_ui_available:
+        try:
+            hip_path = _save_owned_hip_snapshot(hou, status_path.parent)
+        except Exception as exc:
+            initial.update({"state": "failed", "finished_at": time.time(), "error": str(exc)})
+            _isolated_jobs.write_status(status_path, initial)
+            raise
+        initial.update(
+            {
+                "hip_path": str(hip_path),
+                "source_hip_path": str(source_hip_path),
+                "hip_snapshot_owned": True,
+            }
+        )
+        _isolated_jobs.write_status(status_path, initial)
     worker_path = Path(__file__).resolve().parent / "skills" / "houdini-render" / "scripts" / "_render_worker.py"
     command = [
         str(executable),
@@ -84,7 +125,11 @@ def launch_background_render(
     ]
     child_env = dict(os.environ)
     child_env["DCC_MCP_BACKGROUND_RENDER"] = "1"
-    return _isolated_jobs.launch_job(initial["job_id"], command, child_env)
+    try:
+        return _isolated_jobs.launch_job(initial["job_id"], command, child_env)
+    except Exception:
+        _remove_owned_hip_snapshot(status_path, initial)
+        raise
 
 
 def _file_signature(path: str) -> Optional[Dict[str, int]]:
@@ -177,6 +222,8 @@ def _warning_lines(status: Dict[str, Any]) -> List[Any]:
 
 def read_render_job(job_id: str, include_details: bool = False) -> Dict[str, Any]:
     result = _with_progress(_isolated_jobs.read_job(job_id))
+    if result.get("state") in _isolated_jobs._TERMINAL_STATES:
+        _remove_owned_hip_snapshot(_isolated_jobs._status_path(job_id), result)
     warnings = _warning_lines(result)
     result["warning_count"] = len(warnings)
     if include_details:
@@ -198,5 +245,8 @@ def read_render_job(job_id: str, include_details: bool = False) -> Dict[str, Any
     return result
 
 
-def cancel_render_job(job_id: str) -> Dict[str, Any]:
-    return _isolated_jobs.cancel_job(job_id)
+def cancel_render_job(job_id: str, terminate: Any = None) -> Dict[str, Any]:
+    result = _isolated_jobs.cancel_job(job_id, terminate=terminate)
+    if result.get("state") in _isolated_jobs._TERMINAL_STATES:
+        _remove_owned_hip_snapshot(_isolated_jobs._status_path(job_id), result)
+    return result

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -81,6 +81,7 @@ defaults to isolated `hython`; poll its `job_id` with
 `houdini_render__cancel_render_job`. Pass `background=false` for intentional
 foreground execution. Interactive background launch requires an explicitly
 saved, clean HIP and never auto-saves the GUI scene. Explicit headless
-background launch requires an existing HIP and saves its current state before
-spawning the worker. Output-path parm names are probed defensively so File
+background launch requires an existing HIP and captures its current state in a
+job-owned temporary snapshot without saving the source scene. Output-path parm
+names are probed defensively so File
 Cache, DOP I/O, and Geometry ROPs are all tolerated.

--- a/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
@@ -346,4 +346,5 @@ tools:
             Explicitly select isolated hython (true) or foreground (false)
             execution. When omitted, interactive Houdini uses an isolated job
             and headless Houdini runs in the foreground. Explicit headless
-            isolation saves the existing HIP before spawning the worker.
+            isolation uses a job-owned temporary HIP snapshot without saving the
+            source scene.

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -51,8 +51,9 @@ definition introspection, instantiation, validation, and graph-level cooking.
   to render only the named driver. Interactive Houdini defaults to isolated
   `hython`, while headless Houdini defaults to foreground. Interactive isolated
   launch requires a saved, clean HIP and never auto-saves the GUI scene.
-  Explicit headless isolated launch requires an existing HIP and saves its
-  current state before spawning the worker. A chain can complete without a
+  Explicit headless isolated launch requires an existing HIP and captures its
+  current state in a job-owned temporary snapshot without saving the source
+  scene. A chain can complete without a
   discoverable output path when it has no execution/cook errors;
   inspect `output_verification` to distinguish this from verified file output.
 

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/tools.yaml
@@ -164,4 +164,5 @@ tools:
             Explicitly select isolated hython (true) or foreground (false)
             execution. When omitted, interactive Houdini uses an isolated job
             and headless Houdini runs in the foreground. Explicit headless
-            isolation saves the existing HIP before spawning the worker.
+            isolation uses a job-owned temporary HIP snapshot without saving the
+            source scene.

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -91,7 +91,8 @@ to `unavailable`. Render and cache jobs still require a new or updated output.
 Interactive background launch requires a saved HIP with no unsaved changes and
 never auto-saves the GUI scene. Headless Houdini defaults to foreground; when
 `background=true` is explicitly requested, the adapter requires an existing HIP
-and saves its current state before spawning the isolated worker.
+and captures its current state in a job-owned temporary HIP snapshot without
+saving or renaming the source scene.
 The main thread only validates the ROP and launches the isolated process;
 Mantra/Karma work never occupies Houdini's event loop. Output-path and
 resolution parameter writes are defensive (candidate names) so Mantra, Karma,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -20,4 +20,4 @@ _terminate_process_tree = _isolated_jobs._terminate_process_tree
 
 
 def cancel_render_job(job_id: str) -> dict:
-    return _isolated_jobs.cancel_job(job_id, terminate=_terminate_process_tree)
+    return _rop_jobs.cancel_render_job(job_id, terminate=_terminate_process_tree)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -35,11 +35,21 @@ def _cook_errors(status: dict) -> list:
     return lines
 
 
+def _remove_owned_hip_snapshot(status_path: Path, status: dict, hip_path: Path) -> None:
+    """Remove only the snapshot created inside this job's directory."""
+    if status.get("hip_snapshot_owned") is True and hip_path.resolve().parent == status_path.parent.resolve():
+        try:
+            hip_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
 def main() -> None:
     import hou  # Lazy import: requires Houdini's embedded Python.
 
-    hip_path, rop_path, range_json, status_arg, output_json = sys.argv[1:6]
+    hip_arg, rop_path, range_json, status_arg, output_json = sys.argv[1:6]
     ignore_inputs = json.loads(sys.argv[6]) if len(sys.argv) > 6 else False
+    hip_path = Path(hip_arg)
     status_path = Path(status_arg)
     frame_range = json.loads(range_json)
     output_pattern = json.loads(output_json)
@@ -55,7 +65,10 @@ def main() -> None:
         "written_file_count": 0,
     }
     try:
-        hou.hipFile.load(hip_path, suppress_save_prompt=True)
+        hou.hipFile.load(str(hip_path), suppress_save_prompt=True)
+        if status.get("hip_snapshot_owned") is True:
+            hou.hipFile.setName(status["source_hip_path"])
+            _remove_owned_hip_snapshot(status_path, status, hip_path)
         rop = hou.node(rop_path)
         if rop is None:
             raise ValueError("ROP node not found: {}".format(rop_path))
@@ -116,6 +129,7 @@ def main() -> None:
             }
         )
     finally:
+        _remove_owned_hip_snapshot(status_path, status, hip_path)
         status["finished_at"] = time.time()
         write_status(status_path, status)
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -188,7 +188,8 @@ tools:
             Explicitly select isolated hython (true) or foreground (false)
             execution. When omitted, interactive Houdini uses an isolated job
             and headless Houdini renders in the foreground. Explicit headless
-            isolation saves the existing HIP before spawning the worker.
+            isolation uses a job-owned temporary HIP snapshot without saving the
+            source scene.
   - name: get_render_job
     description: >-
       Read bounded status, output progress, elapsed time, and ETA for a background

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -1029,6 +1029,7 @@ class TestRenderExecution:
         assert mod._PROCESS_HANDLES[job["job_id"]] is process
         assert status["ignore_inputs"] is True
         assert status["job_kind"] == "rop_chain"
+        mock_hou.hipFile.saveAsBackup.assert_not_called()
 
     def test_background_render_gui_rejects_dirty_hip_without_saving(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "_background_render.py")
@@ -1043,9 +1044,54 @@ class TestRenderExecution:
             mod.launch_background_render(mock_hou, "/out/mantra1", [1, 2, 1], "beauty.$F4.exr")
 
         mock_hou.hipFile.save.assert_not_called()
+        mock_hou.hipFile.saveAsBackup.assert_not_called()
         popen.assert_not_called()
 
-    def test_background_render_headless_saves_current_hip_before_launch(self, tmp_path: Path) -> None:
+    def test_background_render_headless_launches_from_owned_snapshot_without_saving_source(
+        self, tmp_path: Path
+    ) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        hip = tmp_path / "scene.hip"
+        hip.write_bytes(b"source")
+        hython = tmp_path / ("hython.exe" if mod.os.name == "nt" else "hython")
+        hython.write_bytes(b"exe")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.path.return_value = str(hip)
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+        mock_hou.isUIAvailable.return_value = False
+        backup_env = {}
+        mock_hou.getenv.return_value = None
+        mock_hou.putenv.side_effect = lambda name, value: backup_env.__setitem__(name, value)
+        mock_hou.unsetenv.side_effect = lambda name: backup_env.pop(name, None)
+
+        def save_snapshot():
+            snapshot = Path(backup_env["HOUDINI_BACKUP_DIR"]) / "scene_bak1.hip"
+            snapshot.write_bytes(b"snapshot")
+            return str(snapshot)
+
+        mock_hou.hipFile.saveAsBackup.side_effect = save_snapshot
+        mock_hou.hipFile.save.side_effect = lambda: hip.write_bytes(b"overwritten")
+
+        with patch.object(mod.sys, "executable", str(tmp_path / "houdini.exe")), patch.object(
+            mod.tempfile, "gettempdir", return_value=str(tmp_path)
+        ), patch.object(mod.subprocess, "Popen", return_value=MagicMock(pid=4321)) as popen:
+            job = mod.launch_background_render(mock_hou, "/out/geometry1", [1, 2, 1], "cache.$F4.bgeo.sc")
+
+        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
+        mock_hou.hipFile.save.assert_not_called()
+        mock_hou.hipFile.saveAsBackup.assert_called_once_with()
+        mock_hou.hipFile.setName.assert_not_called()
+        assert hip.read_bytes() == b"source"
+        status = json.loads((tmp_path / "dcc-mcp-houdini-render-jobs" / job["job_id"] / "status.json").read_text())
+        snapshot = Path(status["hip_path"])
+        assert snapshot.parent == tmp_path / "dcc-mcp-houdini-render-jobs" / job["job_id"]
+        assert snapshot.read_bytes() == b"snapshot"
+        assert status["source_hip_path"] == str(hip)
+        assert status["hip_snapshot_owned"] is True
+        assert Path(popen.call_args.args[0][2]) == snapshot
+        popen.assert_called_once()
+
+    def test_background_render_headless_rejects_failed_snapshot(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "_background_render.py")
         hip = tmp_path / "scene.hip"
         hip.write_bytes(b"hip")
@@ -1053,30 +1099,17 @@ class TestRenderExecution:
         hython.write_bytes(b"exe")
         mock_hou = MagicMock()
         mock_hou.hipFile.path.return_value = str(hip)
-        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+        mock_hou.getenv.return_value = None
+        mock_hou.hipFile.saveAsBackup.side_effect = RuntimeError("snapshot failed")
         mock_hou.isUIAvailable.return_value = False
 
         with patch.object(mod.sys, "executable", str(tmp_path / "houdini.exe")), patch.object(
             mod.tempfile, "gettempdir", return_value=str(tmp_path)
-        ), patch.object(mod.subprocess, "Popen", return_value=MagicMock(pid=4321)) as popen:
+        ), patch.object(mod.subprocess, "Popen") as popen, pytest.raises(ValueError, match="snapshot"):
             mod.launch_background_render(mock_hou, "/out/geometry1", [1, 2, 1], "cache.$F4.bgeo.sc")
 
-        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
-        mock_hou.hipFile.save.assert_called_once_with()
-        popen.assert_called_once()
-
-    def test_background_render_headless_rejects_failed_save(self, tmp_path: Path) -> None:
-        mod = _load_script("houdini-render", "_background_render.py")
-        hip = tmp_path / "scene.hip"
-        hip.write_bytes(b"hip")
-        mock_hou = MagicMock()
-        mock_hou.hipFile.path.return_value = str(hip)
-        mock_hou.hipFile.save.side_effect = RuntimeError("save failed")
-        mock_hou.isUIAvailable.return_value = False
-
-        with patch.object(mod.subprocess, "Popen") as popen, pytest.raises(ValueError, match="failed to save"):
-            mod.launch_background_render(mock_hou, "/out/geometry1", [1, 2, 1], "cache.$F4.bgeo.sc")
-
+        mock_hou.hipFile.save.assert_not_called()
+        mock_hou.hipFile.saveAsBackup.assert_called_once_with()
         popen.assert_not_called()
 
     def test_background_render_headless_rejects_missing_hip(self, tmp_path: Path) -> None:
@@ -1113,6 +1146,64 @@ class TestRenderExecution:
         assert second["cancel_requested"] is False
         terminate.assert_called_once_with(process)
         assert job_id not in mod._PROCESS_HANDLES
+
+    def test_cancel_background_render_removes_only_job_owned_hip_snapshot(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "8" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        snapshot = job_dir / "scene_bak1.hip"
+        snapshot.write_bytes(b"snapshot")
+        source = tmp_path / "scene.hip"
+        source.write_bytes(b"source")
+        (job_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "state": "running",
+                    "hip_path": str(snapshot),
+                    "source_hip_path": str(source),
+                    "hip_snapshot_owned": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        process = MagicMock(pid=4321)
+        process.poll.side_effect = [None, 0]
+        mod._PROCESS_HANDLES[job_id] = process
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+            mod, "_terminate_process_tree"
+        ):
+            result = mod.cancel_render_job(job_id)
+
+        assert result["state"] == "cancelled"
+        assert not snapshot.exists()
+        assert source.read_bytes() == b"source"
+
+    def test_terminal_status_never_removes_snapshot_path_outside_owned_job_directory(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "7" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        outside = tmp_path / "scene.hip"
+        outside.write_bytes(b"source")
+        (job_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "state": "completed",
+                    "hip_path": str(outside),
+                    "hip_snapshot_owned": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            mod.read_render_job(job_id)
+
+        assert outside.read_bytes() == b"source"
 
     def test_concurrent_cancel_terminates_owned_process_once(self, tmp_path: Path) -> None:
         from concurrent.futures import ThreadPoolExecutor
@@ -1445,6 +1536,62 @@ class TestRenderExecution:
 
         assert killpg.call_args_list[0].args == (4321, mod._SIGTERM)
         assert killpg.call_args_list[1].args == (4321, mod._SIGKILL)
+
+    def test_background_worker_restores_source_hip_name_and_removes_owned_snapshot(self, tmp_path: Path) -> None:
+        mod = _load_render_worker()
+        source = tmp_path / "source.hip"
+        source.write_bytes(b"source")
+        snapshot = tmp_path / "snapshot.hip"
+        snapshot.write_bytes(b"snapshot")
+        output = tmp_path / "beauty.0001.exr"
+        stdout = tmp_path / "stdout.log"
+        stderr = tmp_path / "stderr.log"
+        stdout.write_text("", encoding="utf-8")
+        stderr.write_text("", encoding="utf-8")
+        status_path = tmp_path / "status.json"
+        status_path.write_text(
+            json.dumps(
+                {
+                    "state": "queued",
+                    "job_kind": "render",
+                    "stdout_path": str(stdout),
+                    "stderr_path": str(stderr),
+                    "source_hip_path": str(source),
+                    "hip_snapshot_owned": True,
+                    "expected_outputs": [str(output)],
+                    "output_snapshot": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+
+        def render(_rop, _frame_range):
+            output.write_bytes(b"new")
+            return [1.0, 1.0], "render"
+
+        argv = [
+            "_render_worker.py",
+            str(snapshot),
+            "/out/mantra1",
+            json.dumps([1, 1, 1]),
+            str(status_path),
+            json.dumps(str(tmp_path / "beauty.$F4.exr")),
+            "false",
+        ]
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod.sys, "argv", argv), patch.object(
+            mod, "render_node", side_effect=render
+        ):
+            mod.main()
+
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status["state"] == "completed"
+        mock_hou.hipFile.load.assert_called_once_with(str(snapshot), suppress_save_prompt=True)
+        mock_hou.hipFile.setName.assert_called_once_with(str(source))
+        assert not snapshot.exists()
+        assert source.read_bytes() == b"source"
 
     def test_background_worker_reports_only_updated_requested_outputs(self, tmp_path: Path) -> None:
         stale = tmp_path / "beauty.0001.exr"


### PR DESCRIPTION
## Summary

- launch explicit headless background jobs from a job-owned temporary HIP snapshot instead of saving the active source scene
- restore the source scene name in the worker for `$HIP` resolution and clean snapshots after load, cancellation, launch failure, or terminal reconciliation
- preserve the existing interactive clean/dirty scene contract and restrict cleanup to files inside the owning job directory

## Validation

- `python -m pytest`
- `python -m ruff check src/ tests/ tools/ packaging/`
- `python -m ruff format --check src/ tests/ tools/ packaging/`
- `python tools/lint_skills.py --require-cli --warnings-as-errors`
- `python tools/check_py37_syntax.py src tests tools packaging`
- isolated licensed Houdini smoke: source path and bytes remained unchanged, the snapshot contained unsaved scene state, and the snapshot was removed