### PR TITLE
fix(render): enforce background output verification

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -84,7 +84,9 @@ to ten `recent_written_files`. `output_verification.state` distinguishes
 `verified`, `partial`, `failed`, `not_observed`, and `unavailable` output
 evidence. `verified` requires every expected output to be newly written,
 readable, non-empty, and produced without an execution/cook failure. Pass
-`include_details=true` only when the full
+an explicit frame range when exact completeness matters; render and cache jobs
+with only part of that requested range written fail with bounded output counts.
+Pass `include_details=true` only when the full
 expected-output snapshot, complete written-file and warning lists, error, and
 traceback are needed. The same job lifecycle also observes `cache_simulation` and
 `execute_rop_chain` jobs.

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -149,6 +149,24 @@ def expanded_outputs(pattern: Optional[str]) -> list:
     return [pattern] if os.path.isfile(pattern) else []
 
 
+def expand_output_variables(hou: Any, pattern: Optional[str]) -> Optional[str]:
+    """Expand Houdini variables while preserving frame tokens for discovery."""
+    if not pattern:
+        return pattern
+    tokens = {}
+
+    def protect_frame_token(match: re.Match) -> str:
+        placeholder = "__DCC_MCP_FRAME_TOKEN_{}__".format(len(tokens))
+        tokens[placeholder] = match.group(0)
+        return placeholder
+
+    protected = re.sub(r"\$F\d*", protect_frame_token, pattern)
+    expanded = hou.text.expandString(protected)
+    for placeholder, token in tokens.items():
+        expanded = expanded.replace(placeholder, token)
+    return expanded
+
+
 def requested_outputs(hou: Any, pattern: Optional[str], frame_range: Optional[Sequence[float]]) -> list:
     """Expand the output paths for the exact requested frame range."""
     if not pattern:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -9,7 +9,14 @@ import time
 import traceback
 from pathlib import Path
 
-from _render_common import expanded_outputs, output_snapshot, render_node, requested_outputs, updated_outputs
+from _render_common import (
+    expand_output_variables,
+    expanded_outputs,
+    output_snapshot,
+    render_node,
+    requested_outputs,
+    updated_outputs,
+)
 
 
 def write_status(path: Path, payload: dict) -> None:
@@ -91,13 +98,16 @@ def main() -> None:
         if status.get("hip_snapshot_owned") is True:
             hou.hipFile.setName(status["source_hip_path"])
             _remove_owned_hip_snapshot(status_path, status, hip_path)
+        resolved_output_pattern = output_pattern
+        if not frame_range:
+            resolved_output_pattern = expand_output_variables(hou, output_pattern)
         rop = hou.node(rop_path)
         if rop is None:
             raise ValueError("ROP node not found: {}".format(rop_path))
         expected_outputs = (
             status["expected_outputs"]
             if frame_range and "expected_outputs" in status
-            else requested_outputs(hou, output_pattern, frame_range)
+            else requested_outputs(hou, resolved_output_pattern, frame_range)
         )
         before = status.get("output_snapshot")
         if before is None:
@@ -111,12 +121,23 @@ def main() -> None:
             _, execution_mode = render_node(rop, frame_range)
         rop_errors = [str(error) for error in rop.errors()] if hasattr(rop, "errors") else []
         logged_cook_errors = _cook_errors(status)
-        candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
-        written_files, output_verification = _verify_outputs(candidates, before, output_pattern)
+        candidates = expected_outputs if frame_range else expanded_outputs(resolved_output_pattern)
+        written_files, output_verification = _verify_outputs(candidates, before, resolved_output_pattern)
         if logged_cook_errors:
             raise RuntimeError("ROP cook error: {}".format("; ".join(logged_cook_errors[:3])))
         if rop_errors:
             raise RuntimeError("ROP errors: {}".format("; ".join(rop_errors)))
+        if (
+            frame_range
+            and output_verification["state"] == "partial"
+            and status.get("job_kind", "render") != "rop_chain"
+        ):
+            raise RuntimeError(
+                "Render produced {} of {} expected outputs".format(
+                    output_verification["written_file_count"],
+                    output_verification["expected_output_count"],
+                )
+            )
         if not written_files and status.get("job_kind", "render") != "rop_chain":
             raise RuntimeError("Render produced no new or updated output for the requested frame range")
         status.update(
@@ -131,8 +152,8 @@ def main() -> None:
         )
     except Exception as exc:  # noqa: BLE001
         if verification_ready:
-            candidates = expected_outputs if frame_range else expanded_outputs(output_pattern)
-            written_files, output_verification = _verify_outputs(candidates, before, output_pattern)
+            candidates = expected_outputs if frame_range else expanded_outputs(resolved_output_pattern)
+            written_files, output_verification = _verify_outputs(candidates, before, resolved_output_pattern)
             if output_verification["state"] == "verified":
                 output_verification["state"] = "failed"
         status.update(

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -305,6 +305,7 @@ def _run_render_worker(
     ignore_inputs=False,
     job_kind="render",
     rop_errors=(),
+    expand_string=None,
 ):
     mod = _load_render_worker()
     if pattern is _DEFAULT_PATTERN:
@@ -332,6 +333,7 @@ def _run_render_worker(
     rop.errors.return_value = list(rop_errors)
     mock_hou = MagicMock()
     mock_hou.node.return_value = rop
+    mock_hou.text.expandString.side_effect = expand_string or (lambda value: value)
     mock_hou.text.expandStringAtFrame.side_effect = lambda value, frame: value.replace(
         "$F4", "{:04d}".format(int(frame))
     )
@@ -1774,7 +1776,7 @@ class TestRenderExecution:
         assert not snapshot.exists()
         assert source.read_bytes() == b"source"
 
-    def test_background_worker_reports_only_updated_requested_outputs(self, tmp_path: Path) -> None:
+    def test_background_worker_rejects_partial_requested_outputs(self, tmp_path: Path) -> None:
         stale = tmp_path / "beauty.0001.exr"
         stale.write_bytes(b"stale")
         outside = tmp_path / "beauty.0002.exr"
@@ -1791,8 +1793,14 @@ class TestRenderExecution:
             {str(stale): {"mtime_ns": stale.stat().st_mtime_ns, "size": stale.stat().st_size}},
             render,
         )
-        assert status["state"] == "completed"
+        assert status["state"] == "failed"
         assert status["written_files"] == [str(tmp_path / "beauty.0005.exr")]
+        assert status["output_verification"] == {
+            "state": "partial",
+            "expected_output_count": 3,
+            "written_file_count": 1,
+        }
+        assert status["error"] == "Render produced 1 of 3 expected outputs"
 
     def test_get_render_job_counts_new_output_without_explicit_frame_range(self, tmp_path: Path) -> None:
         output = tmp_path / "beauty.0001.exr"
@@ -1826,6 +1834,32 @@ class TestRenderExecution:
         assert result["progress"] == 1.0
         assert result["written_file_count"] == 1
         assert result["recent_written_files"] == [str(output)]
+
+    def test_background_worker_expands_houdini_variables_without_explicit_frame_range(self, tmp_path: Path) -> None:
+        output = tmp_path / "renders" / "beauty.0001.exr"
+
+        def render(_rop, _frame_range):
+            output.parent.mkdir()
+            output.write_bytes(b"new output")
+            return None, "render"
+
+        status = _run_render_worker(
+            tmp_path,
+            None,
+            [],
+            {},
+            render,
+            pattern="$HIP/renders/beauty.$F4.exr",
+            expand_string=lambda value: value.replace("$HIP", str(tmp_path)),
+        )
+
+        assert status["state"] == "completed"
+        assert [Path(path) for path in status["written_files"]] == [output]
+        assert status["output_verification"] == {
+            "state": "verified",
+            "expected_output_count": 1,
+            "written_file_count": 1,
+        }
 
     def test_background_worker_reports_partial_outputs_when_range_fails(self, tmp_path: Path) -> None:
         expected = [tmp_path / "beauty.{:04d}.exr".format(frame) for frame in range(1, 8)]


### PR DESCRIPTION
## Summary
- expand Houdini output-path variables after restoring the source HIP identity while preserving frame tokens for no-range discovery
- fail render and cache jobs with explicit frame ranges when only a subset of expected outputs is written
- keep diagnostics bounded to written/expected counts and preserve ROP-chain execution semantics

## Validation
- `python -m pytest -q` — 574 passed, 1 skipped, 3 deselected
- `ruff check src tests tools packaging`
- `ruff format --check src tests tools packaging`
- `python tools/lint_skills.py --warnings-as-errors` — 31 skills, 0 errors, 0 warnings
- `python tools/check_py37_syntax.py src tests tools packaging`