### PR TITLE
fix(scene): report Object visibility and renderability

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-scene/scripts/get_node_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/scripts/get_node_info.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
@@ -27,6 +27,18 @@ def _path_or_none(node: Any) -> Optional[str]:
 def _optional_bool(node: Any, method_name: str) -> Optional[bool]:
     value = _call_or_none(node, method_name)
     return bool(value) if value is not None else None
+
+
+def _object_visibility_flags(node: Any, category: Optional[str]) -> Dict[str, Optional[bool]]:
+    if category != "Object":
+        return {"object_displayed": None, "object_renderable": None}
+
+    parm_method = getattr(node, "parm", None)
+    renderable_parm = parm_method("vm_renderable") if callable(parm_method) else None
+    return {
+        "object_displayed": _optional_bool(node, "isObjectDisplayed"),
+        "object_renderable": _optional_bool(renderable_parm, "evalAsInt"),
+    }
 
 
 def _type_context(node: Any) -> dict:
@@ -57,6 +69,7 @@ def get_node_info(node_path: str, include_connections: bool = True) -> dict:
             return skill_error("Houdini node not found", node_path)
 
         children = list(node.children())
+        type_context = _type_context(node)
         context = {
             "path": node.path(),
             "name": node.name(),
@@ -71,9 +84,10 @@ def get_node_info(node_path: str, include_connections: bool = True) -> dict:
                 "current": _optional_bool(node, "isCurrent"),
                 "selected": _optional_bool(node, "isSelected"),
                 "hidden": _optional_bool(node, "isHidden"),
+                **_object_visibility_flags(node, type_context["category"]),
             },
         }
-        context.update(_type_context(node))
+        context.update(type_context)
         if include_connections:
             context["inputs"] = _connection_paths(_call_or_none(node, "inputs"))
             context["outputs"] = _connection_paths(_call_or_none(node, "outputs"))

--- a/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
@@ -106,6 +106,8 @@ tools:
     description: >-
       Return a read-only summary for a Houdini node including path, type,
       category, parent, child count, flags, and optional input/output links.
+      Object nodes additionally report effective object display and the
+      vm_renderable property; null means unsupported while false means off.
     source_file: scripts/get_node_info.py
     execution: sync
     affinity: main

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -27,6 +27,21 @@ def _load_script(skill_name: str, script_name: str) -> ModuleType:
     return module
 
 
+def _mock_inspection_node(category_name: str, path: str, type_name: str, *methods: str) -> MagicMock:
+    category = MagicMock()
+    category.name.return_value = category_name
+    type_obj = MagicMock()
+    type_obj.name.return_value = type_name
+    type_obj.category.return_value = category
+    node = MagicMock(spec=["children", "name", "parent", "path", "type", *methods])
+    node.path.return_value = path
+    node.name.return_value = path.rsplit("/", 1)[-1]
+    node.type.return_value = type_obj
+    node.parent.return_value = None
+    node.children.return_value = []
+    return node
+
+
 @pytest.mark.parametrize("skill_dir", _SKILL_DIRS)
 def test_validate_skill_clean(skill_dir: str) -> None:
     from dcc_mcp_core import validate_skill
@@ -223,6 +238,58 @@ class TestSceneNodeInspectionSkills:
         assert info["child_count"] == 1
         assert info["inputs"] == ["/obj/geo1/input", None]
         assert info["outputs"] == ["/obj/geo1/output"]
+
+    def test_get_node_info_reports_object_visibility_without_fabricating_sop_flags(self) -> None:
+        mod = _load_script("houdini-scene", "get_node_info.py")
+        node = _mock_inspection_node(
+            "Object",
+            "/obj/geo1",
+            "geo",
+            "isCurrent",
+            "isDisplayFlagSet",
+            "isHidden",
+            "isObjectDisplayed",
+            "isSelected",
+            "parm",
+        )
+        renderable = MagicMock(spec=["evalAsInt"])
+        renderable.evalAsInt.return_value = 0
+        node.isDisplayFlagSet.return_value = True
+        node.isObjectDisplayed.return_value = False
+        node.isCurrent.return_value = False
+        node.isSelected.return_value = False
+        node.isHidden.return_value = False
+        node.parm.return_value = renderable
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_node_info("/obj/geo1", include_connections=False)
+
+        assert result["success"] is True
+        flags = result["context"]["node"]["flags"]
+        assert flags["display"] is True
+        assert flags["object_displayed"] is False
+        assert flags["object_renderable"] is False
+        assert flags["bypassed"] is None
+        assert flags["render"] is None
+        assert flags["template"] is None
+        node.parm.assert_called_once_with("vm_renderable")
+
+    def test_get_node_info_marks_object_visibility_unsupported_for_other_categories(self) -> None:
+        mod = _load_script("houdini-scene", "get_node_info.py")
+        node = _mock_inspection_node("Unknown", "/custom/node1", "custom", "isObjectDisplayed", "parm")
+        node.isObjectDisplayed.return_value = False
+        node.parm.return_value.evalAsInt.return_value = 0
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_node_info("/custom/node1", include_connections=False)
+
+        flags = result["context"]["node"]["flags"]
+        assert flags["object_displayed"] is None
+        assert flags["object_renderable"] is None
 
 
 class TestNodeSkills:


### PR DESCRIPTION
## Summary

- report effective Object visibility through `hou.ObjNode.isObjectDisplayed()`
- report the Object `vm_renderable` property without reinterpreting SOP-only flags
- preserve existing flag fields and use `null` for unsupported states versus `false` for supported flags that are off
- document and test the additive response contract, including unknown node categories

## References

- [SideFX `hou.ObjNode` flags](https://www.sidefx.com/docs/houdini/hom/hou/ObjNode.html#flags)
- [SideFX Geometry object render properties](https://www.sidefx.com/docs/houdini/nodes/obj/geo.html#render)

## Validation

- `python -m pytest -q` — 586 passed, 1 skipped, 3 deselected
- `ruff check src tests tools packaging`
- `ruff format --check src tests tools packaging`
- `python tools/check_py37_syntax.py src tests tools packaging`
- `python tools/lint_skills.py --warnings-as-errors` — 31 skills, 0 errors, 0 warnings