### PR TITLE
feat(render): add staged no-clobber publication for isolated ROP jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ When adding or changing bundled skills, load the project skill:
 ### pipeline stage (load on demand)
 | Skill | Key tools |
 |-------|-----------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `finalize_render_outputs`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
@@ -128,7 +128,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 198 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 31 skill packages, 199 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 ### pipeline (load on demand)
 | Skill | Tools |
 |-------|-------|
-| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
+| `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `finalize_render_outputs`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
 | `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |

--- a/llms.txt
+++ b/llms.txt
@@ -68,7 +68,7 @@ server.list_skills()
 - `houdini_import_to_scene__import_to_scene`
 
 ### pipeline (load on demand)
-- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
+- `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `finalize_render_outputs`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
 - `houdini_karma__configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output`
 - `houdini_husk__render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
 - `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`

--- a/src/dcc_mcp_houdini/_isolated_jobs.py
+++ b/src/dcc_mcp_houdini/_isolated_jobs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import signal
 import subprocess
@@ -14,6 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 from dcc_mcp_houdini._render_artifacts import aggregate_artifacts
+from dcc_mcp_houdini._status_io import read_status as _read_status_document
+from dcc_mcp_houdini._status_io import write_status
 
 if os.name == "nt":
     from dcc_mcp_houdini._windows_process import terminate_process_tree as _terminate_windows_process_tree
@@ -27,46 +28,6 @@ _TERMINAL_STATES = frozenset({"completed", "failed", "cancelled", "interrupted"}
 _CANCEL_GRACE_SECS = 2
 _SIGTERM = getattr(signal, "SIGTERM", 15)
 _SIGKILL = getattr(signal, "SIGKILL", 9)
-_STATUS_IO_TIMEOUT_SECONDS = 1.0
-_STATUS_IO_POLL_SECONDS = 0.01
-
-
-def _retry_windows_status_io(operation: Any, description: str) -> Any:
-    """Retry transient Windows sharing violations within one bounded deadline."""
-    if os.name != "nt":
-        return operation()
-    deadline = time.monotonic() + _STATUS_IO_TIMEOUT_SECONDS
-    while True:
-        try:
-            return operation()
-        except PermissionError as exc:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError("timed out while {}".format(description)) from exc
-            time.sleep(min(_STATUS_IO_POLL_SECONDS, remaining))
-
-
-def _remove_pending_status(path: Path) -> None:
-    try:
-        _retry_windows_status_io(path.unlink, "cleaning pending status file {}".format(path))
-    except FileNotFoundError:
-        pass
-
-
-def write_status(path: Path, payload: Mapping[str, Any]) -> None:
-    pending = path.with_name("{}.{}.tmp".format(path.name, uuid.uuid4().hex))
-    try:
-        pending.write_text(json.dumps(dict(payload), indent=2), encoding="utf-8")
-        _retry_windows_status_io(
-            lambda: os.replace(str(pending), str(path)),
-            "replacing status file {}".format(path),
-        )
-    except Exception:
-        try:
-            _remove_pending_status(pending)
-        except Exception:  # noqa: BLE001
-            pass
-        raise
 
 
 def _status_path(job_id: str) -> Path:
@@ -78,11 +39,7 @@ def _status_path(job_id: str) -> Path:
 def _read_status(path: Path) -> Dict[str, Any]:
     if not path.is_file():
         raise FileNotFoundError("Background job was not found")
-    payload = _retry_windows_status_io(
-        lambda: path.read_text(encoding="utf-8"),
-        "reading status file {}".format(path),
-    )
-    return json.loads(payload)
+    return _read_status_document(path)
 
 
 def create_job(initial: Mapping[str, Any]) -> Tuple[Dict[str, Any], Path]:

--- a/src/dcc_mcp_houdini/_isolated_jobs.py
+++ b/src/dcc_mcp_houdini/_isolated_jobs.py
@@ -27,12 +27,46 @@ _TERMINAL_STATES = frozenset({"completed", "failed", "cancelled", "interrupted"}
 _CANCEL_GRACE_SECS = 2
 _SIGTERM = getattr(signal, "SIGTERM", 15)
 _SIGKILL = getattr(signal, "SIGKILL", 9)
+_STATUS_IO_TIMEOUT_SECONDS = 1.0
+_STATUS_IO_POLL_SECONDS = 0.01
+
+
+def _retry_windows_status_io(operation: Any, description: str) -> Any:
+    """Retry transient Windows sharing violations within one bounded deadline."""
+    if os.name != "nt":
+        return operation()
+    deadline = time.monotonic() + _STATUS_IO_TIMEOUT_SECONDS
+    while True:
+        try:
+            return operation()
+        except PermissionError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out while {}".format(description)) from exc
+            time.sleep(min(_STATUS_IO_POLL_SECONDS, remaining))
+
+
+def _remove_pending_status(path: Path) -> None:
+    try:
+        _retry_windows_status_io(path.unlink, "cleaning pending status file {}".format(path))
+    except FileNotFoundError:
+        pass
 
 
 def write_status(path: Path, payload: Mapping[str, Any]) -> None:
     pending = path.with_name("{}.{}.tmp".format(path.name, uuid.uuid4().hex))
-    pending.write_text(json.dumps(dict(payload), indent=2), encoding="utf-8")
-    os.replace(str(pending), str(path))
+    try:
+        pending.write_text(json.dumps(dict(payload), indent=2), encoding="utf-8")
+        _retry_windows_status_io(
+            lambda: os.replace(str(pending), str(path)),
+            "replacing status file {}".format(path),
+        )
+    except Exception:
+        try:
+            _remove_pending_status(pending)
+        except Exception:  # noqa: BLE001
+            pass
+        raise
 
 
 def _status_path(job_id: str) -> Path:
@@ -44,7 +78,11 @@ def _status_path(job_id: str) -> Path:
 def _read_status(path: Path) -> Dict[str, Any]:
     if not path.is_file():
         raise FileNotFoundError("Background job was not found")
-    return json.loads(path.read_text(encoding="utf-8"))
+    payload = _retry_windows_status_io(
+        lambda: path.read_text(encoding="utf-8"),
+        "reading status file {}".format(path),
+    )
+    return json.loads(payload)
 
 
 def create_job(initial: Mapping[str, Any]) -> Tuple[Dict[str, Any], Path]:

--- a/src/dcc_mcp_houdini/_isolated_jobs.py
+++ b/src/dcc_mcp_houdini/_isolated_jobs.py
@@ -13,6 +13,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
+from dcc_mcp_houdini._render_artifacts import aggregate_artifacts
+
 if os.name == "nt":
     from dcc_mcp_houdini._windows_process import terminate_process_tree as _terminate_windows_process_tree
 else:
@@ -92,6 +94,12 @@ def launch_job(
             )
     except Exception as exc:
         status.update({"state": "failed", "finished_at": time.time(), "error": str(exc)})
+        transaction = status.get("artifact_transaction")
+        if isinstance(transaction, dict):
+            transaction = dict(transaction)
+            transaction["state"] = "failed"
+            transaction["aggregate"] = aggregate_artifacts(transaction.get("artifacts", []))
+            status["artifact_transaction"] = transaction
         write_status(status_path, status)
         raise
     result = dict(status)
@@ -114,6 +122,23 @@ def _finish_status(status: Dict[str, Any], state: str, return_code: int) -> Dict
         status["elapsed_secs"] = round(finished_at - float(status["started_at"]), 3)
     if state == "interrupted":
         status["error"] = "Background worker exited before reporting a terminal state"
+    transaction = status.get("artifact_transaction")
+    if isinstance(transaction, dict) and transaction.get("state") not in {"committed", "partially_committed"}:
+        transaction = dict(transaction)
+        artifacts = []
+        for source in transaction.get("artifacts", []):
+            artifact = dict(source)
+            if artifact.get("committed") is not True:
+                artifact["state"] = state
+            artifacts.append(artifact)
+        transaction.update(
+            {
+                "state": state,
+                "artifacts": artifacts,
+                "aggregate": aggregate_artifacts(artifacts),
+            }
+        )
+        status["artifact_transaction"] = transaction
     return status
 
 

--- a/src/dcc_mcp_houdini/_render_artifacts.py
+++ b/src/dcc_mcp_houdini/_render_artifacts.py
@@ -1,0 +1,311 @@
+"""Staged, identity-bound publication helpers for isolated render outputs."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import stat
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+TRANSACTION_MODE = "staged_no_clobber"
+_REPARSE_POINT = 0x400
+_SHA256_HEX_LENGTH = 64
+
+
+def normalize_transaction_request(value: Any) -> Dict[str, Any]:
+    """Validate the opt-in request while keeping the legacy path untouched."""
+    if not isinstance(value, Mapping):
+        raise ValueError("artifact_transaction must be an object")
+    unknown = sorted(set(value) - {"mode"})
+    if unknown:
+        raise ValueError("artifact_transaction has unsupported fields: {}".format(", ".join(unknown)))
+    if value.get("mode") != TRANSACTION_MODE:
+        raise ValueError("artifact_transaction.mode must be staged_no_clobber")
+    return {
+        "mode": TRANSACTION_MODE,
+        "state": "queued",
+        "artifacts": [],
+        "aggregate": aggregate_artifacts([]),
+    }
+
+
+def integer_frames(frame_range: Optional[Sequence[float]]) -> list:
+    """Expand an explicit integral frame range used by one-file-per-frame jobs."""
+    if not frame_range or len(frame_range) not in (2, 3):
+        raise ValueError("artifact_transaction requires frame_range with two or three values")
+    values = list(frame_range)
+    if any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in values):
+        raise ValueError("artifact_transaction frame_range values must be numbers")
+    if any(not math.isfinite(float(value)) or float(value) != int(value) for value in values):
+        raise ValueError("artifact_transaction supports integral frames only")
+    start, end = int(values[0]), int(values[1])
+    step = int(values[2]) if len(values) == 3 else 1
+    if step == 0 or (end - start) * step < 0:
+        raise ValueError("frame_range step must move from start toward end")
+    stop = end + (1 if step > 0 else -1)
+    frames = list(range(start, stop, step))
+    if not frames:
+        raise ValueError("artifact_transaction frame_range produced no frames")
+    return frames
+
+
+def staging_pattern(final_pattern: str, job_id: str) -> str:
+    """Place a unique staging EXR beside the final output for atomic publication."""
+    if not isinstance(final_pattern, str) or not final_pattern.lower().endswith(".exr"):
+        raise ValueError("artifact_transaction requires one EXR output pattern")
+    if not job_id or any(char not in "0123456789abcdef" for char in job_id.lower()):
+        raise ValueError("job_id must be a hexadecimal identifier")
+    return "{}.dcc-mcp-{}.partial{}".format(final_pattern[:-4], job_id, final_pattern[-4:])
+
+
+def _is_reparse(file_stat: os.stat_result) -> bool:
+    return bool(getattr(file_stat, "st_file_attributes", 0) & _REPARSE_POINT)
+
+
+def _absolute(path: Any) -> Path:
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def assert_no_links_or_reparse(path: Any) -> None:
+    """Reject symlinks and Windows reparse points in every existing component."""
+    current = _absolute(path)
+    while True:
+        try:
+            file_stat = os.lstat(str(current))
+        except FileNotFoundError:
+            pass
+        else:
+            if stat.S_ISLNK(file_stat.st_mode) or _is_reparse(file_stat):
+                raise ValueError("artifact paths cannot contain symlinks or reparse points")
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def assert_same_parent_and_volume(staged_path: Any, final_path: Any) -> None:
+    """Require staging and final names to share one real directory and volume."""
+    staged = _absolute(staged_path)
+    final = _absolute(final_path)
+    if os.path.normcase(str(staged.parent)) != os.path.normcase(str(final.parent)):
+        raise ValueError("staging and final outputs must share one directory")
+    assert_no_links_or_reparse(staged)
+    assert_no_links_or_reparse(final)
+    parent_stat = os.stat(str(final.parent), follow_symlinks=False)
+    if not stat.S_ISDIR(parent_stat.st_mode):
+        raise ValueError("artifact output directory does not exist")
+    try:
+        staged_stat = os.lstat(str(staged))
+    except FileNotFoundError:
+        return
+    if staged_stat.st_dev != parent_stat.st_dev:
+        raise ValueError("staging and final outputs must be on the same volume")
+
+
+def _fingerprint(file_stat: os.stat_result) -> tuple:
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_mode,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+    )
+
+
+def _assert_regular(file_stat: os.stat_result) -> None:
+    if not stat.S_ISREG(file_stat.st_mode) or _is_reparse(file_stat):
+        raise ValueError("artifact output must be a regular non-reparse file")
+
+
+def stable_file_identity(path: Any) -> Dict[str, Any]:
+    """Hash one regular file and fail if its path or handle identity drifts."""
+    absolute = _absolute(path)
+    assert_no_links_or_reparse(absolute)
+    path_before = os.lstat(str(absolute))
+    _assert_regular(path_before)
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(str(absolute), flags)
+    try:
+        handle_before = os.fstat(descriptor)
+        _assert_regular(handle_before)
+        if _fingerprint(handle_before) != _fingerprint(path_before):
+            raise ValueError("artifact identity changed before hashing")
+        digest = hashlib.sha256()
+        while True:
+            payload = os.read(descriptor, 1024 * 1024)
+            if not payload:
+                break
+            digest.update(payload)
+        handle_after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    path_after = os.lstat(str(absolute))
+    _assert_regular(path_after)
+    if _fingerprint(handle_before) != _fingerprint(handle_after) or _fingerprint(handle_after) != _fingerprint(
+        path_after
+    ):
+        raise ValueError("artifact identity changed while hashing")
+    return {
+        "bytes": path_after.st_size,
+        "mtime_ns": path_after.st_mtime_ns,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def fsync_file(path: Any) -> None:
+    """Flush staged bytes before the no-clobber publication boundary."""
+    flags = os.O_RDWR | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(str(_absolute(path)), flags)
+    try:
+        _assert_regular(os.fstat(descriptor))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def fsync_parent(path: Any, platform_name: Optional[str] = None) -> None:
+    """Flush the containing directory on POSIX; Windows rename is the boundary."""
+    if (platform_name or os.name) == "nt":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(str(_absolute(path).parent), flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def publish_no_clobber(
+    staged_path: Any,
+    final_path: Any,
+    platform_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Commit with native no-clobber semantics and never fall back to replace."""
+    staged = _absolute(staged_path)
+    final = _absolute(final_path)
+    assert_same_parent_and_volume(staged, final)
+    if os.path.lexists(str(final)):
+        raise FileExistsError("final output already exists: {}".format(final))
+    cleanup_error = None
+    if (platform_name or os.name) == "nt":
+        os.rename(str(staged), str(final))
+    else:
+        os.link(str(staged), str(final), follow_symlinks=False)
+        try:
+            os.unlink(str(staged))
+        except OSError as exc:
+            cleanup_error = str(exc)
+    return {"committed": True, "cleanup_error": cleanup_error}
+
+
+def _require_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > 256:
+        raise ValueError("{} must be a non-empty bounded string".format(field))
+    return value
+
+
+def _require_sha256(value: Any, field: str) -> str:
+    value = _require_text(value, field).lower()
+    if len(value) != _SHA256_HEX_LENGTH or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError("{} must be a SHA-256 hex digest".format(field))
+    return value
+
+
+def validate_receipt(
+    receipt: Any,
+    job_id: str,
+    artifact: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Bind external validation to one exact staged file and final destination."""
+    if not isinstance(receipt, Mapping):
+        raise ValueError("validator receipt must be an object")
+    if receipt.get("accepted") is not True:
+        raise ValueError("validator receipt must set accepted=true")
+    if receipt.get("job_id") != job_id:
+        raise ValueError("validator receipt job_id does not match")
+    frame = receipt.get("frame")
+    if isinstance(frame, bool) or not isinstance(frame, int) or frame != artifact.get("frame"):
+        raise ValueError("validator receipt frame does not match")
+    for field in ("staging_path", "final_path"):
+        if receipt.get(field) != artifact.get(field):
+            raise ValueError("validator receipt {} does not match".format(field))
+    byte_count = receipt.get("bytes")
+    mtime_ns = receipt.get("mtime_ns")
+    if isinstance(byte_count, bool) or not isinstance(byte_count, int) or byte_count <= 0:
+        raise ValueError("validator receipt bytes must be a positive integer")
+    if isinstance(mtime_ns, bool) or not isinstance(mtime_ns, int) or mtime_ns < 0:
+        raise ValueError("validator receipt mtime_ns must be a non-negative integer")
+    validator = receipt.get("validator")
+    if not isinstance(validator, Mapping):
+        raise ValueError("validator receipt validator must be an object")
+    return {
+        "accepted": True,
+        "job_id": job_id,
+        "frame": frame,
+        "staging_path": artifact["staging_path"],
+        "final_path": artifact["final_path"],
+        "bytes": byte_count,
+        "mtime_ns": mtime_ns,
+        "sha256": _require_sha256(receipt.get("sha256"), "validator receipt sha256"),
+        "validator": {
+            "id": _require_text(validator.get("id"), "validator id"),
+            "version": _require_text(validator.get("version"), "validator version"),
+            "implementation_sha256": _require_sha256(
+                validator.get("implementation_sha256"), "validator implementation_sha256"
+            ),
+        },
+    }
+
+
+def identity_matches_receipt(identity: Mapping[str, Any], receipt: Mapping[str, Any]) -> bool:
+    return all(identity.get(field) == receipt.get(field) for field in ("bytes", "mtime_ns", "sha256"))
+
+
+def aggregate_artifacts(artifacts: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    """Return one bounded publication aggregate for job polling."""
+    total = len(artifacts)
+    committed = sum(1 for artifact in artifacts if artifact.get("committed") is True)
+    verified = sum(
+        1 for artifact in artifacts if artifact.get("committed") is True and artifact.get("state") == "committed"
+    )
+    staged = sum(1 for artifact in artifacts if artifact.get("state") == "staged")
+    failed = sum(
+        1
+        for artifact in artifacts
+        if artifact.get("state")
+        in {
+            "attention_required",
+            "cancelled",
+            "collision",
+            "commit_verification_failed",
+            "drifted",
+            "interrupted",
+            "missing",
+            "render_failed",
+        }
+    )
+    complete = bool(total) and verified == total
+    if complete:
+        state = "committed"
+    elif failed:
+        state = "blocked"
+    elif committed:
+        state = "partially_committed"
+    elif total and staged == total:
+        state = "staged"
+    elif total:
+        state = "pending"
+    else:
+        state = "queued"
+    return {
+        "state": state,
+        "total": total,
+        "staged": staged,
+        "committed": committed,
+        "verified_committed": verified,
+        "failed": failed,
+        "pending": max(0, total - verified - failed),
+        "complete": complete,
+    }

--- a/src/dcc_mcp_houdini/_render_artifacts.py
+++ b/src/dcc_mcp_houdini/_render_artifacts.py
@@ -15,6 +15,10 @@ _REPARSE_POINT = 0x400
 _SHA256_HEX_LENGTH = 64
 
 
+class PublicationIdentityMismatchError(ValueError):
+    """Publication completed, but ownership of the final path is unprovable."""
+
+
 def normalize_transaction_request(value: Any) -> Dict[str, Any]:
     """Validate the opt-in request while keeping the legacy path untouched."""
     if not isinstance(value, Mapping):
@@ -181,19 +185,6 @@ def fsync_parent(path: Any, platform_name: Optional[str] = None) -> None:
         os.close(descriptor)
 
 
-def _rollback_mismatched_publication(final: Path, published_identity: Mapping[str, Any]) -> None:
-    """Remove only the mismatched final identity created by this publication."""
-    try:
-        current_identity = stable_file_identity(final)
-    except FileNotFoundError:
-        return
-    if current_identity != dict(published_identity):
-        raise RuntimeError("published final identity changed before rollback")
-    os.unlink(str(final))
-    if os.path.lexists(str(final)):
-        raise RuntimeError("mismatched published final could not be removed")
-
-
 def publish_no_clobber(
     staged_path: Any,
     final_path: Any,
@@ -217,8 +208,9 @@ def publish_no_clobber(
     if expected is not None:
         published_identity = stable_file_identity(final)
         if published_identity != expected:
-            _rollback_mismatched_publication(final, published_identity)
-            raise ValueError("published final identity does not match the expected staged identity")
+            raise PublicationIdentityMismatchError(
+                "published final identity does not match the expected staged identity; final ownership is unprovable"
+            )
     if (platform_name or os.name) != "nt":
         try:
             os.unlink(str(staged))

--- a/src/dcc_mcp_houdini/_render_artifacts.py
+++ b/src/dcc_mcp_houdini/_render_artifacts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence
 
 TRANSACTION_MODE = "staged_no_clobber"
+MAX_TRANSACTION_FRAMES = 100000
 _REPARSE_POINT = 0x400
 _SHA256_HEX_LENGTH = 64
 
@@ -38,12 +39,15 @@ def integer_frames(frame_range: Optional[Sequence[float]]) -> list:
     values = list(frame_range)
     if any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in values):
         raise ValueError("artifact_transaction frame_range values must be numbers")
-    if any(not math.isfinite(float(value)) or float(value) != int(value) for value in values):
+    if any(isinstance(value, float) and (not math.isfinite(value) or not value.is_integer()) for value in values):
         raise ValueError("artifact_transaction supports integral frames only")
     start, end = int(values[0]), int(values[1])
     step = int(values[2]) if len(values) == 3 else 1
     if step == 0 or (end - start) * step < 0:
         raise ValueError("frame_range step must move from start toward end")
+    frame_count = (abs(end - start) // abs(step)) + 1
+    if frame_count > MAX_TRANSACTION_FRAMES:
+        raise ValueError("artifact_transaction supports at most {} frames".format(MAX_TRANSACTION_FRAMES))
     stop = end + (1 if step > 0 else -1)
     frames = list(range(start, stop, step))
     if not frames:
@@ -177,10 +181,24 @@ def fsync_parent(path: Any, platform_name: Optional[str] = None) -> None:
         os.close(descriptor)
 
 
+def _rollback_mismatched_publication(final: Path, published_identity: Mapping[str, Any]) -> None:
+    """Remove only the mismatched final identity created by this publication."""
+    try:
+        current_identity = stable_file_identity(final)
+    except FileNotFoundError:
+        return
+    if current_identity != dict(published_identity):
+        raise RuntimeError("published final identity changed before rollback")
+    os.unlink(str(final))
+    if os.path.lexists(str(final)):
+        raise RuntimeError("mismatched published final could not be removed")
+
+
 def publish_no_clobber(
     staged_path: Any,
     final_path: Any,
     platform_name: Optional[str] = None,
+    expected_identity: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Commit with native no-clobber semantics and never fall back to replace."""
     staged = _absolute(staged_path)
@@ -188,11 +206,20 @@ def publish_no_clobber(
     assert_same_parent_and_volume(staged, final)
     if os.path.lexists(str(final)):
         raise FileExistsError("final output already exists: {}".format(final))
+    expected = dict(expected_identity) if expected_identity is not None else None
+    if expected is not None and stable_file_identity(staged) != expected:
+        raise ValueError("staged output identity changed before publication")
     cleanup_error = None
     if (platform_name or os.name) == "nt":
         os.rename(str(staged), str(final))
     else:
         os.link(str(staged), str(final), follow_symlinks=False)
+    if expected is not None:
+        published_identity = stable_file_identity(final)
+        if published_identity != expected:
+            _rollback_mismatched_publication(final, published_identity)
+            raise ValueError("published final identity does not match the expected staged identity")
+    if (platform_name or os.name) != "nt":
         try:
             os.unlink(str(staged))
         except OSError as exc:

--- a/src/dcc_mcp_houdini/_render_artifacts.py
+++ b/src/dcc_mcp_houdini/_render_artifacts.py
@@ -206,7 +206,12 @@ def publish_no_clobber(
     else:
         os.link(str(staged), str(final), follow_symlinks=False)
     if expected is not None:
-        published_identity = stable_file_identity(final)
+        try:
+            published_identity = stable_file_identity(final)
+        except Exception as exc:
+            raise PublicationIdentityMismatchError(
+                "published final identity could not be verified; final ownership is unprovable"
+            ) from exc
         if published_identity != expected:
             raise PublicationIdentityMismatchError(
                 "published final identity does not match the expected staged identity; final ownership is unprovable"

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -16,6 +16,7 @@ from dcc_mcp_houdini import _isolated_jobs
 from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
 from dcc_mcp_houdini._render_artifacts import (
     TRANSACTION_MODE,
+    PublicationIdentityMismatchError,
     aggregate_artifacts,
     assert_same_parent_and_volume,
     fsync_file,
@@ -608,7 +609,10 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
                     expected_identity=publication_identity,
                 )
             except Exception as exc:
-                if isinstance(exc, FileExistsError):
+                committed = isinstance(exc, PublicationIdentityMismatchError)
+                if committed:
+                    failure_state = "attention_required"
+                elif isinstance(exc, FileExistsError):
                     failure_state = "collision"
                 elif isinstance(exc, ValueError):
                     failure_state = "drifted"
@@ -621,6 +625,7 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
                     artifact_index,
                     failure_state,
                     exc,
+                    committed=committed,
                 )
                 raise
 

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -29,6 +31,72 @@ from dcc_mcp_houdini._render_artifacts import (
 _SUMMARY_WARNING_LIMIT = 10
 _SUMMARY_TEXT_LIMIT = 500
 _STDERR_TAIL_BYTES = 256 * 1024
+_ARTIFACT_LOCK_TIMEOUT_SECONDS = 120.0
+_ARTIFACT_LOCK_POLL_SECONDS = 0.05
+_LOCK_CONTENTION_ERRORS = {
+    errno.EACCES,
+    errno.EAGAIN,
+    getattr(errno, "EDEADLK", errno.EACCES),
+    getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
+}
+
+
+def _try_artifact_transaction_lock(stream: Any) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError as exc:
+            if exc.errno not in _LOCK_CONTENTION_ERRORS:
+                raise
+            return False
+        return True
+
+    import fcntl
+
+    try:
+        fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno not in _LOCK_CONTENTION_ERRORS:
+            raise
+        return False
+    return True
+
+
+def _release_artifact_transaction_lock(stream: Any) -> None:
+    stream.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _artifact_transaction_lock(status_path: Path):
+    """Serialize one job's artifact status updates across adapter processes."""
+    lock_path = status_path.with_name("artifact-transaction.lock")
+    with lock_path.open("a+b") as stream:
+        stream.seek(0, os.SEEK_END)
+        if stream.tell() == 0:
+            stream.write(b"\0")
+            stream.flush()
+        stream.seek(0)
+        deadline = time.monotonic() + _ARTIFACT_LOCK_TIMEOUT_SECONDS
+        while not _try_artifact_transaction_lock(stream):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out acquiring artifact transaction lock: {}".format(lock_path))
+            time.sleep(min(_ARTIFACT_LOCK_POLL_SECONDS, remaining))
+        try:
+            yield
+        finally:
+            _release_artifact_transaction_lock(stream)
 
 
 def _hython_executable() -> Path:
@@ -274,7 +342,40 @@ def _set_transaction(status: Dict[str, Any], transaction: Dict[str, Any]) -> Non
     status["artifact_transaction"] = transaction
 
 
-def _revalidate_committed(transaction: Dict[str, Any]) -> tuple:
+def _clear_current_artifact_errors(artifact: Dict[str, Any]) -> None:
+    for field in ("last_error", "last_error_at", "post_commit_error"):
+        artifact.pop(field, None)
+
+
+def _recover_committed_artifact(job_id: str, source: Dict[str, Any]) -> Dict[str, Any]:
+    """Finish a previously published artifact after a transient post-commit failure."""
+    artifact = dict(source)
+    receipt = validate_receipt(artifact.get("validator_receipt"), job_id, artifact)
+    final_identity = stable_file_identity(artifact["final_path"])
+    if not identity_matches_receipt(final_identity, receipt):
+        raise ValueError("committed final output does not match its validator receipt")
+    if os.path.lexists(artifact["staging_path"]):
+        staged_identity = stable_file_identity(artifact["staging_path"])
+        if not identity_matches_receipt(staged_identity, receipt) or not os.path.samefile(
+            artifact["staging_path"], artifact["final_path"]
+        ):
+            raise FileExistsError("committed final output has an unrelated staging path")
+        os.unlink(artifact["staging_path"])
+    fsync_parent(artifact["final_path"])
+    artifact.update(
+        {
+            "state": "committed",
+            "committed": True,
+            "committed_identity": final_identity,
+            "cleanup_error": None,
+            "post_commit_recovered_at": time.time(),
+        }
+    )
+    _clear_current_artifact_errors(artifact)
+    return artifact
+
+
+def _revalidate_committed(job_id: str, transaction: Dict[str, Any]) -> tuple:
     artifacts = []
     errors = []
     for source in transaction.get("artifacts", []):
@@ -282,11 +383,21 @@ def _revalidate_committed(transaction: Dict[str, Any]) -> tuple:
         if artifact.get("committed") is True:
             expected = artifact.get("committed_identity")
             try:
-                identity = stable_file_identity(artifact["final_path"])
-                if not isinstance(expected, dict) or identity != expected:
+                if artifact.get("state") in {
+                    "attention_required",
+                    "commit_verification_failed",
+                    "post_commit_verification",
+                } or not isinstance(expected, dict):
+                    artifact = _recover_committed_artifact(job_id, artifact)
+                elif stable_file_identity(artifact["final_path"]) != expected:
                     raise ValueError("committed final output identity drifted")
             except Exception as exc:  # noqa: BLE001
-                artifact["state"] = "drifted"
+                if isinstance(exc, FileExistsError):
+                    artifact["state"] = "collision"
+                elif isinstance(exc, ValueError):
+                    artifact["state"] = "drifted"
+                else:
+                    artifact["state"] = "commit_verification_failed"
                 artifact["post_commit_error"] = str(exc)
                 errors.append("frame {}: {}".format(artifact.get("frame"), exc))
         artifacts.append(artifact)
@@ -314,6 +425,7 @@ def _recover_publication_intents(job_id: str, transaction: Dict[str, Any]) -> tu
                 if not staged_exists:
                     raise ValueError("publication intent lost both staged and final outputs")
                 artifact["state"] = "staged"
+                _clear_current_artifact_errors(artifact)
                 artifacts.append(artifact)
                 continue
             final_identity = stable_file_identity(artifact["final_path"])
@@ -343,6 +455,8 @@ def _recover_publication_intents(job_id: str, transaction: Dict[str, Any]) -> tu
                     "recovered_at": time.time(),
                 }
             )
+            if not cleanup_error:
+                _clear_current_artifact_errors(artifact)
             if cleanup_error:
                 errors.append("frame {}: {}".format(artifact.get("frame"), cleanup_error))
         except Exception as exc:  # noqa: BLE001
@@ -390,7 +504,7 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
     _isolated_jobs.read_job(job_id)
     status_path = _isolated_jobs._status_path(job_id)
     finalized_frames = []
-    with _isolated_jobs._PROCESS_LOCK:
+    with _isolated_jobs._PROCESS_LOCK, _artifact_transaction_lock(status_path):
         status = _isolated_jobs._read_status(status_path)
         if status.get("state") != "completed":
             raise ValueError("render worker must be completed before finalization")
@@ -409,7 +523,7 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
         transaction = status["artifact_transaction"]
         if recovery_errors:
             raise ValueError("; ".join(recovery_errors))
-        transaction, drift_errors = _revalidate_committed(transaction)
+        transaction, drift_errors = _revalidate_committed(job_id, transaction)
         if drift_errors:
             _set_transaction(status, transaction)
             _isolated_jobs.write_status(status_path, status)
@@ -483,9 +597,23 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
             transaction = status["artifact_transaction"]
 
             try:
-                publication = publish_no_clobber(artifact["staging_path"], artifact["final_path"])
+                publication_identity = stable_file_identity(artifact["staging_path"])
+                if not identity_matches_receipt(publication_identity, receipt):
+                    raise ValueError(
+                        "staged output identity no longer matches its validator receipt before publication"
+                    )
+                publication = publish_no_clobber(
+                    artifact["staging_path"],
+                    artifact["final_path"],
+                    expected_identity=publication_identity,
+                )
             except Exception as exc:
-                failure_state = "collision" if isinstance(exc, FileExistsError) else "attention_required"
+                if isinstance(exc, FileExistsError):
+                    failure_state = "collision"
+                elif isinstance(exc, ValueError):
+                    failure_state = "drifted"
+                else:
+                    failure_state = "publishing"
                 _persist_finalize_failure(
                     status_path,
                     status,
@@ -557,7 +685,7 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
             transaction = status["artifact_transaction"]
             finalized_frames.append(frame)
 
-        transaction, drift_errors = _revalidate_committed(transaction)
+        transaction, drift_errors = _revalidate_committed(job_id, transaction)
         _set_transaction(status, transaction)
         _isolated_jobs.write_status(status_path, status)
         if drift_errors:

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -12,6 +12,19 @@ from typing import Any, Dict, List, Optional
 
 from dcc_mcp_houdini import _isolated_jobs
 from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
+from dcc_mcp_houdini._render_artifacts import (
+    TRANSACTION_MODE,
+    aggregate_artifacts,
+    assert_same_parent_and_volume,
+    fsync_file,
+    fsync_parent,
+    identity_matches_receipt,
+    integer_frames,
+    normalize_transaction_request,
+    publish_no_clobber,
+    stable_file_identity,
+    validate_receipt,
+)
 
 _SUMMARY_WARNING_LIMIT = 10
 _SUMMARY_TEXT_LIMIT = 500
@@ -84,26 +97,36 @@ def launch_background_render(
     output_pattern: Optional[str],
     ignore_inputs: bool = False,
     job_kind: str = "render",
+    artifact_transaction: Optional[dict] = None,
 ) -> Dict[str, Any]:
     """Launch one saved ROP job in an isolated hython process."""
     source_hip_path, is_ui_available = _validate_saved_hip(hou)
     executable = _hython_executable()
-    initial, status_path = _isolated_jobs.create_job(
-        {
-            "job_kind": job_kind,
-            "hip_path": str(source_hip_path),
-            "rop_path": rop_path,
-            "frame_range": frame_range,
-            "output_pattern": output_pattern,
-            "ignore_inputs": bool(ignore_inputs),
-        }
-    )
+    transaction = None
+    if artifact_transaction is not None:
+        if job_kind != "render":
+            raise ValueError("artifact_transaction supports render jobs only")
+        transaction = normalize_transaction_request(artifact_transaction)
+        transaction["requested_frames"] = integer_frames(frame_range)
+    initial_payload = {
+        "job_kind": job_kind,
+        "hip_path": str(source_hip_path),
+        "rop_path": rop_path,
+        "frame_range": frame_range,
+        "output_pattern": output_pattern,
+        "ignore_inputs": bool(ignore_inputs),
+    }
+    if transaction is not None:
+        initial_payload["artifact_transaction"] = transaction
+    initial, status_path = _isolated_jobs.create_job(initial_payload)
     hip_path = source_hip_path
     if not is_ui_available:
         try:
             hip_path = _save_owned_hip_snapshot(hou, status_path.parent)
         except Exception as exc:
             initial.update({"state": "failed", "finished_at": time.time(), "error": str(exc)})
+            if isinstance(initial.get("artifact_transaction"), dict):
+                initial["artifact_transaction"]["state"] = "failed"
             _isolated_jobs.write_status(status_path, initial)
             raise
         initial.update(
@@ -239,6 +262,316 @@ def _warning_lines(status: Dict[str, Any]) -> List[Any]:
     return warnings
 
 
+def _transaction_summary(transaction: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: transaction[key] for key in ("mode", "state", "output_parm_name", "aggregate") if key in transaction}
+
+
+def _set_transaction(status: Dict[str, Any], transaction: Dict[str, Any]) -> None:
+    transaction = dict(transaction)
+    transaction["aggregate"] = aggregate_artifacts(transaction.get("artifacts", []))
+    transaction["state"] = transaction["aggregate"]["state"]
+    transaction["updated_at"] = time.time()
+    status["artifact_transaction"] = transaction
+
+
+def _revalidate_committed(transaction: Dict[str, Any]) -> tuple:
+    artifacts = []
+    errors = []
+    for source in transaction.get("artifacts", []):
+        artifact = dict(source)
+        if artifact.get("committed") is True:
+            expected = artifact.get("committed_identity")
+            try:
+                identity = stable_file_identity(artifact["final_path"])
+                if not isinstance(expected, dict) or identity != expected:
+                    raise ValueError("committed final output identity drifted")
+            except Exception as exc:  # noqa: BLE001
+                artifact["state"] = "drifted"
+                artifact["post_commit_error"] = str(exc)
+                errors.append("frame {}: {}".format(artifact.get("frame"), exc))
+        artifacts.append(artifact)
+    transaction = dict(transaction)
+    transaction["artifacts"] = artifacts
+    transaction["aggregate"] = aggregate_artifacts(artifacts)
+    transaction["state"] = transaction["aggregate"]["state"]
+    return transaction, errors
+
+
+def _recover_publication_intents(job_id: str, transaction: Dict[str, Any]) -> tuple:
+    """Resolve the narrow crash window between publication and status update."""
+    artifacts = []
+    errors = []
+    for source in transaction.get("artifacts", []):
+        artifact = dict(source)
+        if artifact.get("state") != "publishing" or artifact.get("committed") is True:
+            artifacts.append(artifact)
+            continue
+        try:
+            receipt = validate_receipt(artifact.get("validator_receipt"), job_id, artifact)
+            staged_exists = os.path.lexists(artifact["staging_path"])
+            final_exists = os.path.lexists(artifact["final_path"])
+            if not final_exists:
+                if not staged_exists:
+                    raise ValueError("publication intent lost both staged and final outputs")
+                artifact["state"] = "staged"
+                artifacts.append(artifact)
+                continue
+            final_identity = stable_file_identity(artifact["final_path"])
+            if not identity_matches_receipt(final_identity, receipt):
+                raise ValueError("publication intent final output does not match its validator receipt")
+            cleanup_error = None
+            if staged_exists:
+                staged_identity = stable_file_identity(artifact["staging_path"])
+                if not identity_matches_receipt(staged_identity, receipt) or not os.path.samefile(
+                    artifact["staging_path"], artifact["final_path"]
+                ):
+                    raise FileExistsError("publication intent collided with an unrelated final output")
+                try:
+                    os.unlink(artifact["staging_path"])
+                except OSError as exc:
+                    cleanup_error = str(exc)
+            try:
+                fsync_parent(artifact["final_path"])
+            except OSError as exc:
+                cleanup_error = cleanup_error or str(exc)
+            artifact.update(
+                {
+                    "committed": True,
+                    "committed_identity": final_identity,
+                    "state": "attention_required" if cleanup_error else "committed",
+                    "cleanup_error": cleanup_error,
+                    "recovered_at": time.time(),
+                }
+            )
+            if cleanup_error:
+                errors.append("frame {}: {}".format(artifact.get("frame"), cleanup_error))
+        except Exception as exc:  # noqa: BLE001
+            artifact["state"] = "collision" if isinstance(exc, FileExistsError) else "drifted"
+            artifact["last_error"] = str(exc)
+            errors.append("frame {}: {}".format(artifact.get("frame"), exc))
+        artifacts.append(artifact)
+    transaction = dict(transaction)
+    transaction["artifacts"] = artifacts
+    transaction["aggregate"] = aggregate_artifacts(artifacts)
+    transaction["state"] = transaction["aggregate"]["state"]
+    return transaction, errors
+
+
+def _persist_finalize_failure(
+    status_path: Path,
+    status: Dict[str, Any],
+    transaction: Dict[str, Any],
+    artifact_index: int,
+    state: str,
+    error: Exception,
+    committed: bool = False,
+) -> None:
+    artifacts = [dict(item) for item in transaction.get("artifacts", [])]
+    artifact = artifacts[artifact_index]
+    artifact.update(
+        {
+            "state": state,
+            "committed": committed,
+            "last_error": str(error),
+            "last_error_at": time.time(),
+        }
+    )
+    artifacts[artifact_index] = artifact
+    transaction = dict(transaction)
+    transaction["artifacts"] = artifacts
+    _set_transaction(status, transaction)
+    _isolated_jobs.write_status(status_path, status)
+
+
+def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict[str, Any]:
+    """Publish externally validated staged EXRs without replacing final paths."""
+    if not isinstance(validator_receipts, list) or not validator_receipts:
+        raise ValueError("validator_receipts must be a non-empty array")
+    _isolated_jobs.read_job(job_id)
+    status_path = _isolated_jobs._status_path(job_id)
+    finalized_frames = []
+    with _isolated_jobs._PROCESS_LOCK:
+        status = _isolated_jobs._read_status(status_path)
+        if status.get("state") != "completed":
+            raise ValueError("render worker must be completed before finalization")
+        transaction = status.get("artifact_transaction")
+        if not isinstance(transaction, dict) or transaction.get("mode") != TRANSACTION_MODE:
+            raise ValueError("render job has no staged_no_clobber artifact transaction")
+        artifacts = transaction.get("artifacts")
+        if not isinstance(artifacts, list) or not artifacts:
+            raise ValueError("render job has no staged artifacts")
+        if len(validator_receipts) > len(artifacts):
+            raise ValueError("validator_receipts exceeds the staged artifact count")
+
+        transaction, recovery_errors = _recover_publication_intents(job_id, transaction)
+        _set_transaction(status, transaction)
+        _isolated_jobs.write_status(status_path, status)
+        transaction = status["artifact_transaction"]
+        if recovery_errors:
+            raise ValueError("; ".join(recovery_errors))
+        transaction, drift_errors = _revalidate_committed(transaction)
+        if drift_errors:
+            _set_transaction(status, transaction)
+            _isolated_jobs.write_status(status_path, status)
+            raise ValueError("; ".join(drift_errors))
+
+        seen_frames = set()
+        for receipt_payload in validator_receipts:
+            frame = receipt_payload.get("frame") if isinstance(receipt_payload, dict) else None
+            if isinstance(frame, bool) or not isinstance(frame, int) or frame in seen_frames:
+                raise ValueError("validator_receipts must bind unique integer frames")
+            seen_frames.add(frame)
+            artifacts = [dict(item) for item in transaction["artifacts"]]
+            matching = [index for index, artifact in enumerate(artifacts) if artifact.get("frame") == frame]
+            if len(matching) != 1:
+                raise ValueError("validator receipt frame is not part of this render job")
+            artifact_index = matching[0]
+            artifact = artifacts[artifact_index]
+            receipt = validate_receipt(receipt_payload, job_id, artifact)
+
+            if artifact.get("committed") is True:
+                if artifact.get("validator_receipt") != receipt:
+                    raise ValueError("committed frame validator receipt does not match")
+                final_identity = stable_file_identity(artifact["final_path"])
+                if not identity_matches_receipt(final_identity, receipt):
+                    error = ValueError("committed final output no longer matches its validator receipt")
+                    _persist_finalize_failure(
+                        status_path,
+                        status,
+                        transaction,
+                        artifact_index,
+                        "drifted",
+                        error,
+                        committed=True,
+                    )
+                    raise error
+                finalized_frames.append(frame)
+                continue
+            if artifact.get("state") != "staged":
+                raise ValueError("frame {} is not in staged state".format(frame))
+
+            try:
+                assert_same_parent_and_volume(artifact["staging_path"], artifact["final_path"])
+                staged_identity = stable_file_identity(artifact["staging_path"])
+                if not identity_matches_receipt(staged_identity, receipt):
+                    raise ValueError("staged output does not match its validator receipt")
+                fsync_file(artifact["staging_path"])
+                if stable_file_identity(artifact["staging_path"]) != staged_identity:
+                    raise ValueError("staged output identity drifted after fsync")
+            except Exception as exc:
+                _persist_finalize_failure(
+                    status_path,
+                    status,
+                    transaction,
+                    artifact_index,
+                    "drifted",
+                    exc,
+                )
+                raise
+
+            artifact.update(
+                {
+                    "state": "publishing",
+                    "validator_receipt": receipt,
+                    "publication_started_at": time.time(),
+                }
+            )
+            artifacts[artifact_index] = artifact
+            transaction["artifacts"] = artifacts
+            _set_transaction(status, transaction)
+            _isolated_jobs.write_status(status_path, status)
+            transaction = status["artifact_transaction"]
+
+            try:
+                publication = publish_no_clobber(artifact["staging_path"], artifact["final_path"])
+            except Exception as exc:
+                failure_state = "collision" if isinstance(exc, FileExistsError) else "attention_required"
+                _persist_finalize_failure(
+                    status_path,
+                    status,
+                    transaction,
+                    artifact_index,
+                    failure_state,
+                    exc,
+                )
+                raise
+
+            artifacts = [dict(item) for item in transaction["artifacts"]]
+            artifact = artifacts[artifact_index]
+            artifact.update(
+                {
+                    "state": "post_commit_verification",
+                    "committed": True,
+                    "published_at": time.time(),
+                    "publication_method": "rename" if os.name == "nt" else "hardlink_unlink",
+                    "cleanup_error": publication.get("cleanup_error"),
+                }
+            )
+            artifacts[artifact_index] = artifact
+            transaction["artifacts"] = artifacts
+            _set_transaction(status, transaction)
+            _isolated_jobs.write_status(status_path, status)
+            transaction = status["artifact_transaction"]
+
+            final_identity = None
+            try:
+                final_identity = stable_file_identity(artifact["final_path"])
+                if not identity_matches_receipt(final_identity, receipt):
+                    raise ValueError("published final output does not match its validator receipt")
+                fsync_parent(artifact["final_path"])
+                if publication.get("cleanup_error"):
+                    raise RuntimeError("staging cleanup failed: {}".format(publication["cleanup_error"]))
+            except Exception as exc:
+                artifacts = [dict(item) for item in transaction["artifacts"]]
+                artifact = artifacts[artifact_index]
+                if final_identity is not None:
+                    artifact["committed_identity"] = final_identity
+                artifact.update(
+                    {
+                        "state": "commit_verification_failed",
+                        "committed": True,
+                        "post_commit_error": str(exc),
+                        "post_commit_checked_at": time.time(),
+                    }
+                )
+                artifacts[artifact_index] = artifact
+                transaction["artifacts"] = artifacts
+                _set_transaction(status, transaction)
+                _isolated_jobs.write_status(status_path, status)
+                raise
+
+            artifacts = [dict(item) for item in transaction["artifacts"]]
+            artifact = artifacts[artifact_index]
+            artifact.update(
+                {
+                    "state": "committed",
+                    "committed": True,
+                    "committed_identity": final_identity,
+                    "post_commit_verified_at": time.time(),
+                }
+            )
+            artifacts[artifact_index] = artifact
+            transaction["artifacts"] = artifacts
+            _set_transaction(status, transaction)
+            _isolated_jobs.write_status(status_path, status)
+            transaction = status["artifact_transaction"]
+            finalized_frames.append(frame)
+
+        transaction, drift_errors = _revalidate_committed(transaction)
+        _set_transaction(status, transaction)
+        _isolated_jobs.write_status(status_path, status)
+        if drift_errors:
+            raise ValueError("; ".join(drift_errors))
+        transaction = status["artifact_transaction"]
+        return {
+            "job_id": job_id,
+            "worker_state": status["state"],
+            "transaction_state": transaction["state"],
+            "aggregate": transaction["aggregate"],
+            "finalized_frames": finalized_frames,
+        }
+
+
 def read_render_job(job_id: str, include_details: bool = False) -> Dict[str, Any]:
     result = _with_progress(_isolated_jobs.read_job(job_id))
     if result.get("state") in _isolated_jobs._TERMINAL_STATES:
@@ -248,6 +581,9 @@ def read_render_job(job_id: str, include_details: bool = False) -> Dict[str, Any
     if include_details:
         result["warnings"] = warnings
     if not include_details:
+        transaction = result.get("artifact_transaction")
+        if isinstance(transaction, dict):
+            result["artifact_transaction"] = _transaction_summary(transaction)
         result.pop("expected_outputs", None)
         result.pop("output_snapshot", None)
         written_files = list(result.pop("written_files", []) or [])

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -504,7 +504,7 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
     _isolated_jobs.read_job(job_id)
     status_path = _isolated_jobs._status_path(job_id)
     finalized_frames = []
-    with _isolated_jobs._PROCESS_LOCK, _artifact_transaction_lock(status_path):
+    with _artifact_transaction_lock(status_path):
         status = _isolated_jobs._read_status(status_path)
         if status.get("state") != "completed":
             raise ValueError("render worker must be completed before finalization")

--- a/src/dcc_mcp_houdini/_status_io.py
+++ b/src/dcc_mcp_houdini/_status_io.py
@@ -1,0 +1,61 @@
+"""Pure-stdlib atomic JSON status I/O shared by adapter and workers."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping
+
+_STATUS_IO_TIMEOUT_SECONDS = 1.0
+_STATUS_IO_POLL_SECONDS = 0.01
+
+
+def _retry_windows_status_io(operation: Callable[[], Any], description: str) -> Any:
+    """Retry transient Windows sharing violations within one bounded deadline."""
+    if os.name != "nt":
+        return operation()
+    deadline = time.monotonic() + _STATUS_IO_TIMEOUT_SECONDS
+    while True:
+        try:
+            return operation()
+        except PermissionError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out while {}".format(description)) from exc
+            time.sleep(min(_STATUS_IO_POLL_SECONDS, remaining))
+
+
+def _remove_pending_status(path: Path) -> None:
+    try:
+        _retry_windows_status_io(path.unlink, "cleaning pending status file {}".format(path))
+    except FileNotFoundError:
+        pass
+
+
+def write_status(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically replace one JSON status document without exposing partial JSON."""
+    pending = path.with_name("{}.{}.tmp".format(path.name, uuid.uuid4().hex))
+    try:
+        pending.write_text(json.dumps(dict(payload), indent=2), encoding="utf-8")
+        _retry_windows_status_io(
+            lambda: os.replace(str(pending), str(path)),
+            "replacing status file {}".format(path),
+        )
+    except Exception:
+        try:
+            _remove_pending_status(pending)
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+
+
+def read_status(path: Path) -> Dict[str, Any]:
+    """Read and decode one complete atomic status document."""
+    payload = _retry_windows_status_io(
+        lambda: path.read_text(encoding="utf-8"),
+        "reading status file {}".format(path),
+    )
+    return json.loads(payload)

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -28,7 +28,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Three-point studio lighting | `load_skill("houdini-light-rig")` → `create_three_point_light_rig` → `aim_light_at_object` → `set_light_rig_intensity` → `get_lighting_summary` |
 | HDRI environment lighting | `load_skill("houdini-light-rig")` → `create_hdri_world` → `area_softbox` / `set_render_view_transform` → `get_lighting_summary` |
 | Light rig management | `load_skill("houdini-light-rig")` → `list_light_rigs` → `group_lights` → `set_light_rig_intensity` |
-| Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` → `houdini_render__get_render_job` / `houdini_render__cancel_render_job` |
+| Render & verify | `load_skill("houdini-render")` → `houdini_render__set_render_settings` → `houdini_render__capture_viewport` → `houdini_render__render_rop` → `houdini_render__get_render_job` → optional `houdini_render__finalize_render_outputs` / `houdini_render__cancel_render_job` |
 | Karma stage preflight | `load_skill("houdini-render")` → `houdini_render__validate_karma_stage(lop_path="/stage/OUT", renderer="karma_xpu")` |
 | Texture bake (AO) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_ambient_occlusion` |
 | Texture bake (lighting) | `load_skill("houdini-texture-bake")` → `houdini_texture_bake__list_bake_targets` → `houdini_texture_bake__bake_lighting` |

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -36,7 +36,8 @@ agent can detect and skip cleanly when rendering is unavailable.
 - **`render`:** `get_render_settings` (read-only), `set_render_settings`
   (reports `unsupported` fields per ROP type), `render_rop` (foreground or
   isolated `hython` background job), `get_render_job` (polls and reconciles
-  status without blocking the UI), `cancel_render_job` (cancels only jobs
+  status without blocking the UI), `finalize_render_outputs` (publishes
+  externally validated staged EXRs without replacing finals), `cancel_render_job` (cancels only jobs
   owned by the current adapter process), `configure_aovs` (add/remove Solaris
   RenderVars or native Mantra auxiliary planes with renderer-correct processing),
   `validate_karma_stage` (read-only USD/Karma
@@ -55,6 +56,14 @@ agent can detect and skip cleanly when rendering is unavailable.
 4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only)
 5. `flipbook(output_path="/tmp/preview.$F4.jpg", frame_range=[1,24,4], camera_path="/obj/rendercam")` for a sparse camera preview (UI only)
 6. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive or headless Houdini
+
+For crash-safe final publication, opt in with
+`artifact_transaction={"mode":"staged_no_clobber"}` and an explicit integral
+frame range. Poll the worker to `completed`, validate each returned staging EXR
+externally, then pass the identity-bound receipts to
+`finalize_render_outputs(job_id, validator_receipts)`. The worker discovers and
+temporarily overrides the exact EXR output parameter only in its loaded HIP
+copy. Final paths are created only by the no-clobber finalize step.
 
 ### Render Layers & AOVs
 
@@ -86,6 +95,9 @@ evidence. `verified` requires every expected output to be newly written,
 readable, non-empty, and produced without an execution/cook failure. Pass
 an explicit frame range when exact completeness matters; render and cache jobs
 with only part of that requested range written fail with bounded output counts.
+Transaction polling additionally returns a bounded transaction state and
+aggregate; use `include_details=true` for per-frame staging, validator, commit,
+and post-commit verification evidence.
 Pass `include_details=true` only when the full
 expected-output snapshot, complete written-file and warning lists, error, and
 traceback are needed. The same job lifecycle also observes `cache_simulation` and

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_background_render.py
@@ -11,6 +11,7 @@ tempfile = _isolated_jobs.tempfile
 time = _isolated_jobs.time
 launch_background_render = _rop_jobs.launch_background_render
 read_render_job = _rop_jobs.read_render_job
+finalize_render_outputs = _rop_jobs.finalize_render_outputs
 _PROCESS_HANDLES = _isolated_jobs._PROCESS_HANDLES
 _PROCESS_LOCK = _isolated_jobs._PROCESS_LOCK
 _TERMINAL_STATES = _isolated_jobs._TERMINAL_STATES

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_common.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, Optional, Sequence
 
 MAX_DIMENSION = 4096
+PRIMARY_OUTPUT_PARMS = ("picture", "vm_picture", "outputimage", "lopoutput", "sopoutput", "filename")
 
 
 def get_node(hou: Any, node_path: str) -> Any:
@@ -60,25 +61,30 @@ def set_first_parm(node: Any, names: Sequence[str], value: Any) -> Optional[str]
 
 def eval_first_parm(node: Any, names: Sequence[str], preserve_string: bool = False):
     """Eval the first existing parm/parm-tuple in *names*, else None."""
+    return eval_first_parm_named(node, names, preserve_string=preserve_string)[1]
+
+
+def eval_first_parm_named(node: Any, names: Sequence[str], preserve_string: bool = False):
+    """Return ``(name, value)`` for the first evaluable parameter."""
     for name in names:
         parm = node.parm(name)
         if preserve_string and parm is not None:
             try:
-                return parm.unexpandedString()
+                return name, parm.unexpandedString()
             except Exception:  # noqa: BLE001
                 continue
         parm_tuple = node.parmTuple(name)
         if parm_tuple is not None:
             try:
-                return list(parm_tuple.eval())
+                return name, list(parm_tuple.eval())
             except Exception:  # noqa: BLE001
                 continue
         if parm is not None:
             try:
-                return parm.eval()
+                return name, parm.eval()
             except Exception:  # noqa: BLE001
                 continue
-    return None
+    return None, None
 
 
 def apply_frame_range(node: Any, frame_range: Optional[Sequence[float]]) -> Optional[list]:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -25,13 +25,7 @@ from dcc_mcp_houdini._render_artifacts import (
     integer_frames,
     staging_pattern,
 )
-
-
-def write_status(path: Path, payload: dict) -> None:
-    """Atomically replace worker status without importing the adapter package."""
-    pending = path.with_name("{}.{}.tmp".format(path.name, os.getpid()))
-    pending.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    os.replace(str(pending), str(path))
+from dcc_mcp_houdini._status_io import read_status, write_status
 
 
 def _cook_errors(status: dict) -> list:
@@ -188,7 +182,7 @@ def main() -> None:
     status_path = Path(status_arg)
     frame_range = json.loads(range_json)
     output_pattern = json.loads(output_json)
-    status = json.loads(status_path.read_text(encoding="utf-8"))
+    status = read_status(status_path)
     transaction_enabled = isinstance(status.get("artifact_transaction"), dict)
     transaction = dict(status.get("artifact_transaction") or {})
     output_parm = None

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_render_worker.py
@@ -10,12 +10,20 @@ import traceback
 from pathlib import Path
 
 from _render_common import (
+    PRIMARY_OUTPUT_PARMS,
     expand_output_variables,
     expanded_outputs,
     output_snapshot,
     render_node,
     requested_outputs,
     updated_outputs,
+)
+
+from dcc_mcp_houdini._render_artifacts import (
+    aggregate_artifacts,
+    assert_same_parent_and_volume,
+    integer_frames,
+    staging_pattern,
 )
 
 
@@ -72,6 +80,105 @@ def _verify_outputs(candidates: list, before: dict, output_pattern) -> tuple:
     }
 
 
+def _primary_exr_output(rop) -> tuple:
+    candidates = []
+    for name in PRIMARY_OUTPUT_PARMS:
+        parm = rop.parm(name)
+        if parm is None:
+            continue
+        try:
+            pattern = parm.unexpandedString()
+        except Exception:  # noqa: BLE001
+            continue
+        if isinstance(pattern, str) and pattern.strip() and pattern.lower().endswith(".exr"):
+            candidates.append((name, parm, pattern))
+    if len(candidates) != 1:
+        raise ValueError("artifact_transaction requires exactly one primary EXR output parameter")
+    return candidates[0]
+
+
+def _prepare_artifact_transaction(hou, rop, status: dict, frame_range) -> tuple:
+    transaction = dict(status["artifact_transaction"])
+    frames = integer_frames(frame_range)
+    if transaction.get("requested_frames") != frames:
+        raise ValueError("artifact_transaction requested frame contract changed before worker execution")
+    inputs = getattr(rop, "inputs", None)
+    if callable(inputs) and any(inputs()):
+        raise ValueError("artifact_transaction does not support ROP input chains")
+    output_parm_name, output_parm, final_pattern = _primary_exr_output(rop)
+    staged_pattern = staging_pattern(final_pattern, status["job_id"])
+    artifacts = []
+    seen_final = set()
+    seen_staged = set()
+    for frame in frames:
+        final_path = hou.text.expandStringAtFrame(final_pattern, frame)
+        staged_path = hou.text.expandStringAtFrame(staged_pattern, frame)
+        if not isinstance(final_path, str) or not isinstance(staged_path, str):
+            raise ValueError("artifact_transaction output expansion must return paths")
+        if not os.path.isabs(final_path) or not os.path.isabs(staged_path):
+            raise ValueError("artifact_transaction outputs must resolve to absolute paths")
+        final_path = os.path.abspath(final_path)
+        staged_path = os.path.abspath(staged_path)
+        final_key = os.path.normcase(final_path)
+        staged_key = os.path.normcase(staged_path)
+        if final_key in seen_final or staged_key in seen_staged:
+            raise ValueError("artifact_transaction requires one unique EXR per frame")
+        seen_final.add(final_key)
+        seen_staged.add(staged_key)
+        assert_same_parent_and_volume(staged_path, final_path)
+        if os.path.lexists(final_path):
+            raise FileExistsError("final output already exists: {}".format(final_path))
+        if os.path.lexists(staged_path):
+            raise FileExistsError("staging output already exists: {}".format(staged_path))
+        artifacts.append(
+            {
+                "frame": frame,
+                "staging_path": staged_path,
+                "final_path": final_path,
+                "state": "rendering",
+                "committed": False,
+            }
+        )
+    transaction.update(
+        {
+            "state": "rendering",
+            "output_parm_name": output_parm_name,
+            "final_output_pattern": final_pattern,
+            "staging_output_pattern": staged_pattern,
+            "artifacts": artifacts,
+            "aggregate": aggregate_artifacts(artifacts),
+        }
+    )
+    return transaction, output_parm, final_pattern, staged_pattern
+
+
+def _observe_transaction_outputs(transaction: dict, written_files: list, worker_succeeded: bool) -> dict:
+    written = {os.path.normcase(os.path.abspath(path)) for path in written_files}
+    artifacts = []
+    for source in transaction.get("artifacts", []):
+        artifact = dict(source)
+        staged_path = artifact["staging_path"]
+        if os.path.normcase(os.path.abspath(staged_path)) in written:
+            file_stat = os.lstat(staged_path)
+            artifact["worker_observation"] = {
+                "bytes": file_stat.st_size,
+                "mtime_ns": file_stat.st_mtime_ns,
+            }
+            artifact["state"] = "staged" if worker_succeeded else "render_failed"
+        else:
+            artifact["state"] = "missing" if worker_succeeded else "render_failed"
+        artifacts.append(artifact)
+    transaction = dict(transaction)
+    transaction["artifacts"] = artifacts
+    transaction["state"] = (
+        "staged"
+        if worker_succeeded and all(artifact.get("state") == "staged" for artifact in artifacts)
+        else "render_failed"
+    )
+    transaction["aggregate"] = aggregate_artifacts(artifacts)
+    return transaction
+
+
 def main() -> None:
     import hou  # Lazy import: requires Houdini's embedded Python.
 
@@ -82,6 +189,13 @@ def main() -> None:
     frame_range = json.loads(range_json)
     output_pattern = json.loads(output_json)
     status = json.loads(status_path.read_text(encoding="utf-8"))
+    transaction_enabled = isinstance(status.get("artifact_transaction"), dict)
+    transaction = dict(status.get("artifact_transaction") or {})
+    output_parm = None
+    original_output_pattern = None
+    resolved_output_pattern = output_pattern
+    expected_outputs = []
+    before = {}
     started = time.time()
     status.update({"state": "running", "pid": os.getpid(), "started_at": started})
     write_status(status_path, status)
@@ -104,14 +218,24 @@ def main() -> None:
         rop = hou.node(rop_path)
         if rop is None:
             raise ValueError("ROP node not found: {}".format(rop_path))
-        expected_outputs = (
-            status["expected_outputs"]
-            if frame_range and "expected_outputs" in status
-            else requested_outputs(hou, resolved_output_pattern, frame_range)
-        )
-        before = status.get("output_snapshot")
-        if before is None:
-            before = output_snapshot(expected_outputs)
+        if transaction_enabled:
+            transaction, output_parm, original_output_pattern, resolved_output_pattern = _prepare_artifact_transaction(
+                hou, rop, status, frame_range
+            )
+            status["artifact_transaction"] = transaction
+            write_status(status_path, status)
+            output_parm.set(resolved_output_pattern)
+            expected_outputs = [artifact["staging_path"] for artifact in transaction["artifacts"]]
+            before = {}
+        else:
+            expected_outputs = (
+                status["expected_outputs"]
+                if frame_range and "expected_outputs" in status
+                else requested_outputs(hou, resolved_output_pattern, frame_range)
+            )
+            before = status.get("output_snapshot")
+            if before is None:
+                before = output_snapshot(expected_outputs)
         status.update({"expected_outputs": expected_outputs, "output_snapshot": before})
         write_status(status_path, status)
         verification_ready = True
@@ -140,6 +264,8 @@ def main() -> None:
             )
         if not written_files and status.get("job_kind", "render") != "rop_chain":
             raise RuntimeError("Render produced no new or updated output for the requested frame range")
+        if transaction_enabled:
+            transaction = _observe_transaction_outputs(transaction, written_files, worker_succeeded=True)
         status.update(
             {
                 "state": "completed",
@@ -150,12 +276,22 @@ def main() -> None:
                 "warnings": [],
             }
         )
+        if transaction_enabled:
+            status["artifact_transaction"] = transaction
     except Exception as exc:  # noqa: BLE001
         if verification_ready:
             candidates = expected_outputs if frame_range else expanded_outputs(resolved_output_pattern)
             written_files, output_verification = _verify_outputs(candidates, before, resolved_output_pattern)
             if output_verification["state"] == "verified":
                 output_verification["state"] = "failed"
+        if transaction_enabled:
+            transaction = _observe_transaction_outputs(
+                transaction or status.get("artifact_transaction", {}),
+                written_files,
+                worker_succeeded=False,
+            )
+            transaction["state"] = "render_failed"
+            transaction["worker_error"] = str(exc)
         status.update(
             {
                 "state": "failed",
@@ -167,7 +303,14 @@ def main() -> None:
                 "warnings": rop_errors,
             }
         )
+        if transaction_enabled:
+            status["artifact_transaction"] = transaction
     finally:
+        if output_parm is not None and original_output_pattern is not None:
+            try:
+                output_parm.set(original_output_pattern)
+            except Exception as exc:  # noqa: BLE001
+                status.setdefault("artifact_transaction", {})["override_restore_error"] = str(exc)
         _remove_owned_hip_snapshot(status_path, status, hip_path)
         status["finished_at"] = time.time()
         write_status(status_path, status)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/finalize_render_outputs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/finalize_render_outputs.py
@@ -1,0 +1,27 @@
+"""Publish externally validated staged render outputs without clobbering finals."""
+
+from __future__ import annotations
+
+from _background_render import finalize_render_outputs as _finalize_render_outputs  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+
+def finalize_render_outputs(job_id: str, validator_receipts: list) -> dict:
+    try:
+        return skill_success(
+            "Finalized validated render outputs",
+            **_finalize_render_outputs(job_id, validator_receipts),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to finalize render outputs")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return finalize_render_outputs(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from _render_common import eval_first_parm, get_node, node_summary  # noqa: E402
+from _render_common import (  # noqa: E402
+    PRIMARY_OUTPUT_PARMS,
+    eval_first_parm,
+    eval_first_parm_named,
+    get_node,
+    node_summary,
+)
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
-
-_OUTPUT_PARMS = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
 
 
 def get_render_settings(rop_path: str) -> dict:
@@ -20,15 +24,17 @@ def get_render_settings(rop_path: str) -> dict:
         res_x = eval_first_parm(rop, ("res_overridex", "resx", "vm_resx"))
         res_y = eval_first_parm(rop, ("res_overridey", "resy", "vm_resy"))
         output_frame = float(hou.frame())
-        output_path = eval_first_parm(rop, _OUTPUT_PARMS)
+        output_parm_name, output_path_pattern = eval_first_parm_named(rop, PRIMARY_OUTPUT_PARMS, preserve_string=True)
+        output_path = eval_first_parm(rop, (output_parm_name,)) if output_parm_name else None
         settings = {
             "rop": node_summary(rop),
             "renderer": rop.type().name(),
             "camera": eval_first_parm(rop, ("camera", "render_camera")),
             "resolution": [res_x, res_y] if (res_x is not None or res_y is not None) else None,
             "frame_range": eval_first_parm(rop, ("f",)),
+            "output_parm_name": output_parm_name,
             "output_path": output_path,
-            "output_path_pattern": eval_first_parm(rop, _OUTPUT_PARMS, preserve_string=True),
+            "output_path_pattern": output_path_pattern,
             "output_path_resolution": {
                 "frame": output_frame,
                 "paths": output_path

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -8,10 +8,15 @@ import time
 from typing import List, Optional
 
 from _background_render import launch_background_render  # noqa: E402
-from _render_common import eval_first_parm, expanded_outputs, get_node, node_summary, render_node  # noqa: E402
+from _render_common import (  # noqa: E402
+    PRIMARY_OUTPUT_PARMS,
+    eval_first_parm,
+    expanded_outputs,
+    get_node,
+    node_summary,
+    render_node,
+)
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
-
-_OUTPUT_PARMS = ("picture", "vm_picture", "outputimage", "lopoutput", "sopoutput", "filename")
 
 
 def _expand_outputs(pattern: Optional[str]) -> list:
@@ -33,6 +38,7 @@ def render_rop(
     rop_path: str,
     frame_range: Optional[List[float]] = None,
     background: Optional[bool] = None,
+    artifact_transaction: Optional[dict] = None,
 ) -> dict:
     """Render the ROP at *rop_path*, returning written files and elapsed time."""
     try:
@@ -51,10 +57,24 @@ def render_rop(
                 "Node has no supported render action; expected a ROP/output driver",
                 node_path=rop.path(),
             )
-        output_pattern = eval_first_parm(rop, _OUTPUT_PARMS, preserve_string=True)
+        output_pattern = eval_first_parm(rop, PRIMARY_OUTPUT_PARMS, preserve_string=True)
         use_background = True if background is None else background
+        if artifact_transaction is not None and not use_background:
+            return skill_error(
+                "Artifact transaction requires background rendering",
+                "staged_no_clobber is available only for isolated ROP jobs",
+            )
         if use_background:
-            job = launch_background_render(hou, rop.path(), frame_range, output_pattern)
+            if artifact_transaction is None:
+                job = launch_background_render(hou, rop.path(), frame_range, output_pattern)
+            else:
+                job = launch_background_render(
+                    hou,
+                    rop.path(),
+                    frame_range,
+                    output_pattern,
+                    artifact_transaction=artifact_transaction,
+                )
             return skill_success(
                 "Started background ROP render",
                 rop=node_summary(rop),

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -192,6 +192,19 @@ tools:
             execution. When omitted, both interactive and headless Houdini use
             an isolated job. Headless isolation uses a job-owned temporary HIP
             snapshot without saving the source scene.
+        artifact_transaction:
+          type: object
+          additionalProperties: false
+          required: [mode]
+          description: >-
+            Optional staged publication contract for background renders with one
+            primary multilayer EXR per integral frame. The worker discovers the
+            exact ROP output parameter and creates same-directory staging names;
+            the source HIP and final paths are never changed or overwritten.
+          properties:
+            mode:
+              type: string
+              enum: [staged_no_clobber]
   - name: get_render_job
     description: >-
       Read bounded status, output progress, elapsed time, and ETA for a background
@@ -220,6 +233,72 @@ tools:
           type: boolean
           default: false
           description: Include full expected/output snapshots, written-file and warning lists, errors, and traceback data. The default response is bounded.
+  - name: finalize_render_outputs
+    description: >-
+      Publish one or more staged EXRs from a completed isolated render job. Each
+      external validator receipt is bound to the job, frame, staging/final paths,
+      byte count, mtime, SHA-256, and validator identity. Publication never
+      replaces an existing final: Windows uses rename and POSIX uses hard-link
+      plus unlink. Poll get_render_job for the transaction aggregate and set
+      include_details=true for per-frame evidence.
+    source_file: scripts/finalize_render_outputs.py
+    execution: sync
+    affinity: any
+    group: render
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [job_id, validator_receipts]
+      properties:
+        job_id:
+          type: string
+        validator_receipts:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            additionalProperties: false
+            required: [accepted, job_id, frame, staging_path, final_path, bytes, mtime_ns, sha256, validator]
+            properties:
+              accepted:
+                type: boolean
+                const: true
+              job_id:
+                type: string
+              frame:
+                type: integer
+              staging_path:
+                type: string
+              final_path:
+                type: string
+              bytes:
+                type: integer
+                minimum: 1
+              mtime_ns:
+                type: integer
+                minimum: 0
+              sha256:
+                type: string
+                pattern: "^[0-9A-Fa-f]{64}$"
+              validator:
+                type: object
+                additionalProperties: false
+                required: [id, version, implementation_sha256]
+                properties:
+                  id:
+                    type: string
+                  version:
+                    type: string
+                  implementation_sha256:
+                    type: string
+                    pattern: "^[0-9A-Fa-f]{64}$"
   - name: cancel_render_job
     description: Cancel a background ROP render/cache/chain job owned by the current adapter process. Repeated calls are safe.
     source_file: scripts/cancel_render_job.py

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import multiprocessing
 import os
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -154,6 +156,26 @@ def _completed_job(tmp_path: Path, count: int = 1):
     return job_id, status_path, artifacts
 
 
+def _finalize_frame_in_process(tmp_root, job_id, receipt, start_event, result_queue):
+    real_identity = _rop_jobs.stable_file_identity
+    delayed = [False]
+
+    def delayed_identity(path):
+        if not delayed[0] and os.path.normcase(str(path)) == os.path.normcase(receipt["staging_path"]):
+            delayed[0] = True
+            time.sleep(1.0)
+        return real_identity(path)
+
+    start_event.wait(10.0)
+    try:
+        with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_root)), patch.object(
+            _rop_jobs, "stable_file_identity", side_effect=delayed_identity
+        ):
+            result_queue.put(("ok", _rop_jobs.finalize_render_outputs(job_id, [receipt])))
+    except Exception as exc:  # noqa: BLE001
+        result_queue.put(("error", type(exc).__name__, str(exc)))
+
+
 def _receipt(job_id: str, artifact: dict) -> dict:
     identity = _render_artifacts.stable_file_identity(artifact["staging_path"])
     return {
@@ -173,6 +195,46 @@ def test_transaction_request_and_frames_are_fail_closed() -> None:
         _render_artifacts.normalize_transaction_request({"mode": "replace"})
     with pytest.raises(ValueError, match="integral"):
         _render_artifacts.integer_frames([1, 2.5, 1])
+
+
+def test_integer_frames_accepts_the_bounded_limit_in_both_directions() -> None:
+    limit = _render_artifacts.MAX_TRANSACTION_FRAMES
+    assert 1 <= limit <= 100000
+    assert len(_render_artifacts.integer_frames([1, limit])) == limit
+    assert len(_render_artifacts.integer_frames([limit, 1, -1])) == limit
+    assert len(_render_artifacts.integer_frames([1, 1 + ((limit - 1) * 2), 2])) == limit
+
+
+def test_integer_frames_rejects_above_limit_before_expansion() -> None:
+    limit = _render_artifacts.MAX_TRANSACTION_FRAMES
+    with patch.object(_render_artifacts, "range", side_effect=AssertionError("range must not expand"), create=True):
+        with pytest.raises(ValueError, match="at most"):
+            _render_artifacts.integer_frames([1, limit + 1])
+        with pytest.raises(ValueError, match="at most"):
+            _render_artifacts.integer_frames([1, 10**1000])
+
+
+def test_job_transaction_lock_releases_after_exception(tmp_path: Path) -> None:
+    status_path = tmp_path / "job" / "status.json"
+    status_path.parent.mkdir()
+    with pytest.raises(RuntimeError, match="inside lock"):
+        with _rop_jobs._artifact_transaction_lock(status_path):
+            raise RuntimeError("inside lock")
+    with _rop_jobs._artifact_transaction_lock(status_path):
+        pass
+
+
+def test_job_transaction_lock_times_out_and_remains_available(tmp_path: Path) -> None:
+    status_path = tmp_path / "job" / "status.json"
+    status_path.parent.mkdir()
+    with patch.object(_rop_jobs, "_ARTIFACT_LOCK_TIMEOUT_SECONDS", 0.0), patch.object(
+        _rop_jobs, "_try_artifact_transaction_lock", return_value=False
+    ):
+        with pytest.raises(TimeoutError, match="artifact transaction lock"):
+            with _rop_jobs._artifact_transaction_lock(status_path):
+                pass
+    with _rop_jobs._artifact_transaction_lock(status_path):
+        pass
 
 
 def test_get_render_settings_prefers_outputimage_and_reports_exact_parm() -> None:
@@ -373,6 +435,37 @@ def test_windows_path_uses_rename_and_preserves_collision(tmp_path: Path) -> Non
     assert final.read_bytes() == b"stage"
 
 
+@pytest.mark.parametrize(
+    ("platform_name", "primitive_name"),
+    [("nt", "rename"), ("posix", "link")],
+)
+def test_publication_never_commits_source_replaced_after_expected_identity_check(
+    tmp_path: Path,
+    platform_name: str,
+    primitive_name: str,
+) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"validated bytes")
+    expected_identity = _render_artifacts.stable_file_identity(staged)
+    real_primitive = getattr(os, primitive_name)
+
+    def replace_then_publish(source, destination, *args, **kwargs):
+        staged.unlink()
+        staged.write_bytes(b"unvalidated replacement")
+        return real_primitive(source, destination, *args, **kwargs)
+
+    with patch.object(_render_artifacts.os, primitive_name, side_effect=replace_then_publish):
+        with pytest.raises(ValueError, match="identity"):
+            _render_artifacts.publish_no_clobber(
+                staged,
+                final,
+                platform_name=platform_name,
+                expected_identity=expected_identity,
+            )
+    assert not final.exists()
+
+
 def test_cross_volume_identity_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     staged = tmp_path / "stage.exr"
     final = tmp_path / "final.exr"
@@ -441,6 +534,25 @@ def test_finalize_rejects_staged_drift_without_writing_final(tmp_path: Path) -> 
     assert not Path(artifacts[0]["final_path"]).exists()
 
 
+def test_finalize_rejects_drift_after_persisting_publish_intent_without_writing_final(tmp_path: Path) -> None:
+    job_id, _, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    real_write_status = _isolated_jobs.write_status
+
+    def write_status(path, payload):
+        real_write_status(path, payload)
+        transaction = payload.get("artifact_transaction", {})
+        if any(artifact.get("state") == "publishing" for artifact in transaction.get("artifacts", [])):
+            Path(artifacts[0]["staging_path"]).write_bytes(b"changed after publication intent")
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _isolated_jobs, "write_status", side_effect=write_status
+    ):
+        with pytest.raises(ValueError, match="identity"):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    assert not Path(artifacts[0]["final_path"]).exists()
+
+
 def test_finalize_collision_never_overwrites_final(tmp_path: Path) -> None:
     job_id, status_path, artifacts = _completed_job(tmp_path)
     receipt = _receipt(job_id, artifacts[0])
@@ -474,6 +586,92 @@ def test_finalize_preserves_committed_evidence_when_post_check_fails(tmp_path: P
     assert artifact["committed"] is True
     assert artifact["state"] == "commit_verification_failed"
     assert Path(artifact["final_path"]).is_file()
+
+
+def test_finalize_retry_recovers_transient_post_commit_failure(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _rop_jobs, "fsync_parent", side_effect=OSError("transient flush failure")
+    ):
+        with pytest.raises(OSError, match="transient flush failure"):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        recovered = _rop_jobs.finalize_render_outputs(job_id, [receipt])
+
+    assert recovered["transaction_state"] == "committed"
+    assert recovered["aggregate"]["complete"] is True
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    artifact = status["artifact_transaction"]["artifacts"][0]
+    assert artifact["state"] == "committed"
+    assert "post_commit_error" not in artifact
+
+
+def test_finalize_retry_recovers_transient_helper_post_check_failure(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    real_identity = _render_artifacts.stable_file_identity
+    failed = [False]
+
+    def transient_final_identity(path):
+        if not failed[0] and os.path.normcase(str(path)) == os.path.normcase(artifacts[0]["final_path"]):
+            failed[0] = True
+            raise OSError("transient helper post-check failure")
+        return real_identity(path)
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _render_artifacts, "stable_file_identity", side_effect=transient_final_identity
+    ):
+        with pytest.raises(OSError, match="transient helper post-check failure"):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    assert Path(artifacts[0]["final_path"]).is_file()
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        recovered = _rop_jobs.finalize_render_outputs(job_id, [receipt])
+
+    assert recovered["transaction_state"] == "committed"
+    assert recovered["aggregate"]["complete"] is True
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    artifact = status["artifact_transaction"]["artifacts"][0]
+    assert artifact["state"] == "committed"
+    assert "last_error" not in artifact
+
+
+def test_two_processes_finalize_different_frames_without_lost_status(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path, count=2)
+    receipts = [_receipt(job_id, artifact) for artifact in artifacts]
+    context = multiprocessing.get_context("spawn")
+    start_event = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_finalize_frame_in_process,
+            args=(tmp_path, job_id, receipt, start_event, result_queue),
+        )
+        for receipt in receipts
+    ]
+    for process in processes:
+        process.start()
+    start_event.set()
+    for process in processes:
+        process.join(20.0)
+    hung = [process for process in processes if process.is_alive()]
+    for process in hung:
+        process.terminate()
+        process.join(5.0)
+    assert not hung
+    assert [process.exitcode for process in processes] == [0, 0]
+    results = [result_queue.get(timeout=5.0) for _ in processes]
+    result_queue.close()
+    result_queue.join_thread()
+    assert [result[0] for result in results] == ["ok", "ok"]
+
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    transaction = status["artifact_transaction"]
+    assert [artifact["state"] for artifact in transaction["artifacts"]] == ["committed", "committed"]
+    assert transaction["aggregate"]["complete"] is True
+    assert all(Path(artifact["final_path"]).is_file() for artifact in transaction["artifacts"])
 
 
 def test_finalize_recovers_commit_before_status_update(tmp_path: Path) -> None:

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -1,0 +1,517 @@
+"""Pure tests for staged no-clobber render publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from skill_loader import skill_script_import_context
+
+from dcc_mcp_houdini import _isolated_jobs, _render_artifacts, _rop_jobs
+
+_SKILL_SCRIPTS = (
+    Path(__file__).resolve().parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-render" / "scripts"
+)
+_VALIDATOR = {
+    "id": "openexr-structure-gate",
+    "version": "1.0.0",
+    "implementation_sha256": "a" * 64,
+}
+
+
+def _load_script(name: str) -> ModuleType:
+    path = _SKILL_SCRIPTS / name
+    spec = importlib.util.spec_from_file_location("transaction_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+class _MutableParm:
+    def __init__(self, value: str):
+        self.value = value
+        self.set_calls = []
+
+    def unexpandedString(self) -> str:
+        return self.value
+
+    def set(self, value: str) -> None:
+        self.set_calls.append(value)
+        self.value = value
+
+
+def _run_transaction_worker(
+    tmp_path: Path,
+    frames=(1, 2),
+    produced=(1, 2),
+    render_error=None,
+    outputs=None,
+    rop_inputs=(),
+):
+    module = _load_script("_render_worker.py")
+    job_id = "1" * 32
+    final_pattern = str(tmp_path / "beauty.$F4.exr")
+    output_patterns = outputs or {"vm_picture": final_pattern}
+    parms = {name: _MutableParm(pattern) for name, pattern in output_patterns.items()}
+    rop = MagicMock()
+    rop.parm.side_effect = lambda name: parms.get(name)
+    rop.inputs.return_value = list(rop_inputs)
+    rop.errors.return_value = []
+
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = rop
+    mock_hou.text.expandStringAtFrame.side_effect = lambda pattern, frame: pattern.replace(
+        "$F4", "{:04d}".format(int(frame))
+    )
+    stdout = tmp_path / "stdout.log"
+    stderr = tmp_path / "stderr.log"
+    stdout.write_text("", encoding="utf-8")
+    stderr.write_text("", encoding="utf-8")
+    status_path = tmp_path / "status.json"
+    transaction = _render_artifacts.normalize_transaction_request({"mode": "staged_no_clobber"})
+    frame_range = [frames[0], frames[-1], 1]
+    transaction["requested_frames"] = _render_artifacts.integer_frames(frame_range)
+    status_path.write_text(
+        json.dumps(
+            {
+                "job_id": job_id,
+                "state": "queued",
+                "job_kind": "render",
+                "stdout_path": str(stdout),
+                "stderr_path": str(stderr),
+                "artifact_transaction": transaction,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def render(_rop, _frame_range):
+        for frame in produced:
+            staged = Path(mock_hou.text.expandStringAtFrame(parms["vm_picture"].value, frame))
+            staged.write_bytes("frame {}".format(frame).encode("ascii"))
+        if render_error:
+            raise RuntimeError(render_error)
+        return [float(frames[0]), float(frames[-1])], "render"
+
+    argv = [
+        "_render_worker.py",
+        "scene.hip",
+        "/out/mantra1",
+        json.dumps(frame_range),
+        str(status_path),
+        json.dumps(final_pattern),
+        json.dumps(False),
+    ]
+    with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(module.sys, "argv", argv), patch.object(
+        module, "render_node", side_effect=render
+    ):
+        module.main()
+    return json.loads(status_path.read_text(encoding="utf-8")), parms, mock_hou, final_pattern
+
+
+def _completed_job(tmp_path: Path, count: int = 1):
+    job_id = "2" * 32
+    artifacts = []
+    for frame in range(1, count + 1):
+        final_path = tmp_path / "beauty.{:04d}.exr".format(frame)
+        staged_path = tmp_path / "beauty.{:04d}.dcc-mcp-{}.partial.exr".format(frame, job_id)
+        staged_path.write_bytes("validated frame {}".format(frame).encode("ascii"))
+        artifacts.append(
+            {
+                "frame": frame,
+                "staging_path": str(staged_path),
+                "final_path": str(final_path),
+                "state": "staged",
+                "committed": False,
+            }
+        )
+    transaction = {
+        "mode": "staged_no_clobber",
+        "state": "staged",
+        "output_parm_name": "vm_picture",
+        "final_output_pattern": str(tmp_path / "beauty.$F4.exr"),
+        "staging_output_pattern": str(tmp_path / "beauty.$F4.partial.exr"),
+        "artifacts": artifacts,
+        "aggregate": _render_artifacts.aggregate_artifacts(artifacts),
+    }
+    job_dir = tmp_path / "dcc-mcp-houdini-render-jobs" / job_id
+    job_dir.mkdir(parents=True)
+    status_path = job_dir / "status.json"
+    status_path.write_text(
+        json.dumps({"job_id": job_id, "state": "completed", "artifact_transaction": transaction}),
+        encoding="utf-8",
+    )
+    return job_id, status_path, artifacts
+
+
+def _receipt(job_id: str, artifact: dict) -> dict:
+    identity = _render_artifacts.stable_file_identity(artifact["staging_path"])
+    return {
+        "accepted": True,
+        "job_id": job_id,
+        "frame": artifact["frame"],
+        "staging_path": artifact["staging_path"],
+        "final_path": artifact["final_path"],
+        **identity,
+        "validator": dict(_VALIDATOR),
+    }
+
+
+def test_transaction_request_and_frames_are_fail_closed() -> None:
+    assert _render_artifacts.integer_frames([3, 1, -1]) == [3, 2, 1]
+    with pytest.raises(ValueError, match="mode"):
+        _render_artifacts.normalize_transaction_request({"mode": "replace"})
+    with pytest.raises(ValueError, match="integral"):
+        _render_artifacts.integer_frames([1, 2.5, 1])
+
+
+def test_get_render_settings_prefers_outputimage_and_reports_exact_parm() -> None:
+    module = _load_script("get_render_settings.py")
+    outputimage = MagicMock()
+    outputimage.unexpandedString.return_value = "/tmp/beauty.$F4.exr"
+    outputimage.eval.return_value = "/tmp/beauty.0001.exr"
+    lopoutput = MagicMock()
+    lopoutput.unexpandedString.return_value = "/tmp/render.usd"
+    lopoutput.eval.return_value = "/tmp/render.usd"
+    rop = MagicMock()
+    rop.parm.side_effect = lambda name: {"outputimage": outputimage, "lopoutput": lopoutput}.get(name)
+    rop.parmTuple.return_value = None
+    rop.path.return_value = "/stage/karma"
+    rop.name.return_value = "karma"
+    rop.type.return_value.name.return_value = "usdrender_rop"
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = rop
+    mock_hou.frame.return_value = 1.0
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = module.get_render_settings("/stage/karma")["context"]
+    assert result["output_parm_name"] == "outputimage"
+    assert result["output_path_pattern"] == "/tmp/beauty.$F4.exr"
+
+
+def test_render_rop_opts_in_only_for_background(tmp_path: Path) -> None:
+    module = _load_script("render_rop.py")
+    output = MagicMock()
+    output.unexpandedString.return_value = str(tmp_path / "beauty.$F4.exr")
+    rop = MagicMock()
+    rop.parm.side_effect = lambda name: output if name == "vm_picture" else None
+    rop.parmTuple.return_value = None
+    rop.path.return_value = "/out/mantra1"
+    rop.name.return_value = "mantra1"
+    rop.type.return_value.name.return_value = "ifd"
+    mock_hou = MagicMock()
+    mock_hou.node.return_value = rop
+    request = {"mode": "staged_no_clobber"}
+    with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(
+        module,
+        "launch_background_render",
+        return_value={"job_id": "f" * 32, "state": "queued"},
+    ) as launch:
+        background = module.render_rop(
+            "/out/mantra1", frame_range=[1, 1, 1], background=True, artifact_transaction=request
+        )
+        foreground = module.render_rop(
+            "/out/mantra1", frame_range=[1, 1, 1], background=False, artifact_transaction=request
+        )
+    assert background["success"] is True
+    launch.assert_called_once_with(
+        mock_hou,
+        "/out/mantra1",
+        [1, 1, 1],
+        str(tmp_path / "beauty.$F4.exr"),
+        artifact_transaction=request,
+    )
+    assert foreground["success"] is False
+    rop.render.assert_not_called()
+
+
+def test_background_launch_persists_transaction_without_changing_worker_argv(tmp_path: Path) -> None:
+    module = _load_script("_background_render.py")
+    hip = tmp_path / "scene.hip"
+    hip.write_bytes(b"hip")
+    hython = tmp_path / ("hython.exe" if module.os.name == "nt" else "hython")
+    hython.write_bytes(b"exe")
+    mock_hou = MagicMock()
+    mock_hou.hipFile.path.return_value = str(hip)
+    mock_hou.hipFile.hasUnsavedChanges.return_value = False
+    mock_hou.isUIAvailable.return_value = True
+    process = MagicMock(pid=4321)
+    request = {"mode": "staged_no_clobber"}
+    with patch.object(module.sys, "executable", str(tmp_path / "houdini.exe")), patch.object(
+        module.tempfile, "gettempdir", return_value=str(tmp_path)
+    ), patch.object(module.subprocess, "Popen", return_value=process) as popen:
+        job = module.launch_background_render(
+            mock_hou,
+            "/out/mantra1",
+            [1, 2, 1],
+            str(tmp_path / "beauty.$F4.exr"),
+            artifact_transaction=request,
+        )
+    status_path = tmp_path / "dcc-mcp-houdini-render-jobs" / job["job_id"] / "status.json"
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status["artifact_transaction"]["state"] == "queued"
+    assert status["artifact_transaction"]["requested_frames"] == [1, 2]
+    command = popen.call_args.args[0]
+    assert len(command) == 8
+    assert json.loads(command[4]) == [1, 2, 1]
+    module._PROCESS_HANDLES.pop(job["job_id"], None)
+
+
+def test_worker_stages_in_memory_without_saving_or_writing_final(tmp_path: Path) -> None:
+    status, parms, mock_hou, final_pattern = _run_transaction_worker(tmp_path)
+    transaction = status["artifact_transaction"]
+    assert status["state"] == "completed"
+    assert transaction["state"] == "staged"
+    assert transaction["output_parm_name"] == "vm_picture"
+    assert transaction["aggregate"]["staged"] == 2
+    assert parms["vm_picture"].set_calls[0].endswith(".partial.exr")
+    assert parms["vm_picture"].set_calls[-1] == final_pattern
+    assert not list(tmp_path.glob("beauty.000?.exr"))
+    assert len(list(tmp_path.glob("*.partial.exr"))) == 2
+    mock_hou.hipFile.save.assert_not_called()
+
+
+def test_worker_rejects_multiple_primary_exr_outputs(tmp_path: Path) -> None:
+    status, _, _, _ = _run_transaction_worker(
+        tmp_path,
+        outputs={
+            "vm_picture": str(tmp_path / "beauty.$F4.exr"),
+            "outputimage": str(tmp_path / "second.$F4.exr"),
+        },
+    )
+    assert status["state"] == "failed"
+    assert status["artifact_transaction"]["state"] == "render_failed"
+    assert "exactly one" in status["error"]
+
+
+def test_worker_rejects_rop_input_chains(tmp_path: Path) -> None:
+    status, _, _, _ = _run_transaction_worker(tmp_path, rop_inputs=(object(),))
+    assert status["state"] == "failed"
+    assert status["artifact_transaction"]["state"] == "render_failed"
+    assert "input chains" in status["error"]
+    assert not list(tmp_path.glob("*.partial.exr"))
+
+
+@pytest.mark.parametrize("render_error", [None, "renderer crashed"])
+def test_worker_partial_or_error_never_publishes_final(tmp_path: Path, render_error: str) -> None:
+    status, _, _, _ = _run_transaction_worker(tmp_path, produced=(1,), render_error=render_error)
+    assert status["state"] == "failed"
+    assert status["artifact_transaction"]["state"] == "render_failed"
+    assert status["artifact_transaction"]["aggregate"]["failed"] == 2
+    assert not list(tmp_path.glob("beauty.000?.exr"))
+
+
+def test_cancel_updates_worker_and_transaction_states() -> None:
+    status = {
+        "state": "cancelling",
+        "artifact_transaction": {
+            "mode": "staged_no_clobber",
+            "state": "rendering",
+            "artifacts": [{"frame": 1, "state": "rendering", "committed": False}],
+        },
+    }
+    result = _isolated_jobs._finish_status(status, "cancelled", -1)
+    assert result["state"] == "cancelled"
+    assert result["artifact_transaction"]["state"] == "cancelled"
+    assert result["artifact_transaction"]["artifacts"][0]["state"] == "cancelled"
+
+
+def test_posix_publication_is_no_clobber_and_unlinks_stage(tmp_path: Path) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"first")
+    result = _render_artifacts.publish_no_clobber(staged, final, platform_name="posix")
+    assert result == {"committed": True, "cleanup_error": None}
+    assert final.read_bytes() == b"first"
+    assert not staged.exists()
+    replacement = tmp_path / "replacement.exr"
+    replacement.write_bytes(b"second")
+    with pytest.raises(FileExistsError):
+        _render_artifacts.publish_no_clobber(replacement, final, platform_name="posix")
+    assert final.read_bytes() == b"first"
+
+
+def test_concurrent_posix_publication_has_exactly_one_winner(tmp_path: Path) -> None:
+    final = tmp_path / "final.exr"
+    staged = [tmp_path / "a.exr", tmp_path / "b.exr"]
+    staged[0].write_bytes(b"a")
+    staged[1].write_bytes(b"b")
+
+    def publish(path: Path):
+        try:
+            _render_artifacts.publish_no_clobber(path, final, platform_name="posix")
+            return "committed"
+        except FileExistsError:
+            return "collision"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(publish, staged))
+    assert sorted(outcomes) == ["collision", "committed"]
+    assert final.read_bytes() in {b"a", b"b"}
+
+
+def test_windows_path_uses_rename_and_preserves_collision(tmp_path: Path) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"stage")
+    with patch.object(_render_artifacts.os, "rename", wraps=os.rename) as rename:
+        _render_artifacts.publish_no_clobber(staged, final, platform_name="nt")
+    rename.assert_called_once_with(str(staged), str(final))
+    collision = tmp_path / "collision.exr"
+    collision.write_bytes(b"new")
+    with pytest.raises(FileExistsError):
+        _render_artifacts.publish_no_clobber(collision, final, platform_name="nt")
+    assert final.read_bytes() == b"stage"
+
+
+def test_cross_volume_identity_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"stage")
+    real_lstat = _render_artifacts.os.lstat
+
+    def lstat(path):
+        result = real_lstat(path)
+        if os.path.normcase(str(path)) == os.path.normcase(str(staged)):
+            return SimpleNamespace(
+                st_dev=result.st_dev + 1,
+                st_ino=result.st_ino,
+                st_mode=result.st_mode,
+                st_size=result.st_size,
+                st_mtime_ns=result.st_mtime_ns,
+                st_file_attributes=0,
+            )
+        return result
+
+    monkeypatch.setattr(_render_artifacts.os, "lstat", lstat)
+    with pytest.raises(ValueError, match="same volume"):
+        _render_artifacts.assert_same_parent_and_volume(staged, final)
+
+
+def test_windows_reparse_output_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = tmp_path / "stage.exr"
+    output.write_bytes(b"stage")
+    real_lstat = _render_artifacts.os.lstat
+
+    def lstat(path):
+        result = real_lstat(path)
+        if os.path.normcase(str(path)) == os.path.normcase(str(output)):
+            return SimpleNamespace(st_mode=result.st_mode, st_file_attributes=0x400)
+        return result
+
+    monkeypatch.setattr(_render_artifacts.os, "lstat", lstat)
+    with pytest.raises(ValueError, match="reparse"):
+        _render_artifacts.assert_no_links_or_reparse(output)
+
+
+def test_finalize_binds_receipt_and_updates_aggregate(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        first = _rop_jobs.finalize_render_outputs(job_id, [receipt])
+        repeated = _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    assert first["aggregate"]["complete"] is True
+    assert repeated["finalized_frames"] == [1]
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    artifact = status["artifact_transaction"]["artifacts"][0]
+    assert artifact["committed"] is True
+    assert artifact["state"] == "committed"
+    assert artifact["validator_receipt"] == receipt
+    assert Path(artifact["final_path"]).read_bytes() == b"validated frame 1"
+
+
+def test_finalize_rejects_staged_drift_without_writing_final(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    Path(artifacts[0]["staging_path"]).write_bytes(b"changed after validation")
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        with pytest.raises(ValueError, match="receipt"):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status["artifact_transaction"]["artifacts"][0]["state"] == "drifted"
+    assert not Path(artifacts[0]["final_path"]).exists()
+
+
+def test_finalize_collision_never_overwrites_final(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    final = Path(artifacts[0]["final_path"])
+    final.write_bytes(b"artist-owned")
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        with pytest.raises(FileExistsError):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    assert final.read_bytes() == b"artist-owned"
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status["artifact_transaction"]["artifacts"][0]["state"] == "collision"
+
+
+def test_finalize_preserves_committed_evidence_when_post_check_fails(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    real_identity = _rop_jobs.stable_file_identity
+
+    def identity(path):
+        if os.path.normcase(str(path)) == os.path.normcase(artifacts[0]["final_path"]):
+            raise OSError("post-commit verification unavailable")
+        return real_identity(path)
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _rop_jobs, "stable_file_identity", side_effect=identity
+    ):
+        with pytest.raises(OSError, match="post-commit"):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    artifact = status["artifact_transaction"]["artifacts"][0]
+    assert artifact["committed"] is True
+    assert artifact["state"] == "commit_verification_failed"
+    assert Path(artifact["final_path"]).is_file()
+
+
+def test_finalize_recovers_commit_before_status_update(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    artifact = status["artifact_transaction"]["artifacts"][0]
+    artifact.update({"state": "publishing", "validator_receipt": receipt})
+    os.rename(artifact["staging_path"], artifact["final_path"])
+    status_path.write_text(json.dumps(status), encoding="utf-8")
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        result = _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    assert result["aggregate"]["complete"] is True
+    recovered = json.loads(status_path.read_text(encoding="utf-8"))["artifact_transaction"]["artifacts"][0]
+    assert recovered["committed"] is True
+    assert recovered["state"] == "committed"
+    assert "recovered_at" in recovered
+
+
+def test_aggregate_revalidates_previous_final_before_next_commit(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path, count=2)
+    first_receipt = _receipt(job_id, artifacts[0])
+    second_receipt = _receipt(job_id, artifacts[1])
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        _rop_jobs.finalize_render_outputs(job_id, [first_receipt])
+        Path(artifacts[0]["final_path"]).write_bytes(b"drifted final")
+        with pytest.raises(ValueError, match="drifted"):
+            _rop_jobs.finalize_render_outputs(job_id, [second_receipt])
+    assert not Path(artifacts[1]["final_path"]).exists()
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status["artifact_transaction"]["aggregate"]["state"] == "blocked"
+
+
+def test_get_render_job_bounds_transaction_details(tmp_path: Path) -> None:
+    job_id, _, artifacts = _completed_job(tmp_path)
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        summary = _rop_jobs.read_render_job(job_id)
+        details = _rop_jobs.read_render_job(job_id, include_details=True)
+    assert "artifacts" not in summary["artifact_transaction"]
+    assert summary["artifact_transaction"]["aggregate"]["total"] == 1
+    assert details["artifact_transaction"]["artifacts"][0]["frame"] == artifacts[0]["frame"]

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -7,8 +7,9 @@ import json
 import multiprocessing
 import os
 import sys
+import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -121,12 +122,11 @@ def _run_transaction_worker(
     return json.loads(status_path.read_text(encoding="utf-8")), parms, mock_hou, final_pattern
 
 
-def _completed_job(tmp_path: Path, count: int = 1):
-    job_id = "2" * 32
+def _completed_job(tmp_path: Path, count: int = 1, job_id: str = "2" * 32, stem: str = "beauty"):
     artifacts = []
     for frame in range(1, count + 1):
-        final_path = tmp_path / "beauty.{:04d}.exr".format(frame)
-        staged_path = tmp_path / "beauty.{:04d}.dcc-mcp-{}.partial.exr".format(frame, job_id)
+        final_path = tmp_path / "{}.{:04d}.exr".format(stem, frame)
+        staged_path = tmp_path / "{}.{:04d}.dcc-mcp-{}.partial.exr".format(stem, frame, job_id)
         staged_path.write_bytes("validated frame {}".format(frame).encode("ascii"))
         artifacts.append(
             {
@@ -141,8 +141,8 @@ def _completed_job(tmp_path: Path, count: int = 1):
         "mode": "staged_no_clobber",
         "state": "staged",
         "output_parm_name": "vm_picture",
-        "final_output_pattern": str(tmp_path / "beauty.$F4.exr"),
-        "staging_output_pattern": str(tmp_path / "beauty.$F4.partial.exr"),
+        "final_output_pattern": str(tmp_path / "{}.$F4.exr".format(stem)),
+        "staging_output_pattern": str(tmp_path / "{}.$F4.partial.exr".format(stem)),
         "artifacts": artifacts,
         "aggregate": _render_artifacts.aggregate_artifacts(artifacts),
     }
@@ -174,6 +174,21 @@ def _finalize_frame_in_process(tmp_root, job_id, receipt, start_event, result_qu
             result_queue.put(("ok", _rop_jobs.finalize_render_outputs(job_id, [receipt])))
     except Exception as exc:  # noqa: BLE001
         result_queue.put(("error", type(exc).__name__, str(exc)))
+
+
+def _block_first_staging_identity(receipt, entered, release):
+    real_identity = _rop_jobs.stable_file_identity
+    blocked = [False]
+
+    def identity(path):
+        if not blocked[0] and os.path.normcase(str(path)) == os.path.normcase(receipt["staging_path"]):
+            blocked[0] = True
+            entered.set()
+            if not release.wait(5.0):
+                raise TimeoutError("test did not release slow identity")
+        return real_identity(path)
+
+    return identity
 
 
 def _receipt(job_id: str, artifact: dict) -> dict:
@@ -235,6 +250,56 @@ def test_job_transaction_lock_times_out_and_remains_available(tmp_path: Path) ->
                 pass
     with _rop_jobs._artifact_transaction_lock(status_path):
         pass
+
+
+def test_slow_finalize_does_not_block_other_job_read_or_cancel(tmp_path: Path) -> None:
+    job_a, _, artifacts_a = _completed_job(tmp_path, job_id="2" * 32, stem="job_a")
+    job_b, _, _ = _completed_job(tmp_path, job_id="3" * 32, stem="job_b")
+    receipt = _receipt(job_a, artifacts_a[0])
+    entered = threading.Event()
+    release = threading.Event()
+    slow_identity = _block_first_staging_identity(receipt, entered, release)
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _rop_jobs, "stable_file_identity", side_effect=slow_identity
+    ), ThreadPoolExecutor(max_workers=3) as pool:
+        finalize_future = pool.submit(_rop_jobs.finalize_render_outputs, job_a, [receipt])
+        try:
+            assert entered.wait(5.0)
+            read_future = pool.submit(_rop_jobs.read_render_job, job_b)
+            cancel_future = pool.submit(_rop_jobs.cancel_render_job, job_b)
+            _, blocked = wait([read_future, cancel_future], timeout=1.0)
+        finally:
+            release.set()
+        finalize_future.result(timeout=5.0)
+        assert not blocked
+        assert read_future.result(timeout=1.0)["job_id"] == job_b
+        assert cancel_future.result(timeout=1.0)["cancel_requested"] is False
+
+
+def test_second_same_job_finalizer_observes_file_lock_timeout(tmp_path: Path) -> None:
+    job_id, _, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    entered = threading.Event()
+    release = threading.Event()
+    slow_identity = _block_first_staging_identity(receipt, entered, release)
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _rop_jobs, "_ARTIFACT_LOCK_TIMEOUT_SECONDS", 0.2
+    ), patch.object(_rop_jobs, "stable_file_identity", side_effect=slow_identity), ThreadPoolExecutor(
+        max_workers=2
+    ) as pool:
+        first = pool.submit(_rop_jobs.finalize_render_outputs, job_id, [receipt])
+        try:
+            assert entered.wait(5.0)
+            second = pool.submit(_rop_jobs.finalize_render_outputs, job_id, [receipt])
+            _, blocked = wait([second], timeout=1.0)
+        finally:
+            release.set()
+        first.result(timeout=5.0)
+        assert not blocked
+        with pytest.raises(TimeoutError, match="artifact transaction lock"):
+            second.result(timeout=1.0)
 
 
 def test_get_render_settings_prefers_outputimage_and_reports_exact_parm() -> None:

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -229,6 +229,87 @@ def test_integer_frames_rejects_above_limit_before_expansion() -> None:
             _render_artifacts.integer_frames([1, 10**1000])
 
 
+def test_windows_status_read_retries_permission_errors(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    status_path.write_text(json.dumps({"state": "completed"}), encoding="utf-8")
+    real_read_text = Path.read_text
+    attempts = [0]
+
+    def flaky_read_text(path, *args, **kwargs):
+        attempts[0] += 1
+        if attempts[0] < 3:
+            raise PermissionError("status reader temporarily blocked")
+        return real_read_text(path, *args, **kwargs)
+
+    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(
+        _isolated_jobs, "_STATUS_IO_POLL_SECONDS", 0.0
+    ), patch.object(Path, "read_text", autospec=True, side_effect=flaky_read_text):
+        assert _isolated_jobs._read_status(status_path) == {"state": "completed"}
+    assert attempts[0] == 3
+
+
+def test_windows_status_replace_retries_and_preserves_atomic_document(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    status_path.write_text(json.dumps({"state": "old"}), encoding="utf-8")
+    real_replace = os.replace
+    attempts = [0]
+
+    def flaky_replace(source, destination):
+        attempts[0] += 1
+        if attempts[0] < 3:
+            assert json.loads(status_path.read_text(encoding="utf-8")) == {"state": "old"}
+            raise PermissionError("status destination temporarily open")
+        return real_replace(source, destination)
+
+    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(
+        _isolated_jobs, "_STATUS_IO_POLL_SECONDS", 0.0
+    ), patch.object(_isolated_jobs.os, "replace", side_effect=flaky_replace):
+        _isolated_jobs.write_status(status_path, {"state": "new"})
+    assert attempts[0] == 3
+    assert json.loads(status_path.read_text(encoding="utf-8")) == {"state": "new"}
+    assert not list(tmp_path.glob("status.json.*.tmp"))
+
+
+def test_windows_status_replace_timeout_preserves_old_document_and_cleans_pending(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    status_path.write_text(json.dumps({"state": "old"}), encoding="utf-8")
+    blocked = PermissionError("status destination stayed open")
+
+    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(
+        _isolated_jobs, "_STATUS_IO_TIMEOUT_SECONDS", 0.0
+    ), patch.object(_isolated_jobs.os, "replace", side_effect=blocked):
+        with pytest.raises(TimeoutError, match="status file") as captured:
+            _isolated_jobs.write_status(status_path, {"state": "new"})
+    assert captured.value.__cause__ is blocked
+    assert json.loads(status_path.read_text(encoding="utf-8")) == {"state": "old"}
+    assert not list(tmp_path.glob("status.json.*.tmp"))
+
+
+def test_status_replace_non_permission_error_is_preserved_and_pending_is_cleaned(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    status_path.write_text(json.dumps({"state": "old"}), encoding="utf-8")
+    failure = OSError("status disk failure")
+
+    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(_isolated_jobs.os, "replace", side_effect=failure):
+        with pytest.raises(OSError, match="status disk failure") as captured:
+            _isolated_jobs.write_status(status_path, {"state": "new"})
+    assert captured.value is failure
+    assert json.loads(status_path.read_text(encoding="utf-8")) == {"state": "old"}
+    assert not list(tmp_path.glob("status.json.*.tmp"))
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "error"),
+    [("posix", PermissionError("permission denied")), ("nt", OSError("disk failure"))],
+)
+def test_status_io_does_not_retry_out_of_scope_errors(platform_name: str, error: OSError) -> None:
+    operation = MagicMock(side_effect=error)
+    with patch.object(_isolated_jobs.os, "name", platform_name):
+        with pytest.raises(type(error), match=str(error)):
+            _isolated_jobs._retry_windows_status_io(operation, "testing status file")
+    operation.assert_called_once_with()
+
+
 def test_job_transaction_lock_releases_after_exception(tmp_path: Path) -> None:
     status_path = tmp_path / "job" / "status.json"
     status_path.parent.mkdir()
@@ -300,6 +381,49 @@ def test_second_same_job_finalizer_observes_file_lock_timeout(tmp_path: Path) ->
         assert not blocked
         with pytest.raises(TimeoutError, match="artifact transaction lock"):
             second.result(timeout=1.0)
+
+
+def test_finalize_and_high_frequency_poll_share_atomic_status_file(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path, count=20)
+    receipts = [_receipt(job_id, artifact) for artifact in artifacts]
+    poller_count = 4
+    start = threading.Barrier(poller_count + 1)
+    stop = threading.Event()
+    poll_errors = []
+    poll_count = [0]
+
+    def poll_status():
+        start.wait(timeout=5.0)
+        while not stop.is_set():
+            try:
+                result = _rop_jobs.read_render_job(job_id, include_details=True)
+                transaction = result["artifact_transaction"]
+                assert len(transaction["artifacts"]) == 20
+                assert len({artifact["frame"] for artifact in transaction["artifacts"]}) == 20
+                assert transaction["aggregate"]["total"] == 20
+                poll_count[0] += 1
+            except Exception as exc:  # noqa: BLE001
+                poll_errors.append(exc)
+                stop.set()
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), ThreadPoolExecutor(
+        max_workers=poller_count
+    ) as pool:
+        pollers = [pool.submit(poll_status) for _ in range(poller_count)]
+        start.wait(timeout=5.0)
+        try:
+            finalized = _rop_jobs.finalize_render_outputs(job_id, receipts)
+        finally:
+            stop.set()
+            for poller in pollers:
+                poller.result(timeout=5.0)
+
+    assert not poll_errors
+    assert poll_count[0] > 0
+    assert finalized["aggregate"]["complete"] is True
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status["artifact_transaction"]["aggregate"]["complete"] is True
+    assert {artifact["state"] for artifact in status["artifact_transaction"]["artifacts"]} == {"committed"}
 
 
 def test_get_render_settings_prefers_outputimage_and_reports_exact_parm() -> None:

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -11,7 +11,6 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
-from contextlib import nullcontext
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -62,7 +61,6 @@ def _run_transaction_worker(
     render_error=None,
     outputs=None,
     rop_inputs=(),
-    worker_replace=None,
 ):
     module = _load_script("_render_worker.py")
     job_id = "1" * 32
@@ -118,12 +116,9 @@ def _run_transaction_worker(
         json.dumps(final_pattern),
         json.dumps(False),
     ]
-    replace_context = (
-        patch.object(module.os, "replace", side_effect=worker_replace) if worker_replace else nullcontext()
-    )
     with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(module.sys, "argv", argv), patch.object(
         module, "render_node", side_effect=render
-    ), replace_context:
+    ):
         module.main()
     return json.loads(status_path.read_text(encoding="utf-8")), parms, mock_hou, final_pattern
 
@@ -527,7 +522,9 @@ def test_worker_retries_transient_initial_status_write_before_render_try(tmp_pat
             raise PermissionError("initial worker status destination temporarily open")
         return real_replace(source, destination)
 
-    status, _, _, _ = _run_transaction_worker(tmp_path, worker_replace=transient_replace)
+    status_os = SimpleNamespace(name="nt", replace=MagicMock(side_effect=transient_replace))
+    with patch.object(_status_io, "os", status_os):
+        status, _, _, _ = _run_transaction_worker(tmp_path)
 
     assert status["state"] == "completed"
     assert attempts[0] >= 2
@@ -799,6 +796,86 @@ def test_publication_identity_mismatch_never_deletes_unowned_final(
     assert _render_artifacts.stable_file_identity(final)["sha256"] == unrelated_sha256
 
 
+@pytest.mark.parametrize(
+    ("platform_name", "primitive_name"),
+    [("nt", "rename"), ("posix", "link")],
+)
+@pytest.mark.parametrize(
+    "validation_error",
+    [
+        FileNotFoundError("published final disappeared before validation"),
+        ValueError("published final became non-regular"),
+        OSError("published final validation unavailable"),
+    ],
+)
+def test_post_publication_validation_exception_reports_ambiguous_ownership(
+    tmp_path: Path,
+    platform_name: str,
+    primitive_name: str,
+    validation_error: Exception,
+) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"validated frame")
+    expected_identity = _render_artifacts.stable_file_identity(staged)
+    real_identity = _render_artifacts.stable_file_identity
+
+    def fail_final_validation(path):
+        if os.path.normcase(str(path)) == os.path.normcase(str(final)):
+            raise validation_error
+        return real_identity(path)
+
+    with patch.object(_render_artifacts, "stable_file_identity", side_effect=fail_final_validation):
+        with pytest.raises(_render_artifacts.PublicationIdentityMismatchError) as captured:
+            _render_artifacts.publish_no_clobber(
+                staged,
+                final,
+                platform_name=platform_name,
+                expected_identity=expected_identity,
+            )
+
+    assert captured.value.__cause__ is validation_error
+    assert final.read_bytes() == b"validated frame"
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "primitive_name"),
+    [("nt", "rename"), ("posix", "link")],
+)
+def test_post_publication_nonregular_replacement_is_never_removed(
+    tmp_path: Path,
+    platform_name: str,
+    primitive_name: str,
+) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"validated frame")
+    expected_identity = _render_artifacts.stable_file_identity(staged)
+    real_primitive = getattr(os, primitive_name)
+
+    def publish_then_replace_with_directory(source, destination, *args, **kwargs):
+        result = real_primitive(source, destination, *args, **kwargs)
+        final.unlink()
+        final.mkdir()
+        return result
+
+    with patch.object(
+        _render_artifacts.os,
+        primitive_name,
+        side_effect=publish_then_replace_with_directory,
+    ):
+        with pytest.raises(_render_artifacts.PublicationIdentityMismatchError) as captured:
+            _render_artifacts.publish_no_clobber(
+                staged,
+                final,
+                platform_name=platform_name,
+                expected_identity=expected_identity,
+            )
+
+    assert isinstance(captured.value.__cause__, ValueError)
+    assert final.is_dir()
+
+
 def test_finalize_persists_ambiguous_publication_as_attention_required(tmp_path: Path) -> None:
     job_id, status_path, artifacts = _completed_job(tmp_path)
     receipt = _receipt(job_id, artifacts[0])
@@ -987,9 +1064,16 @@ def test_finalize_retry_recovers_transient_helper_post_check_failure(tmp_path: P
     with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
         _render_artifacts, "stable_file_identity", side_effect=transient_final_identity
     ):
-        with pytest.raises(OSError, match="transient helper post-check failure"):
+        with pytest.raises(_render_artifacts.PublicationIdentityMismatchError) as captured:
             _rop_jobs.finalize_render_outputs(job_id, [receipt])
+    assert isinstance(captured.value.__cause__, OSError)
+    assert "transient helper post-check failure" in str(captured.value.__cause__)
     assert Path(artifacts[0]["final_path"]).is_file()
+    failed_status = json.loads(status_path.read_text(encoding="utf-8"))
+    failed_artifact = failed_status["artifact_transaction"]["artifacts"][0]
+    assert failed_artifact["state"] == "attention_required"
+    assert failed_artifact["committed"] is True
+    assert failed_status["artifact_transaction"]["aggregate"]["state"] == "blocked"
 
     with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
         recovered = _rop_jobs.finalize_render_outputs(job_id, [receipt])

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import multiprocessing
@@ -10,6 +11,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
+from contextlib import nullcontext
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -17,7 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from skill_loader import skill_script_import_context
 
-from dcc_mcp_houdini import _isolated_jobs, _render_artifacts, _rop_jobs
+from dcc_mcp_houdini import _isolated_jobs, _render_artifacts, _rop_jobs, _status_io
 
 _SKILL_SCRIPTS = (
     Path(__file__).resolve().parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-render" / "scripts"
@@ -60,6 +62,7 @@ def _run_transaction_worker(
     render_error=None,
     outputs=None,
     rop_inputs=(),
+    worker_replace=None,
 ):
     module = _load_script("_render_worker.py")
     job_id = "1" * 32
@@ -115,9 +118,12 @@ def _run_transaction_worker(
         json.dumps(final_pattern),
         json.dumps(False),
     ]
+    replace_context = (
+        patch.object(module.os, "replace", side_effect=worker_replace) if worker_replace else nullcontext()
+    )
     with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(module.sys, "argv", argv), patch.object(
         module, "render_node", side_effect=render
-    ):
+    ), replace_context:
         module.main()
     return json.loads(status_path.read_text(encoding="utf-8")), parms, mock_hou, final_pattern
 
@@ -241,8 +247,8 @@ def test_windows_status_read_retries_permission_errors(tmp_path: Path) -> None:
             raise PermissionError("status reader temporarily blocked")
         return real_read_text(path, *args, **kwargs)
 
-    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(
-        _isolated_jobs, "_STATUS_IO_POLL_SECONDS", 0.0
+    with patch.object(_status_io.os, "name", "nt"), patch.object(
+        _status_io, "_STATUS_IO_POLL_SECONDS", 0.0
     ), patch.object(Path, "read_text", autospec=True, side_effect=flaky_read_text):
         assert _isolated_jobs._read_status(status_path) == {"state": "completed"}
     assert attempts[0] == 3
@@ -261,9 +267,9 @@ def test_windows_status_replace_retries_and_preserves_atomic_document(tmp_path: 
             raise PermissionError("status destination temporarily open")
         return real_replace(source, destination)
 
-    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(
-        _isolated_jobs, "_STATUS_IO_POLL_SECONDS", 0.0
-    ), patch.object(_isolated_jobs.os, "replace", side_effect=flaky_replace):
+    with patch.object(_status_io.os, "name", "nt"), patch.object(
+        _status_io, "_STATUS_IO_POLL_SECONDS", 0.0
+    ), patch.object(_status_io.os, "replace", side_effect=flaky_replace):
         _isolated_jobs.write_status(status_path, {"state": "new"})
     assert attempts[0] == 3
     assert json.loads(status_path.read_text(encoding="utf-8")) == {"state": "new"}
@@ -275,9 +281,9 @@ def test_windows_status_replace_timeout_preserves_old_document_and_cleans_pendin
     status_path.write_text(json.dumps({"state": "old"}), encoding="utf-8")
     blocked = PermissionError("status destination stayed open")
 
-    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(
-        _isolated_jobs, "_STATUS_IO_TIMEOUT_SECONDS", 0.0
-    ), patch.object(_isolated_jobs.os, "replace", side_effect=blocked):
+    with patch.object(_status_io.os, "name", "nt"), patch.object(
+        _status_io, "_STATUS_IO_TIMEOUT_SECONDS", 0.0
+    ), patch.object(_status_io.os, "replace", side_effect=blocked):
         with pytest.raises(TimeoutError, match="status file") as captured:
             _isolated_jobs.write_status(status_path, {"state": "new"})
     assert captured.value.__cause__ is blocked
@@ -290,7 +296,7 @@ def test_status_replace_non_permission_error_is_preserved_and_pending_is_cleaned
     status_path.write_text(json.dumps({"state": "old"}), encoding="utf-8")
     failure = OSError("status disk failure")
 
-    with patch.object(_isolated_jobs.os, "name", "nt"), patch.object(_isolated_jobs.os, "replace", side_effect=failure):
+    with patch.object(_status_io.os, "name", "nt"), patch.object(_status_io.os, "replace", side_effect=failure):
         with pytest.raises(OSError, match="status disk failure") as captured:
             _isolated_jobs.write_status(status_path, {"state": "new"})
     assert captured.value is failure
@@ -304,9 +310,9 @@ def test_status_replace_non_permission_error_is_preserved_and_pending_is_cleaned
 )
 def test_status_io_does_not_retry_out_of_scope_errors(platform_name: str, error: OSError) -> None:
     operation = MagicMock(side_effect=error)
-    with patch.object(_isolated_jobs.os, "name", platform_name):
+    with patch.object(_status_io.os, "name", platform_name):
         with pytest.raises(type(error), match=str(error)):
-            _isolated_jobs._retry_windows_status_io(operation, "testing status file")
+            _status_io._retry_windows_status_io(operation, "testing status file")
     operation.assert_called_once_with()
 
 
@@ -424,6 +430,108 @@ def test_finalize_and_high_frequency_poll_share_atomic_status_file(tmp_path: Pat
     status = json.loads(status_path.read_text(encoding="utf-8"))
     assert status["artifact_transaction"]["aggregate"]["complete"] is True
     assert {artifact["state"] for artifact in status["artifact_transaction"]["artifacts"]} == {"committed"}
+
+
+def test_worker_status_writes_survive_four_high_frequency_adapter_pollers(tmp_path: Path) -> None:
+    worker = _load_script("_render_worker.py")
+    status_path = tmp_path / "status.json"
+    artifacts = [
+        {
+            "frame": frame,
+            "state": "rendering",
+            "staging_path": str(tmp_path / "beauty.{:04d}.partial.exr".format(frame)),
+            "final_path": str(tmp_path / "beauty.{:04d}.exr".format(frame)),
+        }
+        for frame in range(1, 21)
+    ]
+    payload = {"state": "running", "sequence": -1, "artifact_transaction": {"artifacts": artifacts}}
+    status_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    poller_count = 4
+    rounds = 10
+    opened = [threading.Event() for _ in range(rounds)]
+    release = [threading.Event() for _ in range(rounds)]
+    opened_counts = [0] * rounds
+    counter_lock = threading.Lock()
+    poller_round = threading.local()
+    read_errors = []
+    write_errors = []
+    completed_while_readers_held = []
+    real_read_text = Path.read_text
+
+    def hold_status_read(path, *args, **kwargs):
+        round_index = getattr(poller_round, "index", None)
+        if round_index is None or Path(path) != status_path:
+            return real_read_text(path, *args, **kwargs)
+        with Path(path).open(
+            mode="r",
+            encoding=kwargs.get("encoding"),
+            errors=kwargs.get("errors"),
+        ) as stream:
+            document = stream.read()
+            with counter_lock:
+                opened_counts[round_index] += 1
+                if opened_counts[round_index] == poller_count:
+                    opened[round_index].set()
+            assert release[round_index].wait(timeout=5.0)
+            return document
+
+    def poll_once(round_index):
+        poller_round.index = round_index
+        try:
+            observed = _isolated_jobs._read_status(status_path)
+            assert isinstance(observed["sequence"], int)
+            assert len(observed["artifact_transaction"]["artifacts"]) == 20
+        except Exception as exc:  # noqa: BLE001
+            read_errors.append(exc)
+        finally:
+            del poller_round.index
+
+    with patch.object(Path, "read_text", autospec=True, side_effect=hold_status_read), ThreadPoolExecutor(
+        max_workers=poller_count + 1
+    ) as pool:
+        for sequence in range(rounds):
+            pollers = [pool.submit(poll_once, sequence) for _ in range(poller_count)]
+            assert opened[sequence].wait(timeout=5.0)
+            next_payload = dict(payload)
+            next_payload["sequence"] = sequence
+            writer = pool.submit(worker.write_status, status_path, next_payload)
+            time.sleep(0.02)
+            completed_while_readers_held.append(writer.done())
+            release[sequence].set()
+            for poller in pollers:
+                poller.result(timeout=5.0)
+            try:
+                writer.result(timeout=5.0)
+            except PermissionError as exc:
+                write_errors.append(exc)
+
+    pending = list(tmp_path.glob("status.json.*.tmp"))
+    assert not read_errors
+    assert not write_errors, {
+        "write_error_count": len(write_errors),
+        "pending_status_files": [path.name for path in pending],
+    }
+    if os.name == "nt":
+        assert completed_while_readers_held == [False] * rounds
+    assert _isolated_jobs._read_status(status_path)["sequence"] == rounds - 1
+    assert not pending
+
+
+def test_worker_retries_transient_initial_status_write_before_render_try(tmp_path: Path) -> None:
+    real_replace = os.replace
+    attempts = [0]
+
+    def transient_replace(source, destination):
+        attempts[0] += 1
+        if attempts[0] == 1:
+            raise PermissionError("initial worker status destination temporarily open")
+        return real_replace(source, destination)
+
+    status, _, _, _ = _run_transaction_worker(tmp_path, worker_replace=transient_replace)
+
+    assert status["state"] == "completed"
+    assert attempts[0] >= 2
+    assert not list(tmp_path.glob("status.json.*.tmp"))
 
 
 def test_get_render_settings_prefers_outputimage_and_reports_exact_parm() -> None:
@@ -628,7 +736,7 @@ def test_windows_path_uses_rename_and_preserves_collision(tmp_path: Path) -> Non
     ("platform_name", "primitive_name"),
     [("nt", "rename"), ("posix", "link")],
 )
-def test_publication_never_commits_source_replaced_after_expected_identity_check(
+def test_publication_preserves_ambiguous_final_when_source_changes_after_identity_check(
     tmp_path: Path,
     platform_name: str,
     primitive_name: str,
@@ -652,7 +760,74 @@ def test_publication_never_commits_source_replaced_after_expected_identity_check
                 platform_name=platform_name,
                 expected_identity=expected_identity,
             )
-    assert not final.exists()
+    assert final.read_bytes() == b"unvalidated replacement"
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "primitive_name"),
+    [("nt", "rename"), ("posix", "link")],
+)
+def test_publication_identity_mismatch_never_deletes_unowned_final(
+    tmp_path: Path,
+    platform_name: str,
+    primitive_name: str,
+) -> None:
+    staged = tmp_path / "stage.exr"
+    final = tmp_path / "final.exr"
+    staged.write_bytes(b"validated frame")
+    expected_identity = _render_artifacts.stable_file_identity(staged)
+    unrelated_bytes = b"artist replacement after publication"
+    unrelated_sha256 = hashlib.sha256(unrelated_bytes).hexdigest()
+    real_primitive = getattr(os, primitive_name)
+
+    def publish_then_replace(source, destination, *args, **kwargs):
+        result = real_primitive(source, destination, *args, **kwargs)
+        final.unlink()
+        final.write_bytes(unrelated_bytes)
+        return result
+
+    with patch.object(_render_artifacts.os, primitive_name, side_effect=publish_then_replace):
+        with pytest.raises(ValueError, match="identity"):
+            _render_artifacts.publish_no_clobber(
+                staged,
+                final,
+                platform_name=platform_name,
+                expected_identity=expected_identity,
+            )
+
+    assert final.read_bytes() == unrelated_bytes
+    assert _render_artifacts.stable_file_identity(final)["sha256"] == unrelated_sha256
+
+
+def test_finalize_persists_ambiguous_publication_as_attention_required(tmp_path: Path) -> None:
+    job_id, status_path, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    final = Path(artifacts[0]["final_path"])
+    unrelated_bytes = b"unowned replacement after publication"
+    unrelated_sha256 = hashlib.sha256(unrelated_bytes).hexdigest()
+    primitive_name = "rename" if os.name == "nt" else "link"
+    real_primitive = getattr(os, primitive_name)
+
+    def publish_then_replace(source, destination, *args, **kwargs):
+        result = real_primitive(source, destination, *args, **kwargs)
+        final.unlink()
+        final.write_bytes(unrelated_bytes)
+        return result
+
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)), patch.object(
+        _render_artifacts.os, primitive_name, side_effect=publish_then_replace
+    ):
+        with pytest.raises(ValueError, match="identity"):
+            _rop_jobs.finalize_render_outputs(job_id, [receipt])
+
+    assert final.read_bytes() == unrelated_bytes
+    assert _render_artifacts.stable_file_identity(final)["sha256"] == unrelated_sha256
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    transaction = status["artifact_transaction"]
+    artifact = transaction["artifacts"][0]
+    assert artifact["state"] == "attention_required"
+    assert artifact["committed"] is True
+    assert transaction["aggregate"]["state"] == "blocked"
 
 
 def test_cross_volume_identity_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add an opt-in `staged_no_clobber` artifact transaction for isolated background ROP renders while preserving the legacy render path
- bind external validation receipts to exact staged EXR identities, publish with native no-clobber semantics, and persist per-frame plus aggregate evidence
- share one pure atomic status I/O contract between the adapter and isolated worker, including bounded Windows sharing-violation retries
- serialize same-job finalization across processes without blocking reads, cancellation, or unrelated jobs
- report the exact render output parameter and prefer `outputimage` before `lopoutput`

## Safety contract

- final output parameters are discovered from the worker-loaded ROP and overridden only in worker memory
- source HIP files are never saved by the transaction path
- foreground renders, ROP input chains, non-integral or oversized ranges, multiple primary EXRs, links or reparse points, cross-volume paths, collisions, and identity drift fail closed
- Windows publication uses rename; POSIX publication uses hard-link plus unlink; neither path falls back to replacement
- ambiguous post-publication identities never delete the canonical final and are persisted as blocked, attention-required evidence
- status documents expose only a complete old or new JSON document; temporary files are unique and cleaned on failure

## Validation

- 54 focused artifact-transaction tests
- 645 repository tests passed with 1 skip and 3 intentional deselections
- repeated Windows worker/finalizer polling races, same-job timeouts, different-job liveness, and cross-process status updates
- replacement, disappearance, non-regular output, and validation-error matrices for both publication primitives
- Ruff check and format check
- Python 3.7 syntax check
- skill metadata validation with 31 skills, 0 errors, 0 warnings
- wheel, sdist, quickinstall, and packaged-file inspection
- full GitHub CI matrix and Houdini Docker smoke