### PR TITLE
fix: preserve animated channels in set_parms

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     dcc: houdini
     layer: domain
     stage: authoring
-    version: "1.0.0"
+    version: "1.0.1"
     tags: [houdini, parameters, parms, spare, expression, channel, authoring]
     search-hint: "list parameters, get parm, set parm, parm template, spare parameter, channel expression, reference"
     tools: tools.yaml
@@ -30,11 +30,13 @@ and expression work.
 - **`parm-query`** (read-only): `list_parms`, `get_parms`, `get_parm_templates`,
   `get_expression`.
 - **`parm-edit`** (mutating): `set_parms` (type-aware coercion + per-parm
-  validation), `add_spare_parm`, `remove_spare_parm`.
+  validation while preserving animated channels), `add_spare_parm`,
+  `remove_spare_parm`.
 - **`parm-expression`** (mutating): `set_expression`, `clear_expression`.
 
 ## Suggested flow
 
 1. `list_parms` / `get_parm_templates` to discover names and types
-2. `set_parms` for type-coerced edits (errors reported per parameter)
+2. `set_parms` for static, type-coerced edits (errors reported per parameter;
+   keyframed or expression-driven parms are preserved)
 3. `set_expression` / `clear_expression` to drive or freeze a value

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/_parm_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/_parm_common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 
 def get_node(hou: Any, node_path: str) -> Any:
@@ -65,3 +65,35 @@ def coerce_scalar(value: Any, current: Any) -> Any:
     except (TypeError, ValueError):
         return value
     return value
+
+
+def channel_write_conflict(parm: Any) -> Optional[str]:
+    """Return why a plain value write would be unsafe, or ``None``.
+
+    ``hou.Parm.set`` writes at the current frame. On an animated channel that
+    can create a new keyframe instead of replacing the channel, so callers that
+    promise plain value assignment must inspect the channel before mutating it.
+    Inspection failures are conflicts: preserving an unknown channel is safer
+    than reporting a write that may not have changed its evaluated value.
+    """
+    name = _safe(parm, "name") or "<unknown>"
+    try:
+        keyframe_count = len(parm.keyframes())
+    except Exception as exc:  # noqa: BLE001
+        return "Cannot safely inspect keyframes for parameter {!r}: {}".format(name, exc)
+    if keyframe_count:
+        return (
+            "Parameter {!r} has {} keyframe(s); set_parms preserves keyframed and expression-driven channels. "
+            "Use houdini-animation tools to edit or clear the channel first."
+        ).format(name, keyframe_count)
+
+    try:
+        is_time_dependent = bool(parm.isTimeDependent())
+    except Exception as exc:  # noqa: BLE001
+        return "Cannot safely inspect time dependence for parameter {!r}: {}".format(name, exc)
+    if is_time_dependent:
+        return (
+            "Parameter {!r} is time-dependent; set_parms preserves expression-driven channels. "
+            "Use houdini-animation tools to edit or clear the channel first."
+        ).format(name)
+    return None

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/set_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/set_parms.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from _parm_common import coerce_scalar, get_node  # noqa: E402
+from _parm_common import channel_write_conflict, coerce_scalar, get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
@@ -12,8 +12,9 @@ def set_parms(node_path: str, parameters: Dict[str, Any]) -> dict:
     """Set the given parameters, reporting per-parameter validation errors.
 
     Tuple values (lists) target parm tuples; scalars target single parms with
-    best-effort coercion to the parm's existing value type. Errors are collected
-    per parameter rather than aborting the whole call.
+    best-effort coercion to the parm's existing value type. Existing animation
+    and expressions are preserved and reported as per-parameter conflicts.
+    Errors are collected per parameter rather than aborting the whole call.
     """
     try:
         import hou  # noqa: PLC0415
@@ -31,12 +32,24 @@ def set_parms(node_path: str, parameters: Dict[str, Any]) -> dict:
                     if parm_tuple is None:
                         errors[name] = "No parameter tuple named {!r}".format(name)
                         continue
+                    conflicts = []
+                    for parm in parm_tuple:
+                        conflict = channel_write_conflict(parm)
+                        if conflict is not None:
+                            conflicts.append(conflict)
+                    if conflicts:
+                        errors[name] = "Cannot set parameter tuple {!r}: {}".format(name, "; ".join(conflicts))
+                        continue
                     parm_tuple.set(tuple(value))
                     applied[name] = list(value)
                 else:
                     parm = node.parm(name)
                     if parm is None:
                         errors[name] = "No parameter named {!r}".format(name)
+                        continue
+                    conflict = channel_write_conflict(parm)
+                    if conflict is not None:
+                        errors[name] = conflict
                         continue
                     try:
                         current = parm.eval()

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/tools.yaml
@@ -53,7 +53,10 @@ tools:
   - name: set_parms
     description: >-
       Set one or many parameters with type-aware coercion. Tuple values target
-      parm tuples; per-parameter validation errors are reported, not fatal.
+      parm tuples. Existing keyframes and expression-driven channels are
+      preserved and reported as per-parameter conflicts; use houdini-animation
+      tools for intentional channel edits. Other per-parameter validation errors
+      are reported without aborting safe values in the same request.
     source_file: scripts/set_parms.py
     execution: sync
     affinity: main
@@ -74,7 +77,9 @@ tools:
           description: Node to modify.
         parameters:
           type: object
-          description: Mapping of parm name to scalar or list (tuple) value.
+          description: >-
+            Mapping of static parm name to scalar or list (tuple) value.
+            Animated or expression-driven channels are rejected.
   - name: get_parm_templates
     description: >-
       Inspect parameter templates for one parm or all top-level templates.

--- a/tests/test_parameter_graph_skills.py
+++ b/tests/test_parameter_graph_skills.py
@@ -78,6 +78,8 @@ class TestParameterEdit:
         mod = _load_script("houdini-parameters", "set_parms.py")
         count_parm = MagicMock()
         count_parm.eval.return_value = 3  # int -> coerce "5" to 5
+        count_parm.keyframes.return_value = []
+        count_parm.isTimeDependent.return_value = False
         node = _node()
         node.parmTuple.side_effect = lambda n: None
         node.parm.side_effect = lambda n: count_parm if n == "count" else None
@@ -92,9 +94,84 @@ class TestParameterEdit:
         assert result["context"]["applied"]["count"] == 5
         assert "ghost" in result["context"]["errors"]
 
+    def test_set_parms_rejects_animated_parm_without_adding_ghost_keyframe(self) -> None:
+        mod = _load_script("houdini-parameters", "set_parms.py")
+        keyframes = [MagicMock()]
+        animated_parm = MagicMock()
+        animated_parm.name.return_value = "tx"
+        animated_parm.eval.return_value = 1.25
+        animated_parm.keyframes.side_effect = lambda: list(keyframes)
+        animated_parm.isTimeDependent.return_value = True
+        animated_parm.set.side_effect = lambda _value: keyframes.append(MagicMock())
+        node = _node()
+        node.parm.side_effect = lambda name: animated_parm if name == "tx" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_parms(node.path(), {"tx": 2.5})
+
+        assert result["success"] is False
+        assert "tx" not in result["context"].get("applied", {})
+        assert "tx" in result["context"]["errors"]
+        assert "keyframe" in result["context"]["errors"]["tx"].lower()
+        animated_parm.set.assert_not_called()
+        assert len(keyframes) == 1
+
+    def test_set_parms_rejects_time_dependent_parm_without_keyframes(self) -> None:
+        mod = _load_script("houdini-parameters", "set_parms.py")
+        animated_parm = MagicMock()
+        animated_parm.name.return_value = "tx"
+        animated_parm.keyframes.return_value = []
+        animated_parm.isTimeDependent.return_value = True
+        node = _node()
+        node.parm.side_effect = lambda name: animated_parm if name == "tx" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_parms("/obj/geo1", {"tx": 2.5})
+
+        assert result["success"] is False
+        assert "time-dependent" in result["context"]["errors"]["tx"]
+        animated_parm.set.assert_not_called()
+
+    def test_set_parms_applies_static_values_but_reports_animated_conflicts(self) -> None:
+        mod = _load_script("houdini-parameters", "set_parms.py")
+        static_parm = MagicMock()
+        static_parm.eval.return_value = 1.0
+        static_parm.keyframes.return_value = []
+        static_parm.isTimeDependent.return_value = False
+        animated_parm = MagicMock()
+        animated_parm.name.return_value = "tx"
+        animated_parm.eval.return_value = 1.25
+        animated_parm.keyframes.return_value = [MagicMock()]
+        animated_parm.isTimeDependent.return_value = True
+        node = _node()
+        node.parm.side_effect = lambda name: {
+            "ty": static_parm,
+            "tx": animated_parm,
+        }.get(name)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_parms("/obj/geo1", {"ty": 2.5, "tx": 3.5})
+
+        assert result["success"] is True
+        assert result["context"]["applied"] == {"ty": 2.5}
+        assert "tx" in result["context"]["errors"]
+        static_parm.set.assert_called_once_with(2.5)
+        animated_parm.set.assert_not_called()
+
     def test_set_parms_tuple(self) -> None:
         mod = _load_script("houdini-parameters", "set_parms.py")
         t_tuple = MagicMock()
+        tuple_parms = [MagicMock(), MagicMock(), MagicMock()]
+        for parm in tuple_parms:
+            parm.keyframes.return_value = []
+            parm.isTimeDependent.return_value = False
+        t_tuple.__iter__.return_value = iter(tuple_parms)
         node = _node()
         node.parmTuple.side_effect = lambda n: t_tuple if n == "t" else None
         node.parm.side_effect = lambda n: None
@@ -106,6 +183,31 @@ class TestParameterEdit:
 
         assert result["success"] is True
         t_tuple.set.assert_called_once_with((1, 2, 3))
+
+    def test_set_parms_rejects_tuple_when_a_component_is_animated(self) -> None:
+        mod = _load_script("houdini-parameters", "set_parms.py")
+        static_component = MagicMock()
+        static_component.name.return_value = "ty"
+        static_component.keyframes.return_value = []
+        static_component.isTimeDependent.return_value = False
+        animated_component = MagicMock()
+        animated_component.name.return_value = "tx"
+        animated_component.keyframes.return_value = [MagicMock()]
+        animated_component.isTimeDependent.return_value = True
+        t_tuple = MagicMock()
+        t_tuple.__iter__.return_value = iter([animated_component, static_component])
+        node = _node()
+        node.parmTuple.side_effect = lambda name: t_tuple if name == "t" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_parms("/obj/geo1", {"t": [1.5, 2.5]})
+
+        assert result["success"] is False
+        assert "t" in result["context"]["errors"]
+        assert "tx" in result["context"]["errors"]["t"]
+        t_tuple.set.assert_not_called()
 
     def test_add_spare_parm_unsupported(self) -> None:
         mod = _load_script("houdini-parameters", "add_spare_parm.py")


### PR DESCRIPTION
## Summary

- reject plain-value writes to scalar parameters that already have keyframes or are time-dependent
- inspect every component before setting a parameter tuple, preserving the whole tuple when any component is driven
- keep existing per-parameter partial-success behavior for safe static values
- document the conflict contract and bump the parameter skill patch version

## Why

`hou.Parm.set` writes at the current frame. Calling it on an animated channel can create an extra keyframe while the evaluated channel still differs from the requested value. `set_parms` previously reported the requested value under `applied` without protecting the existing channel.

The default contract now fails closed and returns a per-parameter conflict. Intentional animation edits remain available through the dedicated animation tools.

## Validation

- `pytest tests/test_parameter_graph_skills.py::TestParameterEdit -v --tb=short` — 9 passed
- full unit suite — 588 passed, 1 skipped, 3 deselected
- `ruff check src/ tests/ tools/ packaging/`
- `ruff format --check src/ tests/ tools/ packaging/`
- skill validator — 31 checked, 0 errors, 0 warnings
- Python 3.7 syntax check