### PR TITLE
fix: handle unknown HIP dirty state safely in hython

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ or call `dcc_mcp_houdini.serve_headless(...)` from a dedicated Hython
 entrypoint. A plain headless `start_server()` fails before tools are registered
 instead of silently executing HOM on an HTTP worker.
 
+Hython cannot report a reliable HIP dirty state: context snapshots omit
+`scene_saved`, while `validate_scene` returns `dirty: null`; GUI sessions report
+the real boolean state. Destructive `open_scene` and `new_scene` calls fail
+closed when that state is unknown unless the caller explicitly passes
+`force=true`.
+
 Default minimal mode (`DCC_MCP_MINIMAL=1`) loads only:
 
 - `houdini-scripting`

--- a/src/dcc_mcp_houdini/_context_snapshot.py
+++ b/src/dcc_mcp_houdini/_context_snapshot.py
@@ -25,6 +25,8 @@ import logging
 import os
 from typing import Any, Callable, Dict, List, Optional
 
+from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -96,7 +98,7 @@ class HoudiniContextSnapshotProvider:
         has_file = _safe(lambda: bool(hou.hipFile.hasFile()))
         if scene and has_file:
             snapshot["scene"] = scene
-        modified = _safe(lambda: bool(hou.hipFile.hasUnsavedChanges()))
+        modified = get_hip_dirty_state(hou)
         if modified is not None:
             snapshot["scene_saved"] = not modified
 

--- a/src/dcc_mcp_houdini/_hip_file_state.py
+++ b/src/dcc_mcp_houdini/_hip_file_state.py
@@ -1,0 +1,21 @@
+"""Reliable HIP file state probes across Houdini and hython."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def get_hip_dirty_state(hou: Any) -> Optional[bool]:
+    """Return the GUI dirty state, or ``None`` when HOM cannot report it.
+
+    SideFX documents that ``hou.hipFile.hasUnsavedChanges()`` always returns
+    ``True`` in non-graphical hython sessions, so that value is not evidence of
+    unsaved changes there:
+    https://www.sidefx.com/docs/houdini/hom/hou/hipFile.html
+    """
+    try:
+        if not hou.isUIAvailable():
+            return None
+        return bool(hou.hipFile.hasUnsavedChanges())
+    except Exception:  # noqa: BLE001 -- unavailable HOM state is unknown
+        return None

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from dcc_mcp_houdini import _isolated_jobs
+from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
 
 _SUMMARY_WARNING_LIMIT = 10
 _SUMMARY_TEXT_LIMIT = 500
@@ -32,10 +33,11 @@ def _validate_saved_hip(hou: Any) -> tuple:
     if not hip_path.is_file():
         raise ValueError("Background rendering requires the current HIP file to be saved")
     is_ui_available = bool(hou.isUIAvailable())
-    if is_ui_available:
-        has_unsaved_changes = getattr(hou.hipFile, "hasUnsavedChanges", None)
-        if callable(has_unsaved_changes) and has_unsaved_changes() is True:
-            raise ValueError("Background rendering rejects unsaved changes; save the HIP file explicitly first")
+    dirty = get_hip_dirty_state(hou)
+    if dirty is True:
+        raise ValueError("Background rendering rejects unsaved changes; save the HIP file explicitly first")
+    if is_ui_available and dirty is None:
+        raise ValueError("Background rendering cannot determine the current HIP dirty state")
     return hip_path, is_ui_available
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/scripts/validate_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/scripts/validate_scene.py
@@ -8,6 +8,8 @@ from typing import List, Optional
 from _pipeline_common import expand_path, iter_file_parms, resolve_nodes  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
+
 
 def validate_scene(
     node_paths: Optional[List[str]] = None,
@@ -51,10 +53,7 @@ def validate_scene(
             if errs:
                 node_errors.append({"node": node.path(), "errors": errs})
 
-        try:
-            dirty = bool(hou.hipFile.hasUnsavedChanges())
-        except Exception:  # noqa: BLE001
-            dirty = None
+        dirty = get_hip_dirty_state(hou)
 
         issue_count = len(missing_files) + len(bad_output_dirs) + len(node_errors)
         valid = issue_count == 0

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -28,8 +28,9 @@ lifecycle and navigation.
 
 ## When to use
 
-- **Lifecycle:** `new_scene`, `open_scene`, `save_scene` — each guards against
-  silently discarding unsaved changes (pass `force=true` to override).
+- **Lifecycle:** `new_scene`, `open_scene`, `save_scene` — destructive calls
+  require a known-clean scene or explicit `force=true` when dirty state is
+  unknown.
 - **Selection & discovery:** `get_selection`, `set_selection`, `find_nodes`,
   `list_cameras`, `get_bounding_box`.
 

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/new_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/new_scene.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
+
 
 def new_scene(force: bool = False) -> dict:
     """Clear the current hip file.
 
-    Refuses to discard unsaved changes unless ``force`` is ``True``.
+    Requires a known-clean scene unless ``force`` is ``True``.
     """
     try:
         import hou  # noqa: PLC0415
@@ -16,15 +18,23 @@ def new_scene(force: bool = False) -> dict:
         return skill_error("Houdini not available", "hou could not be imported")
 
     try:
-        if not force and hou.hipFile.hasUnsavedChanges():
-            return skill_error(
-                "Scene has unsaved changes",
-                "Refusing to clear the scene; save first or call with force=true",
-                possible_solutions=[
-                    "Call houdini_scene_edit__save_scene first",
-                    "Re-run new_scene with force=true to discard changes",
-                ],
-            )
+        if not force:
+            dirty = get_hip_dirty_state(hou)
+            if dirty is True:
+                return skill_error(
+                    "Scene has unsaved changes",
+                    "Refusing to clear the scene; save first or call with force=true",
+                    possible_solutions=[
+                        "Call houdini_scene_edit__save_scene first",
+                        "Re-run new_scene with force=true to discard changes",
+                    ],
+                )
+            if dirty is None:
+                return skill_error(
+                    "Scene dirty state unavailable",
+                    "Cannot safely clear the scene when its dirty state is unknown; call with force=true to discard it",
+                    possible_solutions=["Re-run new_scene with force=true to discard the current scene"],
+                )
         hou.hipFile.clear(suppress_save_prompt=True)
         return skill_success("Started a new scene", forced=bool(force))
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/open_scene.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/scripts/open_scene.py
@@ -6,11 +6,13 @@ import os
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
+
 
 def open_scene(file_path: str, force: bool = False) -> dict:
     """Load *file_path* into the current session.
 
-    Refuses to discard unsaved changes unless ``force`` is ``True``.
+    Requires a known-clean scene unless ``force`` is ``True``.
     """
     try:
         import hou  # noqa: PLC0415
@@ -20,15 +22,23 @@ def open_scene(file_path: str, force: bool = False) -> dict:
     try:
         if not os.path.isfile(file_path):
             return skill_error("Hip file not found", "No file at: {}".format(file_path))
-        if not force and hou.hipFile.hasUnsavedChanges():
-            return skill_error(
-                "Scene has unsaved changes",
-                "Refusing to load over unsaved changes; save first or call with force=true",
-                possible_solutions=[
-                    "Call houdini_scene_edit__save_scene first",
-                    "Re-run open_scene with force=true to discard changes",
-                ],
-            )
+        if not force:
+            dirty = get_hip_dirty_state(hou)
+            if dirty is True:
+                return skill_error(
+                    "Scene has unsaved changes",
+                    "Refusing to load over unsaved changes; save first or call with force=true",
+                    possible_solutions=[
+                        "Call houdini_scene_edit__save_scene first",
+                        "Re-run open_scene with force=true to discard changes",
+                    ],
+                )
+            if dirty is None:
+                return skill_error(
+                    "Scene dirty state unavailable",
+                    "Cannot safely load over the current scene when its dirty state is unknown; call with force=true to discard it",
+                    possible_solutions=["Re-run open_scene with force=true to discard the current scene"],
+                )
         hou.hipFile.load(file_path, suppress_save_prompt=True, ignore_load_warnings=False)
         return skill_success(
             "Opened hip file",

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/tools.yaml
@@ -1,8 +1,8 @@
 tools:
   - name: new_scene
     description: >-
-      Clear the current hip file and start an empty scene. Refuses to discard
-      unsaved changes unless force is true.
+      Clear the current hip file and start an empty scene. Requires a
+      known-clean scene unless force is true.
     source_file: scripts/new_scene.py
     execution: sync
     affinity: main
@@ -26,8 +26,8 @@ tools:
         - houdini_scene_edit__save_scene
   - name: open_scene
     description: >-
-      Load an existing hip file. Refuses to discard unsaved changes unless
-      force is true; returns a structured error when the file is missing.
+      Load an existing hip file. Requires a known-clean scene unless force is
+      true; returns a structured error when the file is missing.
     source_file: scripts/open_scene.py
     execution: sync
     affinity: main

--- a/tests/test_context_snapshot.py
+++ b/tests/test_context_snapshot.py
@@ -16,7 +16,15 @@ from dcc_mcp_houdini._context_snapshot import (
 )
 
 
-def _fake_hou(*, scene="/projects/shot.hip", has_file=True, unsaved=False, version="20.5.445", obj_count=3):
+def _fake_hou(
+    *,
+    scene="/projects/shot.hip",
+    has_file=True,
+    unsaved=False,
+    version="20.5.445",
+    obj_count=3,
+    ui_available=True,
+):
     hip = SimpleNamespace(
         path=lambda: scene,
         name=lambda: scene,
@@ -29,6 +37,7 @@ def _fake_hou(*, scene="/projects/shot.hip", has_file=True, unsaved=False, versi
     return SimpleNamespace(
         hipFile=hip,
         playbar=playbar,
+        isUIAvailable=lambda: ui_available,
         frame=lambda: 1001,
         node=lambda path: obj_node if path == "/obj" else None,
         applicationVersionString=lambda: version,
@@ -48,6 +57,16 @@ def test_provider_collects_full_snapshot_when_houdini_available():
     assert snap["version"] == "20.5.445"
     assert snap["display_name"] == "Houdini 20.5.445 — shot.hip"
     assert snap["pid"] > 0
+
+
+def test_provider_omits_saved_state_when_hython_dirty_probe_is_unsupported():
+    provider = HoudiniContextSnapshotProvider(
+        hou_provider=lambda: _fake_hou(ui_available=False, unsaved=True),
+    )
+
+    snap = provider()
+
+    assert "scene_saved" not in snap
 
 
 def test_provider_returns_stub_when_hou_unavailable():

--- a/tests/test_pipeline_skills.py
+++ b/tests/test_pipeline_skills.py
@@ -154,6 +154,24 @@ class TestValidation:
         assert result["context"]["valid"] is True
         assert result["context"]["dirty"] is False
 
+    def test_validate_scene_reports_unknown_dirty_state_in_hython(self, tmp_path) -> None:
+        mod = _load_script("validate_scene.py")
+        existing = tmp_path / "in.bgeo"
+        existing.write_text("x")
+        node = _node("/obj/geo1/file1", "file1", "file")
+        node.parms.return_value = [_file_parm("file", str(existing))]
+        node.errors.return_value = []
+        mock_hou = _mock_hou_with_file_parms()
+        mock_hou.node.return_value = node
+        mock_hou.isUIAvailable.return_value = False
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.validate_scene(node_paths=["/obj/geo1/file1"])
+
+        assert result["context"]["dirty"] is None
+        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
+
     def test_collect_dependencies(self, tmp_path) -> None:
         mod = _load_script("collect_dependencies.py")
         existing = tmp_path / "tex.exr"

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -1106,6 +1106,22 @@ class TestRenderExecution:
         mock_hou.hipFile.saveAsBackup.assert_not_called()
         popen.assert_not_called()
 
+    def test_background_render_gui_rejects_unknown_dirty_state(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "_background_render.py")
+        hip = tmp_path / "scene.hip"
+        hip.write_bytes(b"hip")
+        mock_hou = MagicMock()
+        mock_hou.hipFile.path.return_value = str(hip)
+        mock_hou.hipFile.hasUnsavedChanges.side_effect = RuntimeError("probe failed")
+        mock_hou.isUIAvailable.return_value = True
+
+        with patch.object(mod.subprocess, "Popen") as popen, pytest.raises(ValueError, match="dirty state"):
+            mod.launch_background_render(mock_hou, "/out/mantra1", [1, 2, 1], "beauty.$F4.exr")
+
+        mock_hou.hipFile.save.assert_not_called()
+        mock_hou.hipFile.saveAsBackup.assert_not_called()
+        popen.assert_not_called()
+
     def test_background_render_headless_launches_from_owned_snapshot_without_saving_source(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_scene_transform_skills.py
+++ b/tests/test_scene_transform_skills.py
@@ -39,24 +39,107 @@ class TestSceneLifecycle:
     def test_new_scene_blocks_on_unsaved_changes(self) -> None:
         mod = _load_script("houdini-scene-edit", "new_scene.py")
         mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
         mock_hou.hipFile.hasUnsavedChanges.return_value = True
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.new_scene(force=False)
 
         assert result["success"] is False
+        mock_hou.hipFile.hasUnsavedChanges.assert_called_once_with()
         mock_hou.hipFile.clear.assert_not_called()
 
     def test_new_scene_force_clears(self) -> None:
         mod = _load_script("houdini-scene-edit", "new_scene.py")
         mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
         mock_hou.hipFile.hasUnsavedChanges.return_value = True
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.new_scene(force=True)
 
         assert result["success"] is True
-        mock_hou.hipFile.clear.assert_called_once()
+        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
+        mock_hou.hipFile.clear.assert_called_once_with(suppress_save_prompt=True)
+
+    def test_new_scene_requires_force_when_hython_dirty_state_is_unknown(self) -> None:
+        mod = _load_script("houdini-scene-edit", "new_scene.py")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.new_scene(force=False)
+
+        assert result["success"] is False
+        assert result["message"] == "Scene dirty state unavailable"
+        assert "force=true" in result["error"]
+        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
+        mock_hou.hipFile.clear.assert_not_called()
+
+    def test_open_scene_requires_force_when_hython_dirty_state_is_unknown(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-scene-edit", "open_scene.py")
+        hip = tmp_path / "shot.hip"
+        hip.write_bytes(b"hip")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+        mock_hou.hipFile.path.return_value = str(hip)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.open_scene(str(hip), force=False)
+
+        assert result["success"] is False
+        assert result["message"] == "Scene dirty state unavailable"
+        assert "force=true" in result["error"]
+        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
+        mock_hou.hipFile.load.assert_not_called()
+
+    def test_new_scene_fails_closed_when_gui_dirty_probe_raises(self) -> None:
+        mod = _load_script("houdini-scene-edit", "new_scene.py")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.hipFile.hasUnsavedChanges.side_effect = RuntimeError("probe failed")
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.new_scene(force=False)
+
+        assert result["success"] is False
+        assert result["message"] == "Scene dirty state unavailable"
+        mock_hou.hipFile.clear.assert_not_called()
+
+    def test_open_scene_still_blocks_real_gui_unsaved_changes(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-scene-edit", "open_scene.py")
+        hip = tmp_path / "shot.hip"
+        hip.write_bytes(b"hip")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.hipFile.hasUnsavedChanges.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.open_scene(str(hip), force=False)
+
+        assert result["success"] is False
+        mock_hou.hipFile.load.assert_not_called()
+
+    def test_open_scene_force_loads_in_hython_with_suppressed_prompt(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-scene-edit", "open_scene.py")
+        hip = tmp_path / "shot.hip"
+        hip.write_bytes(b"hip")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = False
+        mock_hou.hipFile.path.return_value = str(hip)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.open_scene(str(hip), force=True)
+
+        assert result["success"] is True
+        mock_hou.hipFile.hasUnsavedChanges.assert_not_called()
+        mock_hou.hipFile.load.assert_called_once_with(
+            str(hip),
+            suppress_save_prompt=True,
+            ignore_load_warnings=False,
+        )
 
     def test_save_scene_requires_path_when_never_saved(self) -> None:
         mod = _load_script("houdini-scene-edit", "save_scene.py")


### PR DESCRIPTION
## Summary
- centralize HIP dirty-state probing across GUI Houdini and hython
- report headless dirty state as unknown instead of trusting hython's sentinel value
- fail closed for destructive scene changes and GUI background renders when the state cannot be determined
- preserve the owned headless HIP snapshot path for background jobs

## Rationale
SideFX documents that `hou.hipFile.hasUnsavedChanges()` only works in graphical sessions and always returns `True` in hython: https://www.sidefx.com/docs/houdini/hom/hou/hipFile.html

## Safety
- GUI sessions retain real clean/dirty behavior
- `open_scene` and `new_scene` require explicit `force=true` when state is unknown
- context snapshots omit optional `scene_saved`; `validate_scene` returns `dirty: null`
- load/clear continue using suppressed save prompts only after explicit caller authorization

## Validation
- `ruff check src/ tests/ tools/ packaging/`
- `ruff format --check src/ tests/ tools/ packaging/`
- `python tools/check_py37_syntax.py src tests tools packaging`
- `python tools/lint_skills.py --require-cli --warnings-as-errors`
- `python -m pytest` — 584 passed, 1 skipped, 3 deselected