### PR TITLE
fix: refresh scene registry after hip changes

### DIFF
--- a/src/dcc_mcp_houdini/_resources.py
+++ b/src/dcc_mcp_houdini/_resources.py
@@ -189,8 +189,13 @@ def _default_event_installer(callback: Callable[[], None]) -> List[Any]:
     if hou is None:
         return []
 
-    def _wrapper(*_args: Any, **_kwargs: Any) -> None:
-        callback()
+    after_events = tuple(
+        getattr(hou.hipFileEventType, name) for name in ("AfterClear", "AfterLoad", "AfterMerge", "AfterSave")
+    )
+
+    def _wrapper(event_type: Any, *_args: Any, **_kwargs: Any) -> None:
+        if event_type in after_events:
+            callback()
 
     try:
         hou.hipFile.addEventCallback(_wrapper)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,12 +7,15 @@ lifecycle, and the trailing-edge throttling — all without a live Houdini.
 from __future__ import annotations
 
 import json
+import threading
 import time
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 from unittest.mock import MagicMock
 
 import pytest
 
+import dcc_mcp_houdini._resources as resources
 from dcc_mcp_houdini._resources import (
     DEFAULT_SCENE_THROTTLE_SECS,
     ENV_RESOURCES,
@@ -213,6 +216,70 @@ class TestInstallResources:
         assert binder is not None
         assert binder.handle is server.resource_handle
         assert binder.scene_publish_count == 1
+
+    def test_save_as_publishes_registry_scene_after_save(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        callbacks: List[Callable[..., None]] = []
+        before_save = object()
+        after_save = object()
+        fake_hou = SimpleNamespace(
+            hipFile=SimpleNamespace(addEventCallback=callbacks.append),
+            hipFileEventType=SimpleNamespace(
+                AfterClear=object(),
+                AfterLoad=object(),
+                AfterMerge=object(),
+                AfterSave=after_save,
+            ),
+        )
+        monkeypatch.setattr(resources, "_hou", lambda: fake_hou)
+
+        main_thread = threading.get_ident()
+        current_scene = {"path": "old.hip"}
+        workers: List[threading.Thread] = []
+
+        class RegistryServer(_FakeServer):
+            def __init__(self) -> None:
+                super().__init__()
+                self.registry_scenes: List[str] = []
+
+            def publish_capability_snapshot(self, *, reason: str) -> bool:
+                if threading.get_ident() != main_thread:
+                    return False
+                self.registry_scenes.append(current_scene["path"])
+                return True
+
+        class ImmediateThreadTimer:
+            def __init__(self, _delay: float, callback: Callable[[], None]) -> None:
+                self.callback = callback
+                self.daemon = False
+
+            def start(self) -> None:
+                worker = threading.Thread(target=self.callback)
+                workers.append(worker)
+                worker.start()
+
+            def cancel(self) -> None:
+                pass
+
+        monkeypatch.setattr(resources.threading, "Timer", ImmediateThreadTimer)
+        server = RegistryServer()
+        binder = install_resources(
+            server,
+            snapshot_provider=lambda: {"scene": current_scene["path"]},
+            throttle_secs=0.5,
+        )
+        assert binder is not None
+        assert len(callbacks) == 1
+        server.registry_scenes.clear()
+        binder._last_publish_at = 0.0
+
+        callbacks[0](before_save)
+        current_scene["path"] = "new.hip"
+        callbacks[0](after_save)
+        for worker in workers:
+            worker.join()
+
+        assert server.registry_scenes == ["new.hip"]
+        binder.unbind()
 
 
 class TestModuleExports:


### PR DESCRIPTION
## Summary

- publish scene metadata only from completed Houdini hip-file lifecycle events
- prevent a pre-save callback from consuming the throttle window before the new path is active
- cover Save As with a regression that models Houdini main-thread-only snapshot access

## Root cause

Houdini invokes hip-file callbacks for both before and after lifecycle events. The pre-save callback published the previous scene path first, while the corresponding post-save refresh was deferred to a timer thread where a HOM-backed snapshot could not be collected reliably. FileRegistry heartbeats therefore kept refreshing liveness without receiving the new scene path.

## Validation

- 576 passed, 1 skipped
- Ruff check and format check
- Python 3.7 syntax check
- dcc-mcp-cli 0.19.59 skill validation: 31 checked, 0 errors

## Dependency

Stacked on #168 so the current runtime-scoped skill-import validator remains green. Rebase onto main after #168 merges.