### PR TITLE
fix(render): reject outputs from failed background jobs

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -81,7 +81,9 @@ default to isolated background execution.
 The default poll response is bounded: it reports `completed`, `total`,
 fractional `progress`, `elapsed_secs`, `eta_secs`, `written_file_count`, and up
 to ten `recent_written_files`. `output_verification.state` distinguishes
-`verified`, `not_observed`, and `unavailable` output evidence. Pass
+`verified`, `partial`, `failed`, `not_observed`, and `unavailable` output
+evidence. `verified` requires every expected output to be newly written,
+readable, non-empty, and produced without an execution/cook failure. Pass
 `include_details=true` only when the full
 expected-output snapshot, complete written-file and warning lists, error, and
 traceback are needed. The same job lifecycle also observes `cache_simulation` and

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -45,7 +45,14 @@ def _remove_owned_hip_snapshot(status_path: Path, status: dict, hip_path: Path) 
 
 
 def _verify_outputs(candidates: list, before: dict, output_pattern) -> tuple:
-    written_files = updated_outputs(candidates, before)
+    written_files = []
+    for output in updated_outputs(candidates, before):
+        try:
+            with Path(output).open("rb") as stream:
+                if stream.read(1):
+                    written_files.append(output)
+        except OSError:
+            continue
     verification_state = "not_observed"
     if written_files:
         verification_state = "verified" if len(written_files) == len(candidates) else "partial"
@@ -126,6 +133,8 @@ def main() -> None:
         if verification_ready:
             candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
             written_files, output_verification = _verify_outputs(candidates, before, output_pattern)
+            if output_verification["state"] == "verified":
+                output_verification["state"] = "failed"
         status.update(
             {
                 "state": "failed",

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -1795,6 +1795,47 @@ class TestRenderExecution:
             "written_file_count": 2,
         }
 
+    def test_background_worker_does_not_verify_outputs_when_render_fails(self, tmp_path: Path) -> None:
+        output = tmp_path / "beauty.0001.exr"
+
+        def render(_rop, _frame_range):
+            output.write_bytes(b"truncated output")
+            return [1.0, 1.0], "execute"
+
+        status = _run_render_worker(
+            tmp_path,
+            [1, 1, 1],
+            [output],
+            {},
+            render,
+            rop_errors=["Command Exit Code: 139"],
+        )
+
+        assert status["state"] == "failed"
+        assert status["written_files"] == [str(output)]
+        assert status["output_verification"] == {
+            "state": "failed",
+            "expected_output_count": 1,
+            "written_file_count": 1,
+        }
+
+    def test_background_worker_rejects_empty_output(self, tmp_path: Path) -> None:
+        output = tmp_path / "beauty.0001.exr"
+
+        def render(_rop, _frame_range):
+            output.write_bytes(b"")
+            return [1.0, 1.0], "execute"
+
+        status = _run_render_worker(tmp_path, [1, 1, 1], [output], {}, render)
+
+        assert status["state"] == "failed"
+        assert status["written_files"] == []
+        assert status["output_verification"] == {
+            "state": "not_observed",
+            "expected_output_count": 1,
+            "written_file_count": 0,
+        }
+
     def test_background_worker_verifies_partial_outputs_when_render_raises(self, tmp_path: Path) -> None:
         expected = [tmp_path / "beauty.{:04d}.exr".format(frame) for frame in range(1, 5)]
 


### PR DESCRIPTION
## Summary

- prevent failed background ROP jobs from reporting `output_verification.state=verified`
- count only newly written outputs that are readable and non-empty
- preserve `partial` evidence for incomplete frame ranges and document the verification states

## Contract

A background ROP execution or cook failure cannot produce verified output evidence, even when every expected path was updated. Validation remains format-neutral and does not impose renderer-specific extensions or size thresholds.

## Tests

- `pytest tests/test_render_camera_light_skills.py -q` (81 passed)
- regression coverage for a renderer failure after writing every expected output
- regression coverage for zero-byte output
- `ruff check` and `ruff format --check` on changed Python files
- Python 3.7 syntax check on changed Python files