### PR TITLE
feat: allow setting take override values

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -68,7 +68,7 @@ agent can detect and skip cleanly when rendering is unavailable.
 ### Takes
 
 1. `manage_takes(action="create", take_name="lighting_variant_a")`
-2. `manage_takes(action="add_override", take_name="lighting_variant_a", node_path="/out/solar_fx", parm_name="vm_picture")` → add the parameter tuple while restoring the previously current take.
+2. `manage_takes(action="add_override", take_name="lighting_variant_a", node_path="/out/solar_fx", parm_name="vm_picture", value="/tmp/lighting_variant_a.$F4.exr")` → add and set the take-local parameter while restoring the previously current take.
 3. `manage_takes(action="remove_override", take_name="lighting_variant_a", node_path="/out/solar_fx", parm_name="vm_picture")` → remove it with the same restoration guarantee.
 4. `manage_takes(action="switch", take_name="lighting_variant_a")`
 5. `manage_takes(action="list")` → review all takes

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/manage_takes.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/manage_takes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
@@ -18,6 +18,7 @@ def manage_takes(
     take_name: Optional[str] = None,
     node_path: Optional[str] = None,
     parm_name: Optional[str] = None,
+    value: Any = None,
 ) -> dict:
     """Manage takes and their parameter-tuple overrides."""
     try:
@@ -63,6 +64,12 @@ def manage_takes(
             )
 
         if action in ("add_override", "remove_override"):
+            if action == "remove_override" and value is not None:
+                return skill_error(
+                    "Invalid value",
+                    "value is supported only for action=add_override",
+                    action=action,
+                )
             if not take_name:
                 return skill_error("Missing take_name", "take_name is required for action={}".format(action))
             target = takes.findTake(take_name)
@@ -94,6 +101,7 @@ def manage_takes(
                 )
 
             changed = False
+            value_applied = False
             takes.setCurrentTake(target)
             try:
                 included = target.hasParmTuple(parm_tuple)
@@ -103,6 +111,15 @@ def manage_takes(
                 elif action == "remove_override" and included:
                     target.removeParmTuple(parm_tuple)
                     changed = True
+                if action == "add_override" and value is not None:
+                    values = tuple(value) if isinstance(value, (list, tuple)) else (value,)
+                    try:
+                        parm_tuple.set(values)
+                    except Exception:
+                        if changed:
+                            target.removeParmTuple(parm_tuple)
+                        raise
+                    value_applied = True
                 return skill_success(
                     "Updated take parameter override",
                     action=action,
@@ -110,6 +127,7 @@ def manage_takes(
                     node_path=node_path,
                     parm_name=parm_name,
                     changed=changed,
+                    value_applied=value_applied,
                 )
             finally:
                 if takes.currentTake() != current:

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -339,8 +339,9 @@ tools:
   - name: manage_takes
     description: >-
       Create, switch, delete, or list takes, and add or remove a parameter
-      tuple override on a child take. Override actions restore the previously
-      current take even when the update fails.
+      tuple override on a child take. add_override can set the take-local
+      parameter value in the same call. Override actions restore the
+      previously current take even when the update fails.
     source_file: scripts/manage_takes.py
     execution: sync
     affinity: main
@@ -368,6 +369,11 @@ tools:
         parm_name:
           type: string
           description: Parameter or parameter-tuple name required for override actions.
+        value:
+          description: >-
+            Optional scalar or list written inside the target take by
+            add_override. Scalars target one-component tuples; lists target
+            multi-component tuples.
   - name: get_render_stats
     description: >-
       Read render statistics (resolution, samples, renderer, output, frame

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -927,6 +927,62 @@ class TestRenderPassAuthoring:
         assert variant.hasParmTuple(parm_tuple) is False
         assert takes.currentTake().name() == "main"
 
+    def test_manage_takes_adds_override_value_inside_target_take(self) -> None:
+        mod = _load_script("houdini-render", "manage_takes.py")
+        takes = _FakeTakes()
+        variant = takes.add("solar_fx")
+        parm_tuple = MagicMock()
+
+        def assert_target_current(_values):
+            assert takes.currentTake() is variant
+
+        parm_tuple.set.side_effect = assert_target_current
+        node = _node("/out/mantra1", "mantra1", "ifd")
+        node.parmTuple.return_value = parm_tuple
+        mock_hou = MagicMock()
+        mock_hou.takes = takes
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.manage_takes(
+                "add_override",
+                take_name="solar_fx",
+                node_path="/out/mantra1",
+                parm_name="vm_picture",
+                value="/renders/solar_fx.$F4.exr",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["value_applied"] is True
+        assert variant.hasParmTuple(parm_tuple) is True
+        parm_tuple.set.assert_called_once_with(("/renders/solar_fx.$F4.exr",))
+        assert takes.currentTake().name() == "main"
+
+    def test_manage_takes_rolls_back_new_override_when_value_write_fails(self) -> None:
+        mod = _load_script("houdini-render", "manage_takes.py")
+        takes = _FakeTakes()
+        variant = takes.add("solar_fx")
+        parm_tuple = MagicMock()
+        parm_tuple.set.side_effect = RuntimeError("value rejected")
+        node = _node("/out/mantra1", "mantra1", "ifd")
+        node.parmTuple.return_value = parm_tuple
+        mock_hou = MagicMock()
+        mock_hou.takes = takes
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.manage_takes(
+                "add_override",
+                take_name="solar_fx",
+                node_path="/out/mantra1",
+                parm_name="vm_picture",
+                value="/renders/solar_fx.$F4.exr",
+            )
+
+        assert result["success"] is False
+        assert variant.hasParmTuple(parm_tuple) is False
+        assert takes.currentTake().name() == "main"
+
     def test_manage_takes_restores_current_take_when_override_update_fails(self) -> None:
         mod = _load_script("houdini-render", "manage_takes.py")
         takes = _FakeTakes()


### PR DESCRIPTION
## Summary
- allow `manage_takes(action="add_override")` to set the take-local parameter value atomically
- restore the previously current take after success or failure
- roll back a newly added override if the value write fails
- document the typed value contract

## Validation
- 83 render/camera/light tests passed
- 82 skill contract tests passed
- Python 3.7 syntax check passed
- 31 bundled skills validated with zero warnings
- Ruff passed