### PR TITLE
feat: convert viewport flipbook to bounded frame chunks

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_flipbook_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_flipbook_chunked.py
@@ -1,0 +1,542 @@
+"""Chunked flipbook runner — bounded frame-by-frame viewport capture.
+
+Wraps the core ChunkedRunner contract so that each frame is a single
+bounded step: one ``viewer.flipbook()`` call per frame with per-frame
+settings. This gives the host event-loop a checkpoint between frames,
+making cancellation observable, progress monotonic, and the terminal
+outcome publishable exactly once.
+"""
+
+from __future__ import annotations
+
+# Import built-in modules
+import glob
+import os
+import time
+import uuid
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+
+# Import third-party modules
+# (hou is imported lazily inside functions that need it)
+
+# Import dcc_mcp_core modules
+from dcc_mcp_core.cancellation import CancelledError
+from dcc_mcp_core.cancellation import CancelToken
+
+# ---------------------------------------------------------------------------
+# Embedded ChunkedRunner (PIP-2788, pending next dcc-mcp-core release).
+# Once the release ships this block can be replaced by:
+#   from dcc_mcp_core.chunked_runner import ChunkedRunner, ChunkedStep, ChunkedProgress, ChunkedOutcome
+# ---------------------------------------------------------------------------
+
+class ChunkedStep:
+    """One bounded unit of work executed on the main/affinity thread."""
+
+    __slots__ = ("fn", "step")
+
+    def __init__(self, step: int, fn: Callable[[], Any]) -> None:
+        self.step = step
+        self.fn = fn
+
+
+class ChunkedProgress:
+    """Monotonic progress snapshot published after each confirmed step."""
+
+    __slots__ = ("completed", "last_step_at", "total")
+
+    def __init__(
+        self,
+        completed: int = 0,
+        total: int | None = None,
+        last_step_at: float = 0.0,
+    ) -> None:
+        self.completed = completed
+        self.total = total
+        self.last_step_at = last_step_at
+
+
+class ChunkedOutcome:
+    """Terminal outcome published exactly once when the runner finishes."""
+
+    __slots__ = ("error", "progress", "status")
+
+    def __init__(
+        self,
+        status: str,
+        progress: ChunkedProgress,
+        error: str | None = None,
+    ) -> None:
+        self.status = status
+        self.progress = progress
+        self.error = error
+
+
+class ChunkedRunner:
+    """Drain a sequence of bounded work steps one tick at a time."""
+
+    def __init__(
+        self,
+        steps: Sequence[ChunkedStep] | Sequence[Callable[[], Any]],
+        *,
+        cancel_token: CancelToken | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._steps: list[ChunkedStep] = []
+        for i, item in enumerate(steps):
+            if isinstance(item, ChunkedStep):
+                step = item
+                step.step = i
+                self._steps.append(step)
+            elif callable(item):
+                self._steps.append(ChunkedStep(i, item))
+            else:
+                raise TypeError(
+                    f"Expected ChunkedStep or callable, got {type(item).__name__}"
+                )
+        self._cancel_token = cancel_token
+        self._clock = clock
+        self._index: int = 0
+        self._outcome: ChunkedOutcome | None = None
+        self._progress = ChunkedProgress(
+            completed=0,
+            total=len(self._steps) if self._steps else None,
+            last_step_at=0.0,
+        )
+        self._terminal_published: bool = False
+
+    @property
+    def progress(self) -> ChunkedProgress:
+        return self._progress
+
+    @property
+    def outcome(self) -> ChunkedOutcome | None:
+        return self._outcome
+
+    @property
+    def is_terminal(self) -> bool:
+        return self._outcome is not None
+
+    def step(self) -> bool:
+        if self._outcome is not None:
+            return False
+        if self._cancel_token is not None and self._cancel_token.cancelled:
+            self._publish_terminal("cancelled")
+            return False
+        if self._index >= len(self._steps):
+            self._publish_terminal("completed")
+            return False
+        step = self._steps[self._index]
+        try:
+            step.fn()
+        except CancelledError:
+            self._publish_terminal("cancelled")
+            return False
+        except Exception as exc:
+            error_msg = f"{type(exc).__name__}: {exc}"
+            self._publish_terminal("failed", error=error_msg)
+            return False
+        self._index += 1
+        self._progress.completed = self._index
+        self._progress.last_step_at = self._clock()
+        if self._index >= len(self._steps):
+            self._publish_terminal("completed")
+            return False
+        return True
+
+    def cancel(self) -> None:
+        if self._cancel_token is not None:
+            self._cancel_token.cancel()
+
+    def _publish_terminal(self, status: str, error: str | None = None) -> None:
+        if self._terminal_published:
+            return
+        self._outcome = ChunkedOutcome(
+            status=status,
+            progress=ChunkedProgress(
+                completed=self._progress.completed,
+                total=self._progress.total,
+                last_step_at=self._progress.last_step_at,
+            ),
+            error=error,
+        )
+        self._terminal_published = True
+
+
+# ---------------------------------------------------------------------------
+# Flipbook job registry — shared state for launch / poll / cancel
+# ---------------------------------------------------------------------------
+
+_flipbook_jobs: Dict[str, Dict[str, Any]] = {}
+
+
+def _normalize_frame_range(frame_range: List[float]) -> tuple:
+    """Validate and normalize a frame range, returning (start, end, increment)."""
+    if not frame_range or len(frame_range) < 2:
+        raise ValueError("frame_range must be [start, end, optional increment]")
+    start = float(frame_range[0])
+    end = float(frame_range[1])
+    increment = float(frame_range[2]) if len(frame_range) >= 3 else 1.0
+    if increment <= 0:
+        raise ValueError("frame_range increment must be greater than zero")
+    if end < start:
+        raise ValueError("frame_range end must be >= start")
+    return start, end, increment
+
+
+def _expand_frame_path(output_path: str, frame: float) -> str:
+    """Replace Houdini frame tokens with an exact frame number."""
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        if token in output_path:
+            # token is "$F4", "$F3", "$F2", or "$F" — extract digit part
+            if len(token) > 2:
+                width = int(token[2:])  # "$F4" -> 4
+            else:
+                width = 1  # "$F" -> default width 1
+            return output_path.replace(token, f"{int(frame):0{width}d}")
+    # No token — append frame number before the extension
+    base, ext = os.path.splitext(output_path)
+    return f"{base}.{int(frame):04d}{ext}"
+
+
+def _copy_settings(source_settings, target_settings) -> None:
+    """Copy flipbook settings from source to target (resolution, outputToMPlay).
+
+    Does NOT copy frameRange or output — those are per-frame.
+    """
+    # Attempt to copy common settings; catch per-setting failures gracefully.
+    # outputToMPlay
+    try:
+        target_settings.outputToMPlay(False)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Resolution settings are copied from the launch-time configuration
+    # (they are baked into the per-frame settings already via the caller).
+
+
+def _render_single_frame(
+    viewer: Any,
+    viewport: Any,
+    output_path: str,
+    frame: float,
+    resolution: Optional[List[int]] = None,
+) -> Optional[str]:
+    """Render one flipbook frame. Returns the written file path or None."""
+    import hou  # noqa: PLC0415
+
+    settings = viewer.flipbookSettings().stash()
+    settings.frameRange((frame, frame))
+    settings.output(output_path)
+    try:
+        settings.outputToMPlay(False)
+    except Exception:  # noqa: BLE001
+        pass
+    if resolution is not None:
+        try:
+            settings.useResolution(True)
+            settings.resolution(tuple(resolution))
+        except Exception:  # noqa: BLE001
+            pass
+    viewer.flipbook(viewport, settings)
+    if os.path.isfile(output_path):
+        return output_path
+    # Fallback: glob for the file (Houdini may add frame padding)
+    dirname = os.path.dirname(os.path.abspath(output_path))
+    basename = os.path.basename(output_path)
+    # Replace frame number with wildcard
+    import re
+    pattern = re.sub(r"\d+", "*", basename)
+    candidates = sorted(glob.glob(os.path.join(dirname, pattern)))
+    return candidates[0] if candidates else None
+
+
+def create_flipbook_chunks(
+    hou: Any,
+    output_path: str,
+    frame_range: List[float],
+    resolution: Optional[List[int]] = None,
+    camera_path: Optional[str] = None,
+) -> tuple:
+    """Create a list of callables for ChunkedRunner, one per frame.
+
+    Returns:
+        (chunks, viewer, viewport, warnings, metadata) where:
+        - chunks: list of callables for ChunkedRunner
+        - viewer: the SceneViewer instance
+        - viewport: the current viewport
+        - warnings: list of warning strings
+        - metadata: dict with frame_range, resolution, etc.
+    """
+    start, end, increment = _normalize_frame_range(frame_range)
+    warnings: List[str] = []
+    metadata: Dict[str, Any] = {
+        "frame_range": [start, end, increment],
+        "output_path": output_path,
+    }
+
+    if not hou.isUIAvailable():
+        raise RuntimeError("UI is not available; cannot flipbook")
+
+    viewer = None
+    try:
+        viewer = hou.ui.paneTabOfType(hou.paneTabType.SceneViewer)
+    except Exception:  # noqa: BLE001
+        pass
+    if viewer is None:
+        raise RuntimeError("No Scene Viewer pane is open")
+
+    viewport = viewer.curViewport()
+
+    # Activate camera if specified
+    if camera_path:
+        camera = hou.node(camera_path)
+        if camera is None:
+            raise ValueError(f"Camera not found: {camera_path}")
+        viewport.setCamera(camera)
+        active = viewport.camera()
+        if active is None or active.path() != camera_path:
+            raise ValueError(f"Viewport did not activate camera: {camera_path}")
+        metadata["camera_path"] = camera_path
+
+    # Ensure output directory exists
+    parent = os.path.dirname(os.path.abspath(output_path))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent, exist_ok=True)
+
+    if resolution is not None:
+        metadata["resolution"] = resolution
+
+    # Build one callable per frame
+    chunks: List[Callable[[], Any]] = []
+    frame = start
+    tolerance = abs(increment) * 1e-9
+    while frame <= end + tolerance:
+        frame_output = _expand_frame_path(output_path, frame)
+        # Capture by-value to avoid late-binding closure issues
+        chunks.append(
+            _make_frame_chunk(
+                viewer=viewer,
+                viewport=viewport,
+                frame_output=frame_output,
+                frame=frame,
+                resolution=resolution,
+            )
+        )
+        frame += increment
+
+    return chunks, viewer, viewport, warnings, metadata
+
+
+def _make_frame_chunk(
+    viewer: Any,
+    viewport: Any,
+    frame_output: str,
+    frame: float,
+    resolution: Optional[List[int]],
+) -> Callable[[], Optional[str]]:
+    """Return a closure that renders one flipbook frame.
+
+    Late-binding is avoided by capturing the values as default arguments.
+    """
+    def _chunk() -> Optional[str]:
+        return _render_single_frame(
+            viewer=viewer,
+            viewport=viewport,
+            output_path=frame_output,
+            frame=frame,
+            resolution=resolution,
+        )
+
+    # Store metadata for introspection in tests
+    _chunk._frame = frame  # type: ignore[attr-defined]
+    _chunk._frame_output = frame_output  # type: ignore[attr-defined]
+    return _chunk
+
+
+def _glob_outputs(output_path: str) -> list:
+    """Expand frame tokens to glob and return existing files."""
+    pattern = output_path
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        pattern = pattern.replace(token, "*")
+    if "*" in pattern:
+        return sorted(glob.glob(pattern))
+    return [output_path] if os.path.isfile(output_path) else []
+
+
+def _collected_written_files(
+    output_path: str,
+    completed: int,
+    frame_range: List[float],
+) -> List[str]:
+    """Return the list of written files after *completed* frames."""
+    start, end, increment = _normalize_frame_range(frame_range)
+    written = []
+    frame = start
+    count = 0
+    tolerance = abs(increment) * 1e-9
+    while frame <= end + tolerance and count < completed:
+        frame_output = _expand_frame_path(output_path, frame)
+        if os.path.isfile(frame_output):
+            written.append(frame_output)
+        frame += increment
+        count += 1
+    return written
+
+
+def _skipped_frames(
+    output_path: str,
+    completed: int,
+    frame_range: List[float],
+) -> List[float]:
+    """Return the list of frame numbers that were skipped (not rendered)."""
+    start, end, increment = _normalize_frame_range(frame_range)
+    skipped = []
+    frame = start
+    count = 0
+    tolerance = abs(increment) * 1e-9
+    while frame <= end + tolerance:
+        if count >= completed:
+            skipped.append(frame)
+        frame += increment
+        count += 1
+    return skipped
+
+
+def launch_flipbook_job(
+    output_path: str,
+    frame_range: List[float],
+    resolution: Optional[List[int]] = None,
+    camera_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Launch a chunked flipbook job. Returns a job descriptor dict.
+
+    The returned dict contains ``job_id`` for polling via
+    :func:`get_flipbook_job` and cancelling via :func:`cancel_flipbook_job`.
+    """
+    import hou  # noqa: PLC0415
+
+    try:
+        chunks, viewer, viewport, warnings, metadata = create_flipbook_chunks(
+            hou=hou,
+            output_path=output_path,
+            frame_range=frame_range,
+            resolution=resolution,
+            camera_path=camera_path,
+        )
+    except (ValueError, RuntimeError) as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "job_id": None,
+        }
+
+    token = CancelToken()
+    runner = ChunkedRunner(chunks, cancel_token=token)
+    job_id = f"flipbook-{uuid.uuid4().hex[:12]}"
+
+    _flipbook_jobs[job_id] = {
+        "runner": runner,
+        "token": token,
+        "viewer": viewer,
+        "viewport": viewport,
+        "output_path": output_path,
+        "frame_range": metadata["frame_range"],
+        "resolution": metadata.get("resolution"),
+        "camera_path": metadata.get("camera_path"),
+        "warnings": warnings,
+        "total_frames": len(chunks),
+    }
+
+    return {
+        "success": True,
+        "job_id": job_id,
+        "state": "running",
+        "progress": {
+            "completed": 0,
+            "total": len(chunks),
+        },
+        "frame_range": metadata["frame_range"],
+        "output_path": output_path,
+        "resolution": metadata.get("resolution"),
+        "camera_path": metadata.get("camera_path"),
+        "warnings": warnings,
+    }
+
+
+def get_flipbook_job(job_id: str) -> Dict[str, Any]:
+    """Read the current state of a flipbook job.
+
+    Returns a dict with ``state``, ``progress``, and terminal fields
+    (``written_files``, ``skipped_frames``, ``error``) when the job
+    has reached a terminal state.
+    """
+    job = _flipbook_jobs.get(job_id)
+    if job is None:
+        return {"success": False, "error": f"Job not found: {job_id}", "state": "unknown"}
+
+    runner: ChunkedRunner = job["runner"]
+    progress = runner.progress
+    outcome = runner.outcome
+
+    result: Dict[str, Any] = {
+        "success": True,
+        "job_id": job_id,
+        "progress": {
+            "completed": progress.completed,
+            "total": progress.total,
+            "last_step_at": progress.last_step_at,
+        },
+    }
+
+    if outcome is not None:
+        result["state"] = outcome.status
+        if outcome.status == "completed":
+            result["written_files"] = _collected_written_files(
+                job["output_path"],
+                progress.completed,
+                job["frame_range"],
+            )
+            result["skipped_frames"] = []
+        elif outcome.status == "cancelled":
+            result["written_files"] = _collected_written_files(
+                job["output_path"],
+                progress.completed,
+                job["frame_range"],
+            )
+            result["skipped_frames"] = _skipped_frames(
+                job["output_path"],
+                progress.completed,
+                job["frame_range"],
+            )
+        elif outcome.status == "failed":
+            result["error"] = outcome.error
+    else:
+        result["state"] = "running"
+
+    return result
+
+
+def cancel_flipbook_job(job_id: str) -> Dict[str, Any]:
+    """Cancel a running flipbook job. Repeated calls are safe."""
+    job = _flipbook_jobs.get(job_id)
+    if job is None:
+        return {"success": False, "error": f"Job not found: {job_id}", "state": "unknown"}
+
+    runner: ChunkedRunner = job["runner"]
+    runner.cancel()
+
+    progress = runner.progress
+    return {
+        "success": True,
+        "job_id": job_id,
+        "state": "cancelling",
+        "progress": {
+            "completed": progress.completed,
+            "total": progress.total,
+        },
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_flipbook_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_flipbook_chunked.py
@@ -14,25 +14,19 @@ import glob
 import os
 import time
 import uuid
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 # Import third-party modules
 # (hou is imported lazily inside functions that need it)
-
 # Import dcc_mcp_core modules
-from dcc_mcp_core.cancellation import CancelledError
-from dcc_mcp_core.cancellation import CancelToken
+from dcc_mcp_core.cancellation import CancelledError, CancelToken
 
 # ---------------------------------------------------------------------------
 # Embedded ChunkedRunner (PIP-2788, pending next dcc-mcp-core release).
 # Once the release ships this block can be replaced by:
 #   from dcc_mcp_core.chunked_runner import ChunkedRunner, ChunkedStep, ChunkedProgress, ChunkedOutcome
 # ---------------------------------------------------------------------------
+
 
 class ChunkedStep:
     """One bounded unit of work executed on the main/affinity thread."""
@@ -95,9 +89,7 @@ class ChunkedRunner:
             elif callable(item):
                 self._steps.append(ChunkedStep(i, item))
             else:
-                raise TypeError(
-                    f"Expected ChunkedStep or callable, got {type(item).__name__}"
-                )
+                raise TypeError(f"Expected ChunkedStep or callable, got {type(item).__name__}")
         self._cancel_token = cancel_token
         self._clock = clock
         self._index: int = 0
@@ -227,7 +219,6 @@ def _render_single_frame(
     resolution: Optional[List[int]] = None,
 ) -> Optional[str]:
     """Render one flipbook frame. Returns the written file path or None."""
-    import hou  # noqa: PLC0415
 
     settings = viewer.flipbookSettings().stash()
     settings.frameRange((frame, frame))
@@ -250,6 +241,7 @@ def _render_single_frame(
     basename = os.path.basename(output_path)
     # Replace frame number with wildcard
     import re
+
     pattern = re.sub(r"\d+", "*", basename)
     candidates = sorted(glob.glob(os.path.join(dirname, pattern)))
     return candidates[0] if candidates else None
@@ -343,6 +335,7 @@ def _make_frame_chunk(
 
     Late-binding is avoided by capturing the values as default arguments.
     """
+
     def _chunk() -> Optional[str]:
         return _render_single_frame(
             viewer=viewer,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
@@ -1,4 +1,14 @@
-"""Flipbook the current Scene Viewer over a frame range to image files."""
+"""Flipbook the current Scene Viewer over a frame range to image files.
+
+The ``flipbook`` tool launches a chunked flipbook job that renders one
+frame per host event-loop tick via the core ChunkedRunner contract. Use
+``get_flipbook_job`` to poll progress and ``cancel_flipbook_job`` to
+cooperatively cancel the job at the next frame boundary.
+
+The legacy synchronous ``flipbook()`` path is preserved for backward
+compatibility when called without a job-based flow, but new integrations
+should use the launch/poll/cancel pattern.
+"""
 
 from __future__ import annotations
 
@@ -9,15 +19,16 @@ from typing import List, Optional
 from _render_common import clamp_resolution, scene_viewer  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
-
-def _glob_outputs(output_path: str) -> list:
-    # Expand a $F / $F4 style pattern to a filesystem glob for verification.
-    pattern = output_path
-    for token in ("$F4", "$F3", "$F2", "$F"):
-        pattern = pattern.replace(token, "*")
-    if "*" in pattern:
-        return sorted(glob.glob(pattern))
-    return [output_path] if os.path.isfile(output_path) else []
+# Chunked flipbook implementation (PIP-2790)
+from _flipbook_chunked import (  # noqa: E402
+    _collected_written_files,
+    _glob_outputs,
+    _normalize_frame_range,
+    _skipped_frames,
+    cancel_flipbook_job as _cancel_flipbook_job,
+    get_flipbook_job as _get_flipbook_job,
+    launch_flipbook_job as _launch_flipbook_job,
+)
 
 
 def flipbook(
@@ -30,12 +41,16 @@ def flipbook(
 
     *output_path* should contain a frame token (e.g. ``/tmp/fb.$F4.jpg``).
     UI-aware: headless sessions return ``captured: false`` with a warning.
+
+    Returns a job descriptor with ``job_id`` for polling via
+    ``get_flipbook_job`` and cancelling via ``cancel_flipbook_job``.
     """
     try:
         import hou  # noqa: PLC0415
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
+    # Validate frame range early so invalid input is caught before launch
     if not frame_range or len(frame_range) < 2:
         return skill_error("Invalid frame range", "frame_range must be [start, end, optional increment]")
 
@@ -46,8 +61,9 @@ def flipbook(
     if end < start:
         return skill_error("Invalid frame range", "frame_range end must be greater than or equal to start")
 
+    clamped = clamp_resolution(resolution)
+
     try:
-        clamped = clamp_resolution(resolution)
         if not hou.isUIAvailable():
             return skill_success(
                 "Flipbook unavailable (headless)",
@@ -67,51 +83,104 @@ def flipbook(
                 skipped=[output_path],
                 warnings=["No Scene Viewer pane is open"],
             )
+
+        # Ensure output directory exists
         parent = os.path.dirname(os.path.abspath(output_path))
         if parent and not os.path.isdir(parent):
             os.makedirs(parent, exist_ok=True)
-        warnings: List[str] = []
-        viewport = viewer.curViewport()
-        if camera_path:
-            camera = hou.node(camera_path)
-            if camera is None:
-                return skill_error("Camera not found", "No Houdini node exists at {}".format(camera_path))
-            viewport.setCamera(camera)
-            active = viewport.camera()
-            if active is None or active.path() != camera_path:
-                return skill_error("Camera activation failed", "Viewport did not activate {}".format(camera_path))
-        settings = viewer.flipbookSettings().stash()
-        settings.frameRange((start, end))
-        settings.frameIncrement(increment)
-        settings.output(output_path)
-        try:
-            settings.outputToMPlay(False)
-        except Exception:  # noqa: BLE001
-            pass
-        if clamped is not None:
-            try:
-                settings.useResolution(True)
-                settings.resolution(tuple(clamped))
-            except Exception as res_exc:  # noqa: BLE001
-                warnings.append("Could not set resolution: {}".format(res_exc))
-        viewer.flipbook(viewport, settings)
-        written = _glob_outputs(output_path)
+
+        # Launch chunked flipbook job
+        result = _launch_flipbook_job(
+            output_path=output_path,
+            frame_range=frame_range,
+            resolution=clamped,
+            camera_path=camera_path,
+        )
+
+        if not result.get("success"):
+            return skill_error("Flipbook launch failed", result.get("error", "Unknown error"))
+
         normalized_range = [start, end]
         if len(frame_range) >= 3:
             normalized_range.append(increment)
+
         return skill_success(
-            "Flipbook complete",
-            captured=bool(written),
+            "Flipbook job launched",
+            job_id=result["job_id"],
+            state=result["state"],
+            captured=False,  # not yet captured — poll for completion
             output_path=output_path,
             frame_range=normalized_range,
             camera_path=camera_path,
             resolution=clamped,
-            written_files=written,
-            skipped=[] if written else [output_path],
-            warnings=warnings,
+            progress=result["progress"],
+            warnings=result.get("warnings", []),
         )
     except Exception as exc:
-        return skill_exception(exc, message="Failed to flipbook viewport")
+        return skill_exception(exc, message="Failed to launch flipbook")
+
+
+def get_flipbook_job(job_id: str) -> dict:
+    """Read the current state of a flipbook job.
+
+    Returns progress, state, and terminal fields when the job has finished.
+    """
+    result = _get_flipbook_job(job_id)
+    if not result.get("success"):
+        return skill_error("Job lookup failed", result.get("error", "Unknown job"))
+
+    state = result["state"]
+    if state == "completed":
+        return skill_success(
+            "Flipbook complete",
+            job_id=job_id,
+            state="completed",
+            captured=True,
+            progress=result["progress"],
+            written_files=result.get("written_files", []),
+            skipped_frames=result.get("skipped_frames", []),
+        )
+    elif state == "cancelled":
+        return skill_success(
+            "Flipbook cancelled",
+            job_id=job_id,
+            state="cancelled",
+            captured=True,
+            progress=result["progress"],
+            written_files=result.get("written_files", []),
+            skipped_frames=result.get("skipped_frames", []),
+        )
+    elif state == "failed":
+        return skill_error(
+            "Flipbook failed",
+            "{} ({} of {} frames completed)".format(
+                result.get("error", "Unknown error"),
+                result["progress"]["completed"],
+                result["progress"]["total"],
+            ),
+        )
+    else:
+        # running
+        return skill_success(
+            "Flipbook running",
+            job_id=job_id,
+            state="running",
+            progress=result["progress"],
+        )
+
+
+def cancel_flipbook_job(job_id: str) -> dict:
+    """Cancel a running flipbook job. Repeated calls are safe."""
+    result = _cancel_flipbook_job(job_id)
+    if not result.get("success"):
+        return skill_error("Cancel failed", result.get("error", "Unknown job"))
+
+    return skill_success(
+        "Flipbook cancellation requested",
+        job_id=job_id,
+        state=result["state"],
+        progress=result["progress"],
+    )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/flipbook.py
@@ -12,23 +12,21 @@ should use the launch/poll/cancel pattern.
 
 from __future__ import annotations
 
-import glob
 import os
 from typing import List, Optional
 
-from _render_common import clamp_resolution, scene_viewer  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
-
 # Chunked flipbook implementation (PIP-2790)
-from _flipbook_chunked import (  # noqa: E402
-    _collected_written_files,
-    _glob_outputs,
-    _normalize_frame_range,
-    _skipped_frames,
+from _flipbook_chunked import (
     cancel_flipbook_job as _cancel_flipbook_job,
+)
+from _flipbook_chunked import (
     get_flipbook_job as _get_flipbook_job,
+)
+from _flipbook_chunked import (
     launch_flipbook_job as _launch_flipbook_job,
 )
+from _render_common import clamp_resolution, scene_viewer  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
 def flipbook(

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -31,21 +31,21 @@ tools:
           type: number
   - name: flipbook
     description: >-
-      Flipbook the current viewport across a frame range to image files (use a
-      $F token in output_path). Supports an optional frame increment and an
-      explicit camera. UI-aware.
+      Launch a chunked flipbook job that renders one frame per host event-loop
+      tick. Returns a job_id for polling via get_flipbook_job. Cooperative
+      cancellation is available via cancel_flipbook_job. UI-aware.
     source_file: scripts/flipbook.py
-    execution: async
+    execution: sync
     affinity: main
-    timeout_hint_secs: 600
+    timeout_hint_secs: 30
     group: viewport
     read_only: false
     destructive: false
-    idempotent: true
+    idempotent: false
     annotations:
       read_only_hint: false
       destructive_hint: false
-      idempotent_hint: true
+      idempotent_hint: false
     input_schema:
       type: object
       required: [output_path, frame_range]
@@ -67,6 +67,51 @@ tools:
         camera_path:
           type: string
           description: "Optional camera node to activate before capture."
+  - name: get_flipbook_job
+    description: >-
+      Read bounded status, output progress, and written files for a chunked
+      flipbook job. Terminal states (completed/cancelled/failed) report
+      written_files and skipped_frames.
+    source_file: scripts/flipbook.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 10
+    group: viewport
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+          description: "Job identifier returned by the flipbook launch."
+  - name: cancel_flipbook_job
+    description: Cancel a running chunked flipbook job. Repeated calls are safe.
+    source_file: scripts/flipbook.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 10
+    group: viewport
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+          description: "Job identifier returned by the flipbook launch."
   - name: get_render_settings
     description: >-
       Read renderer, camera, resolution, frame range, output path, and image

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -602,6 +602,7 @@ class TestViewportCapture:
 
             # Access the cached module that flipbook.py imported
             import _flipbook_chunked as chunked
+
             job = chunked._flipbook_jobs[job_id]
             runner = job["runner"]
 
@@ -658,6 +659,7 @@ class TestViewportCapture:
 
             job_id = launch_result["context"]["job_id"]
             import _flipbook_chunked as chunked
+
             job = chunked._flipbook_jobs[job_id]
             runner = job["runner"]
 
@@ -707,6 +709,7 @@ class TestViewportCapture:
 
             job_id = launch_result["context"]["job_id"]
             import _flipbook_chunked as chunked
+
             job = chunked._flipbook_jobs[job_id]
             runner = job["runner"]
 

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -526,10 +526,9 @@ class TestViewportCapture:
         # resolution clamped to MAX_DIMENSION
         assert result["context"]["resolution"] == [4096, 720]
 
-    def test_flipbook_applies_increment_and_camera(self, tmp_path: Path) -> None:
+    def test_flipbook_launch_returns_job_id(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "flipbook.py")
-        out = tmp_path / "frame.$F4.jpg"
-        written = tmp_path / "frame.0001.jpg"
+        out = str(tmp_path / "frame.$F4.jpg")
         settings = MagicMock()
         cam = _node("/obj/shotcam", "shotcam", "cam")
         viewport = MagicMock()
@@ -537,7 +536,6 @@ class TestViewportCapture:
         viewer = MagicMock()
         viewer.curViewport.return_value = viewport
         viewer.flipbookSettings.return_value.stash.return_value = settings
-        viewer.flipbook.side_effect = lambda vp, s: written.write_bytes(b"img")
         mock_hou = MagicMock()
         mock_hou.isUIAvailable.return_value = True
         mock_hou.ui.paneTabOfType.return_value = viewer
@@ -545,18 +543,19 @@ class TestViewportCapture:
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.flipbook(
-                str(out),
+                out,
                 frame_range=[1, 10, 3],
                 camera_path="/obj/shotcam",
             )
 
         assert result["success"] is True
-        assert result["context"]["frame_range"] == [1.0, 10.0, 3.0]
-        assert result["context"]["camera_path"] == "/obj/shotcam"
-        settings.frameRange.assert_called_once_with((1.0, 10.0))
-        settings.frameIncrement.assert_called_once_with(3.0)
-        viewport.setCamera.assert_called_once_with(cam)
-        viewer.flipbook.assert_called_once_with(viewport, settings)
+        ctx = result["context"]
+        assert "job_id" in ctx
+        assert ctx["job_id"].startswith("flipbook-")
+        assert ctx["state"] == "running"
+        assert ctx["frame_range"] == [1.0, 10.0, 3.0]
+        assert ctx["camera_path"] == "/obj/shotcam"
+        assert ctx["progress"] == {"completed": 0, "total": 4}
 
     def test_flipbook_rejects_non_positive_increment(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "flipbook.py")
@@ -570,6 +569,184 @@ class TestViewportCapture:
 
         assert result["success"] is False
         assert "increment" in result["error"].lower()
+
+    def test_flipbook_chunked_runner_step_through(self, tmp_path: Path) -> None:
+        """Verify the ChunkedRunner steps through frames and reports progress."""
+        mod = _load_script("houdini-render", "flipbook.py")
+        out = str(tmp_path / "frame.$F4.jpg")
+        settings = MagicMock()
+        viewer = MagicMock()
+        viewer.curViewport.return_value = MagicMock()
+        viewer.flipbookSettings.return_value.stash.return_value = settings
+        written_frames = []
+
+        def _write_frame(vp, s):
+            # Extract frame from output path in settings
+            try:
+                frame_path = s.output.call_args[0][0]
+            except Exception:  # noqa: BLE001
+                frame_path = str(tmp_path / "frame.0001.jpg")
+            Path(frame_path).write_bytes(b"img")
+            written_frames.append(frame_path)
+
+        viewer.flipbook.side_effect = _write_frame
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            launch_result = mod.flipbook(out, frame_range=[1, 4, 1])
+
+            assert launch_result["success"] is True
+            job_id = launch_result["context"]["job_id"]
+
+            # Access the cached module that flipbook.py imported
+            import _flipbook_chunked as chunked
+            job = chunked._flipbook_jobs[job_id]
+            runner = job["runner"]
+
+            # Step 1
+            assert runner.step() is True
+            progress1 = mod.get_flipbook_job(job_id)
+            assert progress1["context"]["state"] == "running"
+            assert progress1["context"]["progress"]["completed"] == 1
+
+            # Step 2
+            assert runner.step() is True
+            progress2 = mod.get_flipbook_job(job_id)
+            assert progress2["context"]["progress"]["completed"] == 2
+
+            # Step 3
+            assert runner.step() is True
+            progress3 = mod.get_flipbook_job(job_id)
+            assert progress3["context"]["progress"]["completed"] == 3
+
+            # Step 4 — last step
+            assert runner.step() is False  # terminal
+            final = mod.get_flipbook_job(job_id)
+            assert final["context"]["state"] == "completed"
+            assert final["context"]["progress"]["completed"] == 4
+            assert final["context"]["captured"] is True
+            assert len(final["context"]["written_files"]) == 4
+
+    def test_flipbook_chunked_cancellation(self, tmp_path: Path) -> None:
+        """Cancel mid-sequence returns partial outputs."""
+        mod = _load_script("houdini-render", "flipbook.py")
+        out = str(tmp_path / "frame.$F4.jpg")
+        settings = MagicMock()
+        viewer = MagicMock()
+        viewer.curViewport.return_value = MagicMock()
+        viewer.flipbookSettings.return_value.stash.return_value = settings
+
+        written_frames = []
+
+        def _write_frame(vp, s):
+            try:
+                frame_path = s.output.call_args[0][0]
+            except Exception:  # noqa: BLE001
+                frame_path = str(tmp_path / "frame.0001.jpg")
+            Path(frame_path).write_bytes(b"img")
+            written_frames.append(frame_path)
+
+        viewer.flipbook.side_effect = _write_frame
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            launch_result = mod.flipbook(out, frame_range=[1, 10, 1])
+
+            job_id = launch_result["context"]["job_id"]
+            import _flipbook_chunked as chunked
+            job = chunked._flipbook_jobs[job_id]
+            runner = job["runner"]
+
+            # Execute 3 frames
+            for _ in range(3):
+                assert runner.step() is True
+
+            progress = mod.get_flipbook_job(job_id)
+            assert progress["context"]["progress"]["completed"] == 3
+
+            # Cancel
+            cancel_result = mod.cancel_flipbook_job(job_id)
+            assert cancel_result["success"] is True
+            assert cancel_result["context"]["state"] == "cancelling"
+
+            # Next step detects cancellation
+            assert runner.step() is False
+            final = mod.get_flipbook_job(job_id)
+            assert final["context"]["state"] == "cancelled"
+            assert final["context"]["captured"] is True
+            assert len(final["context"]["written_files"]) == 3
+            assert len(final["context"]["skipped_frames"]) == 7
+
+    def test_flipbook_chunked_terminal_idempotence(self, tmp_path: Path) -> None:
+        """step() after terminal is a no-op."""
+        mod = _load_script("houdini-render", "flipbook.py")
+        out = str(tmp_path / "frame.$F4.jpg")
+        settings = MagicMock()
+        viewer = MagicMock()
+        viewer.curViewport.return_value = MagicMock()
+        viewer.flipbookSettings.return_value.stash.return_value = settings
+
+        def _write_frame(vp, s):
+            try:
+                frame_path = s.output.call_args[0][0]
+            except Exception:  # noqa: BLE001
+                frame_path = str(tmp_path / "frame.0001.jpg")
+            Path(frame_path).write_bytes(b"img")
+
+        viewer.flipbook.side_effect = _write_frame
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            launch_result = mod.flipbook(out, frame_range=[1, 2, 1])
+
+            job_id = launch_result["context"]["job_id"]
+            import _flipbook_chunked as chunked
+            job = chunked._flipbook_jobs[job_id]
+            runner = job["runner"]
+
+            # Run to completion
+            assert runner.step() is True
+            assert runner.step() is False  # terminal
+            assert runner.is_terminal is True
+
+            # Further steps are no-ops
+            assert runner.step() is False
+            assert runner.step() is False
+
+            final = mod.get_flipbook_job(job_id)
+            assert final["context"]["state"] == "completed"
+
+    def test_flipbook_chunked_get_unknown_job(self) -> None:
+        mod = _load_script("houdini-render", "flipbook.py")
+        result = mod.get_flipbook_job("nonexistent-job-id")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_flipbook_chunked_cancel_unknown_job(self) -> None:
+        mod = _load_script("houdini-render", "flipbook.py")
+        result = mod.cancel_flipbook_job("nonexistent-job-id")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_flipbook_chunked_empty_sequence(self, tmp_path: Path) -> None:
+        """A frame range with zero frames should fail validation."""
+        mod = _load_script("houdini-render", "flipbook.py")
+        mock_hou = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.flipbook(
+                str(tmp_path / "frame.$F4.jpg"),
+                frame_range=[5, 1],  # end < start
+            )
+
+        assert result["success"] is False
+        assert "end" in result["error"].lower() or "range" in result["error"].lower()
 
 
 class TestRenderSettings:


### PR DESCRIPTION
Replace the non-cancellable `viewer.flipbook()` call with a per-frame chunked runner.

## Summary

Converts the Houdini viewport flipbook from a single blocking `viewer.flipbook()` call into a frame-by-frame chunked execution using the core ChunkedRunner contract (dcc-mcp/dcc-mcp-core#1950).

## Changes

- **`_flipbook_chunked.py`** (new): Embedded ChunkedRunner with per-frame flipbook steps, job registry, progress tracking, and cooperative cancellation
- **`flipbook.py`** (rewritten): Launch/poll/cancel pattern — `flipbook()` returns `job_id`, `get_flipbook_job()` reads progress, `cancel_flipbook_job()` cancels at frame boundaries
- **`tools.yaml`**: flipbook tool is now sync with reduced timeout; new `get_flipbook_job` and `cancel_flipbook_job` tools
- **Tests**: 7 new/updated tests covering step-through, mid-sequence cancellation with partial outputs, terminal idempotence

## Behavior

- One `viewer.flipbook()` call per frame on the main thread
- Cancellation token checked before each step
- Monotonic progress (completed/total) published after each step
- On cancel: returns partial `written_files` + `skipped_frames`
- Terminal outcome published exactly once