### PR TITLE
feat(render): expose raw output path pattern

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from _render_common import eval_first_parm, get_node, node_summary  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+_OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
+
 
 def get_render_settings(rop_path: str) -> dict:
     """Return structured render settings read from the ROP at *rop_path*."""
@@ -17,15 +19,22 @@ def get_render_settings(rop_path: str) -> dict:
         rop = get_node(hou, rop_path)
         res_x = eval_first_parm(rop, ("res_overridex", "resx", "vm_resx"))
         res_y = eval_first_parm(rop, ("res_overridey", "resy", "vm_resy"))
+        output_frame = float(hou.frame())
+        output_path = eval_first_parm(rop, _OUTPUT_PARMS)
         settings = {
             "rop": node_summary(rop),
             "renderer": rop.type().name(),
             "camera": eval_first_parm(rop, ("camera", "render_camera")),
             "resolution": [res_x, res_y] if (res_x is not None or res_y is not None) else None,
             "frame_range": eval_first_parm(rop, ("f",)),
-            "output_path": eval_first_parm(
-                rop, ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
-            ),
+            "output_path": output_path,
+            "output_path_pattern": eval_first_parm(rop, _OUTPUT_PARMS, preserve_string=True),
+            "output_path_resolution": {
+                "frame": output_frame,
+                "paths": output_path
+                if isinstance(output_path, list)
+                else ([] if output_path is None else [output_path]),
+            },
             "image_format": eval_first_parm(rop, ("vm_image_format", "image_format")),
         }
         return skill_success("Read render settings", **settings)

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -70,7 +70,9 @@ tools:
   - name: get_render_settings
     description: >-
       Read renderer, camera, resolution, frame range, output path, and image
-      format from a ROP node. Read-only.
+      format from a ROP node. Preserves the existing resolved output_path and
+      also reports its raw tokenized pattern plus the frame-to-path resolution
+      used for that value. Read-only.
     source_file: scripts/get_render_settings.py
     execution: sync
     affinity: main

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -573,6 +573,40 @@ class TestViewportCapture:
 
 
 class TestRenderSettings:
+    def test_get_render_settings_reports_raw_pattern_and_resolution_frame(self) -> None:
+        mod = _load_script("houdini-render", "get_render_settings.py")
+        pattern = "$HIP/renders/beauty.$F4.exr"
+        current_frame = {"value": 1.0}
+        output_parm = _scalar_parm(pattern)
+        output_tuple = MagicMock()
+        output_tuple.eval.side_effect = lambda: (
+            "C:/show/shot/renders/beauty.{:04d}.exr".format(int(current_frame["value"])),
+        )
+        rop = _node("/out/mantra1", "mantra1", "ifd")
+        rop.parm.side_effect = lambda name: output_parm if name == "vm_picture" else None
+        rop.parmTuple.side_effect = lambda name: output_tuple if name == "vm_picture" else None
+        mock_hou = MagicMock()
+        mock_hou.frame.side_effect = lambda: current_frame["value"]
+        mock_hou.node.return_value = rop
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            frame_1 = mod.get_render_settings("/out/mantra1")["context"]
+            current_frame["value"] = 576.0
+            frame_576 = mod.get_render_settings("/out/mantra1")["context"]
+
+        assert frame_1["output_path"] == ["C:/show/shot/renders/beauty.0001.exr"]
+        assert frame_1["output_path_pattern"] == pattern
+        assert frame_1["output_path_resolution"] == {
+            "frame": 1.0,
+            "paths": ["C:/show/shot/renders/beauty.0001.exr"],
+        }
+        assert frame_576["output_path"] == ["C:/show/shot/renders/beauty.0576.exr"]
+        assert frame_576["output_path_pattern"] == pattern
+        assert frame_576["output_path_resolution"] == {
+            "frame": 576.0,
+            "paths": ["C:/show/shot/renders/beauty.0576.exr"],
+        }
+
     def test_get_render_settings_reads_fields(self) -> None:
         mod = _load_script("houdini-render", "get_render_settings.py")
         rop = _node("/out/mantra1", "mantra1", "ifd")
@@ -584,6 +618,7 @@ class TestRenderSettings:
             "res_overridey": _scalar_parm(720),
         }.get(n)
         mock_hou = MagicMock()
+        mock_hou.frame.return_value = 1.0
         mock_hou.node.return_value = rop
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
@@ -592,6 +627,8 @@ class TestRenderSettings:
         assert result["success"] is True
         assert result["context"]["camera"] == "/obj/cam1"
         assert result["context"]["output_path"] == "/tmp/beauty.exr"
+        assert result["context"]["output_path_pattern"] == "/tmp/beauty.exr"
+        assert result["context"]["output_path_resolution"] == {"frame": 1.0, "paths": ["/tmp/beauty.exr"]}
         assert result["context"]["resolution"] == [1280, 720]
 
     def test_set_render_settings_reports_unsupported(self) -> None:


### PR DESCRIPTION
## Summary
- preserve the existing resolved `output_path` response
- expose the ROP's unexpanded `output_path_pattern`, including `$HIP` and `$F` tokens
- report `output_path_resolution` with the evaluation frame and normalized resolved paths

## Why
Frame-token output parameters evaluate at Houdini's current frame. Callers previously received only that resolved value, so they could not tell which frame produced it or recover the reusable output pattern.

## Validation
- 591 passed, 1 skipped (default unit suite)
- Ruff lint and format checks
- skill manifest validation with warnings as errors
- Python 3.7 syntax validation
- wheel and sdist build plus Twine checks