### PR TITLE
fix(render): preserve background job identity and progress

### DIFF
--- a/docs/adr/0001-isolate-long-running-houdini-jobs.md
+++ b/docs/adr/0001-isolate-long-running-houdini-jobs.md
@@ -32,8 +32,8 @@ adapter instance.
 - Retain each launched `Popen` handle in the adapter process and cancel only through that owned handle.
 - Persist job status for observation, but never treat a persisted PID as process ownership evidence.
 - Reject interactive isolated launch when the HIP is unsaved or has unsaved
-  changes; never auto-save the user's GUI scene. For explicit headless isolated
-  launch, require an existing HIP and capture its current state with an owned
+  changes; never auto-save the user's GUI scene. For headless isolated launch,
+  require an existing HIP and capture its current state with an owned
   temporary `saveAsBackup()` snapshot. Never overwrite or rename the source HIP.
   The worker restores the source name for `$HIP` resolution after loading the
   snapshot, then removes the snapshot. Reject the launch when capture fails.
@@ -60,9 +60,9 @@ adapter instance.
 
 - Jobs started by an adapter instance cannot be cancelled after that instance restarts.
 - Process-tree termination remains platform-specific (`taskkill /T` on Windows, process groups on POSIX).
-- Explicit headless isolated launch briefly consumes enough temporary storage
-  for one HIP snapshot; normal headless execution remains foreground and does
-  not add a snapshot.
+- Headless `render_rop` launch defaults to isolation and briefly consumes enough
+  temporary storage for one HIP snapshot. Callers can explicitly request
+  `background=false` when foreground execution is intentional.
 - Poll progress is output-file progress, so jobs without a discoverable output
   pattern report unknown progress/ETA.
 - ROP chains use execution/cook errors as their completion contract. They may

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -147,18 +147,36 @@ def _with_progress(status: Dict[str, Any]) -> Dict[str, Any]:
     result = dict(status)
     expected = list(result.get("expected_outputs") or [])
     before = dict(result.get("output_snapshot") or {})
-    observed_written_files = []
+    observed = []
     for output in expected:
         signature = _file_signature(output)
         if signature is not None and signature != before.get(output):
-            observed_written_files.append(output)
-    completed = len(observed_written_files)
+            observed.append(output)
+
+    state = result.get("state")
     total = len(expected)
+    if state in _isolated_jobs._TERMINAL_STATES and "written_files" in result:
+        completed_outputs = list(result.get("written_files") or [])
+        verification = result.get("output_verification") or {}
+        worker_total = verification.get("expected_output_count")
+        if isinstance(worker_total, int) and not isinstance(worker_total, bool) and worker_total >= 0:
+            total = max(total, worker_total)
+        total = max(total, len(completed_outputs))
+    elif state == "completed":
+        # Older workers did not persist written_files. A completed legacy job
+        # has closed all of its observed outputs, so none remains in progress.
+        completed_outputs = observed
+    else:
+        # Frame ranges emit expected outputs in order. The last observed file may
+        # still be open, so hold it pending until the worker verifies it.
+        completed_outputs = observed[:-1]
+
+    completed = len(completed_outputs)
     result["completed"] = completed
     result["total"] = total
     result["progress"] = float(completed) / total if total else None
     if result.get("state") not in _isolated_jobs._TERMINAL_STATES or "written_files" not in result:
-        result["written_files"] = observed_written_files
+        result["written_files"] = completed_outputs
 
     started_at = result.get("started_at")
     if started_at is not None:
@@ -166,7 +184,6 @@ def _with_progress(status: Dict[str, Any]) -> Dict[str, Any]:
         elapsed = float(finished_at) - float(started_at) if finished_at is not None else time.time() - float(started_at)
         result["elapsed_secs"] = round(max(0.0, elapsed), 3)
     elapsed_secs = result.get("elapsed_secs")
-    state = result.get("state")
     if state in {"failed", "cancelled", "interrupted"}:
         result["eta_secs"] = None
     elif state == "completed":

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -54,7 +54,7 @@ agent can detect and skip cleanly when rendering is unavailable.
 3. `get_render_settings("/out/mantra1")` → verify
 4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only)
 5. `flipbook(output_path="/tmp/preview.$F4.jpg", frame_range=[1,24,4], camera_path="/obj/rendercam")` for a sparse camera preview (UI only)
-6. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive Houdini; foreground results in headless Houdini
+6. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive or headless Houdini
 
 ### Render Layers & AOVs
 
@@ -76,7 +76,8 @@ agent can detect and skip cleanly when rendering is unavailable.
 Interactive Houdini defaults to an isolated process; poll
 `get_render_job(job_id)` and use `cancel_render_job(job_id)` to stop a job
 started by the same adapter process. Pass `background=false` only when
-foreground execution is intentional. Headless Houdini defaults to foreground execution.
+foreground execution is intentional. Both interactive and headless Houdini
+default to isolated background execution.
 The default poll response is bounded: it reports `completed`, `total`,
 fractional `progress`, `elapsed_secs`, `eta_secs`, `written_file_count`, and up
 to ten `recent_written_files`. `output_verification.state` distinguishes
@@ -89,9 +90,8 @@ ROP-chain completion is governed by execution/cook errors; a chain without a
 discoverable output pattern can complete with `output_verification.state` set
 to `unavailable`. Render and cache jobs still require a new or updated output.
 Interactive background launch requires a saved HIP with no unsaved changes and
-never auto-saves the GUI scene. Headless Houdini defaults to foreground; when
-`background=true` is explicitly requested, the adapter requires an existing HIP
-and captures its current state in a job-owned temporary HIP snapshot without
+never auto-saves the GUI scene. Headless background launch requires an existing
+HIP and captures its current state in a job-owned temporary HIP snapshot without
 saving or renaming the source scene.
 The main thread only validates the ROP and launches the isolated process;
 Mantra/Karma work never occupies Houdini's event loop. Output-path and

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -44,6 +44,20 @@ def _remove_owned_hip_snapshot(status_path: Path, status: dict, hip_path: Path) 
             pass
 
 
+def _verify_outputs(candidates: list, before: dict, output_pattern) -> tuple:
+    written_files = updated_outputs(candidates, before)
+    verification_state = "not_observed"
+    if written_files:
+        verification_state = "verified" if len(written_files) == len(candidates) else "partial"
+    if not output_pattern:
+        verification_state = "unavailable"
+    return written_files, {
+        "state": verification_state,
+        "expected_output_count": len(candidates),
+        "written_file_count": len(written_files),
+    }
+
+
 def main() -> None:
     import hou  # Lazy import: requires Houdini's embedded Python.
 
@@ -64,6 +78,7 @@ def main() -> None:
         "expected_output_count": 0,
         "written_file_count": 0,
     }
+    verification_ready = False
     try:
         hou.hipFile.load(str(hip_path), suppress_save_prompt=True)
         if status.get("hip_snapshot_owned") is True:
@@ -82,6 +97,7 @@ def main() -> None:
             before = output_snapshot(expected_outputs)
         status.update({"expected_outputs": expected_outputs, "output_snapshot": before})
         write_status(status_path, status)
+        verification_ready = True
         if ignore_inputs:
             _, execution_mode = render_node(rop, frame_range, ignore_inputs=True)
         else:
@@ -89,17 +105,7 @@ def main() -> None:
         rop_errors = [str(error) for error in rop.errors()] if hasattr(rop, "errors") else []
         logged_cook_errors = _cook_errors(status)
         candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
-        written_files = updated_outputs(candidates, before)
-        verification_state = "not_observed"
-        if written_files:
-            verification_state = "verified" if len(written_files) == len(candidates) else "partial"
-        if not output_pattern:
-            verification_state = "unavailable"
-        output_verification = {
-            "state": verification_state,
-            "expected_output_count": len(candidates),
-            "written_file_count": len(written_files),
-        }
+        written_files, output_verification = _verify_outputs(candidates, before, output_pattern)
         if logged_cook_errors:
             raise RuntimeError("ROP cook error: {}".format("; ".join(logged_cook_errors[:3])))
         if rop_errors:
@@ -117,6 +123,9 @@ def main() -> None:
             }
         )
     except Exception as exc:  # noqa: BLE001
+        if verification_ready:
+            candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
+            written_files, output_verification = _verify_outputs(candidates, before, output_pattern)
         status.update(
             {
                 "state": "failed",

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -42,7 +42,7 @@ def render_rop(
                 node_path=rop.path(),
             )
         output_pattern = eval_first_parm(rop, _OUTPUT_PARMS, preserve_string=True)
-        use_background = bool(hou.isUIAvailable()) if background is None else background
+        use_background = True if background is None else background
         if use_background:
             job = launch_background_render(hou, rop.path(), frame_range, output_pattern)
             return skill_success(

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -157,12 +157,13 @@ tools:
   - name: render_rop
     description: >-
       Render a ROP/output driver and report written files, elapsed time,
-      warnings/errors. Interactive Houdini defaults to an isolated job so the
-      UI stays responsive; headless Houdini defaults to foreground execution.
+      warnings/errors. Houdini defaults to an isolated job so UI and headless
+      calls stay responsive. Plain calls return that render job_id directly;
+      explicit MCP async metadata still returns a core job that must be resolved
+      first. Pass background=false only for intentional foreground execution.
     source_file: scripts/render_rop.py
-    execution: async
+    execution: sync
     affinity: main
-    timeout_hint_secs: 1800
     group: render
     read_only: false
     destructive: false
@@ -186,10 +187,9 @@ tools:
           type: boolean
           description: >-
             Explicitly select isolated hython (true) or foreground (false)
-            execution. When omitted, interactive Houdini uses an isolated job
-            and headless Houdini renders in the foreground. Explicit headless
-            isolation uses a job-owned temporary HIP snapshot without saving the
-            source scene.
+            execution. When omitted, both interactive and headless Houdini use
+            an isolated job. Headless isolation uses a job-owned temporary HIP
+            snapshot without saving the source scene.
   - name: get_render_job
     description: >-
       Read bounded status, output progress, elapsed time, and ETA for a background

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import time
@@ -1314,18 +1315,142 @@ class TestRenderExecution:
             summary = mod.read_render_job(job_id)
             details = mod.read_render_job(job_id, include_details=True)
 
-        assert summary["completed"] == 25
+        assert summary["completed"] == 24
         assert summary["total"] == 30
-        assert summary["progress"] == pytest.approx(25.0 / 30.0)
+        assert summary["progress"] == pytest.approx(24.0 / 30.0)
         assert summary["elapsed_secs"] == 30.0
-        assert summary["eta_secs"] == 6.0
-        assert summary["written_file_count"] == 25
-        assert summary["recent_written_files"] == [str(output) for output in outputs[15:25]]
+        assert summary["eta_secs"] == 7.5
+        assert summary["written_file_count"] == 24
+        assert summary["recent_written_files"] == [str(output) for output in outputs[14:24]]
         assert "expected_outputs" not in summary
         assert "output_snapshot" not in summary
         assert details["expected_outputs"] == [str(path) for path in outputs]
         assert details["output_snapshot"] == snapshot
-        assert details["written_files"] == [str(output) for output in outputs[:25]]
+        assert details["written_files"] == [str(output) for output in outputs[:24]]
+
+    def test_get_render_job_does_not_complete_latest_output_while_worker_runs(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "1" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        outputs = [job_dir / "beauty.{:04d}.exr".format(frame) for frame in range(1, 4)]
+        for output, mtime_ns in zip(outputs, (3_000_000_000, 2_000_000_000, 1_000_000_000)):
+            output.write_bytes(b"render output")
+            os.utime(output, ns=(mtime_ns, mtime_ns))
+        status_path = job_dir / "status.json"
+        status = {
+            "job_id": job_id,
+            "state": "running",
+            "expected_outputs": [str(output) for output in outputs],
+            "output_snapshot": {},
+        }
+        status_path.write_text(json.dumps(status), encoding="utf-8")
+        process = MagicMock(pid=4321)
+        process.poll.return_value = None
+        mod._PROCESS_HANDLES[job_id] = process
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            running = mod.read_render_job(job_id)
+            status["state"] = "completed"
+            status["written_files"] = [str(output) for output in outputs]
+            status_path.write_text(json.dumps(status), encoding="utf-8")
+            completed = mod.read_render_job(job_id)
+
+        assert running["completed"] == 2
+        assert running["total"] == 3
+        assert running["progress"] == pytest.approx(2.0 / 3.0)
+        assert running["recent_written_files"] == [str(output) for output in outputs[:2]]
+        assert completed["completed"] == 3
+        assert completed["progress"] == 1.0
+
+    def test_get_render_job_completes_legacy_terminal_job_without_written_files(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "3" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        outputs = [job_dir / "beauty.{:04d}.exr".format(frame) for frame in range(1, 4)]
+        for output in outputs:
+            output.write_bytes(b"completed output")
+        (job_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "state": "completed",
+                    "expected_outputs": [str(output) for output in outputs],
+                    "output_snapshot": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = mod.read_render_job(job_id)
+
+        assert result["completed"] == 3
+        assert result["total"] == 3
+        assert result["progress"] == 1.0
+        assert result["written_file_count"] == 3
+        assert result["recent_written_files"] == [str(output) for output in outputs]
+
+    def test_get_render_job_does_not_claim_unverified_failed_outputs(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "2" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        outputs = [job_dir / "beauty.{:04d}.exr".format(frame) for frame in range(1, 5)]
+        for output in outputs[:2]:
+            output.write_bytes(b"completed output")
+        (job_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "state": "failed",
+                    "expected_outputs": [str(output) for output in outputs],
+                    "output_snapshot": {},
+                    "written_files": [],
+                    "output_verification": {"state": "pending"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = mod.read_render_job(job_id)
+
+        assert result["completed"] == 0
+        assert result["total"] == 4
+        assert result["progress"] == 0.0
+        assert result["written_file_count"] == 0
+        assert result["recent_written_files"] == []
+
+    @pytest.mark.parametrize("state", ["failed", "cancelled", "interrupted"])
+    def test_get_render_job_keeps_latest_legacy_terminal_output_pending(self, tmp_path: Path, state: str) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = {"failed": "f", "cancelled": "c", "interrupted": "e"}[state] * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        outputs = [job_dir / "beauty.{:04d}.exr".format(frame) for frame in range(1, 4)]
+        for output in outputs:
+            output.write_bytes(b"possibly incomplete output")
+        (job_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "state": state,
+                    "expected_outputs": [str(output) for output in outputs],
+                    "output_snapshot": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = mod.read_render_job(job_id)
+
+        assert result["completed"] == 2
+        assert result["total"] == 3
+        assert result["progress"] == pytest.approx(2.0 / 3.0)
+        assert result["recent_written_files"] == [str(output) for output in outputs[:2]]
 
     def test_cancel_complete_race_preserves_completed_state(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "_background_render.py")
@@ -1613,6 +1738,39 @@ class TestRenderExecution:
         assert status["state"] == "completed"
         assert status["written_files"] == [str(tmp_path / "beauty.0005.exr")]
 
+    def test_get_render_job_counts_new_output_without_explicit_frame_range(self, tmp_path: Path) -> None:
+        output = tmp_path / "beauty.0001.exr"
+
+        def render(_rop, _frame_range):
+            output.write_bytes(b"new output")
+            return None, "render"
+
+        status = _run_render_worker(tmp_path, None, [], {}, render)
+
+        assert status["state"] == "completed"
+        assert status["expected_outputs"] == []
+        assert status["written_files"] == [str(output)]
+        assert status["output_verification"] == {
+            "state": "verified",
+            "expected_output_count": 1,
+            "written_file_count": 1,
+        }
+
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "4" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        status["job_id"] = job_id
+        (job_dir / "status.json").write_text(json.dumps(status), encoding="utf-8")
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = mod.read_render_job(job_id)
+
+        assert result["completed"] == 1
+        assert result["total"] == 1
+        assert result["progress"] == 1.0
+        assert result["written_file_count"] == 1
+        assert result["recent_written_files"] == [str(output)]
+
     def test_background_worker_reports_partial_outputs_when_range_fails(self, tmp_path: Path) -> None:
         expected = [tmp_path / "beauty.{:04d}.exr".format(frame) for frame in range(1, 8)]
 
@@ -1636,6 +1794,38 @@ class TestRenderExecution:
             "expected_output_count": 7,
             "written_file_count": 2,
         }
+
+    def test_background_worker_verifies_partial_outputs_when_render_raises(self, tmp_path: Path) -> None:
+        expected = [tmp_path / "beauty.{:04d}.exr".format(frame) for frame in range(1, 5)]
+
+        def render(_rop, _frame_range):
+            for output in expected[:2]:
+                output.write_bytes(b"completed output")
+            raise RuntimeError("render failed")
+
+        status = _run_render_worker(tmp_path, [1, 4, 1], expected, {}, render)
+
+        assert status["state"] == "failed"
+        assert status["written_files"] == [str(output) for output in expected[:2]]
+        assert status["output_verification"] == {
+            "state": "partial",
+            "expected_output_count": 4,
+            "written_file_count": 2,
+        }
+
+        mod = _load_script("houdini-render", "_background_render.py")
+        job_id = "3" * 32
+        job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+        job_dir.mkdir(parents=True)
+        status["job_id"] = job_id
+        (job_dir / "status.json").write_text(json.dumps(status), encoding="utf-8")
+        with patch.object(mod.tempfile, "gettempdir", return_value=str(tmp_path)):
+            result = mod.read_render_job(job_id)
+
+        assert result["completed"] == 2
+        assert result["total"] == 4
+        assert result["progress"] == 0.5
+        assert result["written_file_count"] == 2
 
     def test_background_worker_recovers_from_cached_launcher_without_snapshot(self, tmp_path: Path) -> None:
         output = tmp_path / "karma_beauty.1080.exr"
@@ -1797,6 +1987,28 @@ class TestRenderExecution:
         launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 100000, 1], str(tmp_path / "beauty.$F4.exr"))
         rop.render.assert_not_called()
 
+    def test_render_rop_defaults_to_background_in_headless(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        picture = _scalar_parm(str(tmp_path / "beauty.$F4.exr"))
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = False
+        job = {"job_id": "b" * 32, "state": "queued", "pid": 4321}
+
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(
+            mod, "launch_background_render", return_value=job
+        ) as launch:
+            result = mod.render_rop("/out/mantra1", frame_range=[1, 720, 1])
+
+        assert result["success"] is True
+        assert result["context"]["background"] is True
+        assert result["context"]["job_id"] == "b" * 32
+        launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 720, 1], str(tmp_path / "beauty.$F4.exr"))
+        rop.render.assert_not_called()
+
     def test_render_rop_reports_written_and_elapsed(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
         out = tmp_path / "beauty.exr"
@@ -1812,7 +2024,7 @@ class TestRenderExecution:
         mock_hou.isUIAvailable.return_value = False
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
-            result = mod.render_rop("/out/mantra1")
+            result = mod.render_rop("/out/mantra1", background=False)
 
         assert result["success"] is True
         assert result["context"]["rendered"] is True
@@ -1835,7 +2047,7 @@ class TestRenderExecution:
         mock_hou.isUIAvailable.return_value = False
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
-            result = mod.render_rop("/out/mantra1")
+            result = mod.render_rop("/out/mantra1", background=False)
 
         assert result["success"] is True
         assert result["context"]["rendered"] is False

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -49,6 +49,15 @@ def test_tools_yaml_contract(skill_dir: str) -> None:
             assert tool.get("timeout_hint_secs"), f"{tool['name']} missing timeout_hint_secs"
 
 
+def test_render_rop_returns_its_render_job_identity_directly_by_default() -> None:
+    tools_path = _SKILLS_ROOT / "houdini-render" / "tools.yaml"
+    tools = yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]
+    render_rop = next(tool for tool in tools if tool["name"] == "render_rop")
+
+    assert render_rop["execution"] == "sync"
+    assert "timeout_hint_secs" not in render_rop
+
+
 def test_skills_index_exists() -> None:
     index = _SKILLS_ROOT / "SKILLS_INDEX.md"
     assert index.is_file()


### PR DESCRIPTION
## Summary

- return the adapter-owned render job directly for ordinary `render_rop` calls instead of implicitly creating a second MCP job
- default both interactive and headless calls to the isolated renderer while preserving explicit `background=false` foreground execution
- keep the active output pending during polling, trust worker-verified terminal outputs, and preserve legacy completed-job progress
- verify partial outputs even when the renderer raises before terminal status is written

## Contract notes

Explicit MCP async metadata or a progress token can still request a core async job; callers resolve that core job before polling the adapter render job.

## Validation

- `566 passed, 1 skipped, 3 deselected`
- Ruff check and format check
- Python 3.7 syntax compatibility
- skill manifest validator with warnings as errors
- wheel/sdist build and Twine metadata check
- isolated MCP HTTP smoke confirmed a plain call returns the direct tool result
- independent read-only review: GO