### PR TITLE
feat: support keyframe interpolation modes

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -52,6 +52,10 @@ Typed animation tools for agents. All tools are `affinity: main`.
 6. `export_channels("/obj/geo1", ["tx"], "/tmp/tx.json")` → `import_channels` to retarget
 7. `bake_channels("/obj/geo1", ["tx"], frame_range=[1,48])` to flatten expressions
 
+For numeric keys, `set_keyframe` accepts optional `interpolation`: `bezier`,
+`linear`, or `constant`. It controls the segment starting at that key; omit it
+to preserve Houdini's default. Use `constant` for discrete one-frame switches.
+
 ## Loop range contract
 
 `validate_loop_contract` treats `[start_frame, end_frame]` as **N unique

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_keyframe.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/set_keyframe.py
@@ -14,6 +14,12 @@ if _SCRIPT_DIR not in sys.path:
 
 from _anim_common import get_node, get_parm  # noqa: E402
 
+_INTERPOLATION_EXPRESSIONS = {
+    "bezier": "bezier()",
+    "linear": "linear()",
+    "constant": "constant()",
+}
+
 
 def set_keyframe(
     node_path: str,
@@ -22,11 +28,13 @@ def set_keyframe(
     value: Optional[float] = None,
     expression: Optional[str] = None,
     language: str = "hscript",
+    interpolation: Optional[str] = None,
 ) -> dict:
     """Set a keyframe on ``node_path/parm_name`` at *frame*.
 
-    Provide ``value`` for a constant key or ``expression`` for an expression
-    key (``language`` is "hscript" or "python").
+    Provide ``value`` for a numeric key or ``expression`` for an expression
+    key (``language`` is "hscript" or "python"). For numeric keys, optional
+    ``interpolation`` selects the segment function starting at this key.
     """
     try:
         import hou  # noqa: PLC0415
@@ -35,6 +43,19 @@ def set_keyframe(
 
     if value is None and expression is None:
         return skill_error("Nothing to set", "Provide value or expression")
+    if expression is not None and interpolation is not None:
+        return skill_error(
+            "Conflicting keyframe options",
+            "interpolation applies only to numeric value keys",
+        )
+
+    normalized_interpolation = interpolation.lower() if interpolation is not None else None
+    if normalized_interpolation is not None and normalized_interpolation not in _INTERPOLATION_EXPRESSIONS:
+        return skill_error(
+            "Unsupported interpolation",
+            "interpolation must be 'bezier', 'linear', or 'constant'",
+            requested=interpolation,
+        )
 
     try:
         node = get_node(hou, node_path)
@@ -46,6 +67,11 @@ def set_keyframe(
             kf.setExpression(expression, lang)
         else:
             kf.setValue(float(value))
+            if normalized_interpolation is not None:
+                kf.setExpression(
+                    _INTERPOLATION_EXPRESSIONS[normalized_interpolation],
+                    hou.exprLanguage.Hscript,
+                )
         parm.setKeyframe(kf)
         return skill_success(
             "Set keyframe",
@@ -54,6 +80,7 @@ def set_keyframe(
             frame=float(frame),
             value=value,
             expression=expression,
+            interpolation=normalized_interpolation,
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to set keyframe")

--- a/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
@@ -78,6 +78,12 @@ tools:
           type: string
           enum: [hscript, python]
           default: hscript
+        interpolation:
+          type: string
+          description: >-
+            Optional segment interpolation starting at this numeric value key.
+            Omit to preserve Houdini's default.
+          enum: [bezier, linear, constant]
   - name: get_keyframes
     description: List keyframes on a node parameter (frame, value, expression).
     source_file: scripts/get_keyframes.py

--- a/tests/test_animation_skills.py
+++ b/tests/test_animation_skills.py
@@ -42,6 +42,7 @@ def _hou_with_keyframe_class():
             self.frame = None
             self.value = None
             self.expression = None
+            self.expression_language = None
 
         def setFrame(self, f):
             self.frame = f
@@ -51,6 +52,7 @@ def _hou_with_keyframe_class():
 
         def setExpression(self, e, lang):
             self.expression = e
+            self.expression_language = lang
 
     mock_hou.Keyframe.side_effect = _KF
     mock_hou.exprLanguage.Hscript = "hscript"
@@ -102,6 +104,29 @@ class TestKeyframes:
         applied_kf = parm.setKeyframe.call_args[0][0]
         assert applied_kf.frame == 10.0
         assert applied_kf.value == 5.0
+        assert applied_kf.expression is None
+
+    def test_set_keyframe_value_uses_requested_interpolation(self) -> None:
+        mod = _load_script("set_keyframe.py")
+        for interpolation in ("bezier", "linear", "constant"):
+            parm = MagicMock()
+            node = MagicMock()
+            node.path.return_value = "/obj/geo1"
+            node.parm.return_value = parm
+            mock_hou = _hou_with_keyframe_class()
+            mock_hou.node.return_value = node
+            with patch.dict(sys.modules, {"hou": mock_hou}):
+                result = mod.set_keyframe(
+                    "/obj/geo1",
+                    "tx",
+                    frame=10,
+                    value=5.0,
+                    interpolation=interpolation,
+                )
+            assert result["success"] is True
+            applied_kf = parm.setKeyframe.call_args[0][0]
+            assert applied_kf.expression == "{}()".format(interpolation)
+            assert applied_kf.expression_language == "hscript"
 
     def test_set_keyframe_requires_value_or_expression(self) -> None:
         mod = _load_script("set_keyframe.py")


### PR DESCRIPTION
## Summary
- add an optional `interpolation` mode to numeric `set_keyframe` calls
- support Houdini `bezier()`, `linear()`, and `constant()` segment functions
- preserve Houdini's existing default when the option is omitted
- reject ambiguous expression-key plus interpolation requests

## Validation
- 16 animation tests passed
- Ruff and format checks passed
- Python 3.7 syntax check passed
- 31 bundled skills validated with zero warnings

## Reference
- https://www.sidefx.com/docs/houdini/hom/hou/Keyframe.html
- https://www.sidefx.com/docs/houdini/expressions/constant.html