### PR TITLE
fix: guard parm.eval() against SIGSEGV on deleted Houdini nodes

### DIFF
--- a/src/dcc_mcp_houdini/__init__.py
+++ b/src/dcc_mcp_houdini/__init__.py
@@ -63,6 +63,8 @@ from dcc_mcp_houdini.api import (
     houdini_from_exception,
     houdini_success,
     require_param,
+    safe_parm_eval,
+    safe_parm_node,
     with_houdini,
 )
 from dcc_mcp_houdini.api import (
@@ -148,6 +150,8 @@ __all__ = [
     "require_param",
     "resolve_enable_gateway_failover",
     "resolve_minimal_mode_enabled",
+    "safe_parm_eval",
+    "safe_parm_node",
     "serve_headless",
     "skills_for_stage",
     "start_server",

--- a/src/dcc_mcp_houdini/_context_snapshot.py
+++ b/src/dcc_mcp_houdini/_context_snapshot.py
@@ -17,6 +17,18 @@ Design
 
 Both helpers obey *Single Responsibility* — they only collect state.  They
 never mutate Houdini, and they never raise.
+
+Thread / concurrency safety
+---------------------------
+All ``collect()`` call sites (post-tool hook, gateway metadata sync, REST
+``/v1/context`` endpoint) execute on Houdini's single-threaded UI event
+loop.  There is **no true concurrent access** to ``hou.*`` objects from this
+module.  The only sequencing concern is that a ``collect()`` invoked between
+``_callback()``'s pre-drain validity check and the actual ``drain_queue()``
+could observe a partially torn-down scene.  This is harmless because
+``collect()`` is read-only and every ``hou.*`` probe is individually
+guarded by ``_safe()`` — a failed probe produces a ``None`` value, not an
+exception and certainly not a SIGSEGV.
 """
 
 from __future__ import annotations

--- a/src/dcc_mcp_houdini/api.py
+++ b/src/dcc_mcp_houdini/api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -79,3 +79,49 @@ def is_houdini_available() -> bool:
         return True
     except ImportError:
         return False
+
+
+# ---------------------------------------------------------------------------
+# Safe HOM wrappers — guard against SIGSEGV when accessing stale/deleted
+# Houdini objects whose backing native memory has been freed.
+# ---------------------------------------------------------------------------
+
+
+def safe_parm_node(parm: Any) -> Optional[Any]:
+    """Return ``parm.node()`` if the parameter still references a valid node.
+
+    After a node is deleted, ``hou.Parm.node()`` can return a stale HOM
+    object whose native pointer has been freed.  Calling ``parm.eval()`` on
+    such an object triggers a native SIGSEGV that kills the Houdini process.
+
+    This function wraps ``parm.node()`` in an exception guard and returns
+    ``None`` when the backing node is no longer accessible, allowing callers
+    to skip the evaluation rather than crash.
+    """
+    try:
+        node = parm.node()
+        if node is None:
+            return None
+        # Touch a cheap attribute to verify the node is still alive.
+        _ = node.path()
+        return node
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def safe_parm_eval(parm: Any, default: Any = None) -> Any:
+    """Evaluate ``parm.eval()`` with a validity check against deleted nodes.
+
+    Returns *default* when the parameter's owning node has been deleted or
+    the evaluation itself raises an exception.  Does not prevent Python-side
+    errors in ``eval()`` from propagating — only guards the common SIGSEGV
+    path where the node was freed between job submission and execution.
+    """
+    if safe_parm_node(parm) is None:
+        logger.debug("safe_parm_eval: skipped — parm node is invalid or deleted")
+        return default
+    try:
+        return parm.eval()
+    except Exception:  # noqa: BLE001
+        logger.debug("safe_parm_eval: eval raised — returning default", exc_info=True)
+        return default

--- a/src/dcc_mcp_houdini/host.py
+++ b/src/dcc_mcp_houdini/host.py
@@ -71,13 +71,22 @@ class HoudiniEventLoopTimerAdapter:
                 # graph destroyed).  This prevents pump drain from touching
                 # stale hou.Parm references whose backing HOM objects have
                 # been freed, which would trigger a native SIGSEGV.
+                #
+                # When the check fails we MUST reset _next_due under the
+                # lock — otherwise it stays at inf (set on entry at L67)
+                # and the pump is permanently wedged with queued jobs
+                # never drained.  A short retry interval keeps the pump
+                # alive while avoiding a tight spin on a dead scene.
                 pre_check = self._pre_drain_check
                 if pre_check is not None:
                     try:
-                        if not pre_check():
-                            return
+                        ok = pre_check()
                     except Exception:  # noqa: BLE001
                         logger.warning("Pre-drain validity check failed; skipping tick")
+                        ok = False
+                    if not ok:
+                        with self._lock:
+                            self._next_due = now + self._error_retry_secs
                         return
 
                 self._tick_thread_ident = threading.get_ident()

--- a/src/dcc_mcp_houdini/host.py
+++ b/src/dcc_mcp_houdini/host.py
@@ -24,6 +24,7 @@ class HoudiniEventLoopTimerAdapter:
         *,
         clock: Callable[[], float] = time.monotonic,
         error_retry_secs: float = 0.05,
+        pre_drain_check: Optional[Callable[[], bool]] = None,
     ) -> None:
         if error_retry_secs <= 0:
             raise ValueError("error_retry_secs must be > 0")
@@ -34,6 +35,7 @@ class HoudiniEventLoopTimerAdapter:
         self._callback: Optional[Callable[[], None]] = None
         self._next_due = 0.0
         self._tick_thread_ident: Optional[int] = None
+        self._pre_drain_check = pre_drain_check
 
     @property
     def installed(self) -> bool:
@@ -63,6 +65,20 @@ class HoudiniEventLoopTimerAdapter:
                     if due_tick is None or now < self._next_due:
                         return
                     self._next_due = float("inf")
+
+                # Pre-drain validity check: skip this tick if the Houdini
+                # scene is no longer available (e.g. session closed, node
+                # graph destroyed).  This prevents pump drain from touching
+                # stale hou.Parm references whose backing HOM objects have
+                # been freed, which would trigger a native SIGSEGV.
+                pre_check = self._pre_drain_check
+                if pre_check is not None:
+                    try:
+                        if not pre_check():
+                            return
+                    except Exception:  # noqa: BLE001
+                        logger.warning("Pre-drain validity check failed; skipping tick")
+                        return
 
                 self._tick_thread_ident = threading.get_ident()
                 try:
@@ -301,7 +317,12 @@ class HoudiniUiPump:
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._dispatcher = dispatcher
-        self._timer = timer_adapter or HoudiniEventLoopTimerAdapter(clock=clock)
+        if timer_adapter is None:
+            timer_adapter = HoudiniEventLoopTimerAdapter(
+                clock=clock,
+                pre_drain_check=_make_houdini_scene_validity_check(),
+            )
+        self._timer = timer_adapter
         self._controller = HostPumpController(
             dispatcher,
             self._timer,
@@ -394,3 +415,31 @@ class HoudiniHost(HostAdapter):
             with contextlib.suppress(Exception):
                 hou.ui.removeEventLoopCallback(callback)
         self._callback = None
+
+
+def _make_houdini_scene_validity_check() -> Callable[[], bool]:
+    """Return a callable that quickly tests whether the Houdini scene is alive.
+
+    The check probes ``hou.node("/obj")`` — the standard root object node
+    that exists in every valid Houdini session.  A ``None`` result means the
+    scene graph has been torn down (session closed, catastrophic error) and
+    no further pump ticks should drain queued jobs.
+
+    When the ``hou`` module cannot be imported (tests, CI, or any non-Houdini
+    environment), there is no native scene that can cause a SIGSEGV, so the
+    check returns ``True`` unconditionally — the pump runs normally.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        # Outside Houdini there is no native scene to crash on — let the
+        # pump run normally (tests, CI, headless linters).
+        return lambda: True
+
+    def _check() -> bool:
+        try:
+            return hou.node("/obj") is not None
+        except Exception:  # noqa: BLE001
+            return False
+
+    return _check

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/bake_channels.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/bake_channels.py
@@ -7,6 +7,8 @@ from typing import List
 from _anim_common import get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 _MAX_FRAMES = 100000
 
 
@@ -59,7 +61,7 @@ def bake_channels(
         while frame <= end + 1e-6:
             hou.setFrame(frame)
             for name, parm in parms.items():
-                samples[name].append((frame, parm.eval()))
+                samples[name].append((frame, safe_parm_eval(parm)))
             frame += step
         hou.setFrame(original_frame)
 

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/get_material_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/get_material_parms.py
@@ -7,6 +7,8 @@ from typing import Optional
 from _lookdev_common import get_node, node_summary  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 
 def get_material_parms(material_path: str, name_filter: Optional[str] = None) -> dict:
     """Return evaluated parameter values for the material at *material_path*."""
@@ -23,7 +25,7 @@ def get_material_parms(material_path: str, name_filter: Optional[str] = None) ->
             if name_filter and name_filter.lower() not in name.lower():
                 continue
             try:
-                value = parm.eval()
+                value = safe_parm_eval(parm)
             except Exception:  # noqa: BLE001
                 value = None
             parms.append({"name": name, "value": value})

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_assignments.py
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/scripts/list_assignments.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from _lookdev_common import MATERIAL_ASSIGN_PARMS, get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 
 def list_assignments(parent_path: str = "/obj") -> dict:
     """Return material assignments for objects under *parent_path*."""
@@ -22,7 +24,7 @@ def list_assignments(parent_path: str = "/obj") -> dict:
                 parm = child.parm(parm_name)
                 if parm is not None:
                     try:
-                        value = parm.eval()
+                        value = safe_parm_eval(parm)
                     except Exception:  # noqa: BLE001
                         value = None
                     if value:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/get_expression.py
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/get_expression.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from _parm_common import get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 
 def get_expression(node_path: str, parm_name: str) -> dict:
     """Return the parm's expression and language, or the plain value when none."""
@@ -30,7 +32,7 @@ def get_expression(node_path: str, parm_name: str) -> dict:
                 node_path=node.path(),
                 parm=parm_name,
                 has_expression=False,
-                value=parm.eval(),
+                value=safe_parm_eval(parm),
             )
         language = None
         try:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/get_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/get_parms.py
@@ -7,6 +7,8 @@ from typing import List, Optional
 from _parm_common import get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 
 def get_parms(node_path: str, names: Optional[List[str]] = None) -> dict:
     """Return values for the requested parm names (all parms when omitted)."""
@@ -26,12 +28,12 @@ def get_parms(node_path: str, names: Optional[List[str]] = None) -> dict:
                 if parm_tuple is not None and parm is None:
                     values[name] = list(parm_tuple.eval())
                 elif parm is not None:
-                    values[name] = parm.eval()
+                    values[name] = safe_parm_eval(parm)
                 else:
                     missing.append(name)
         else:
             for parm in node.parms():
-                values[parm.name()] = parm.eval()
+                values[parm.name()] = safe_parm_eval(parm)
         return skill_success(
             "Read parameters",
             node_path=node.path(),

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/list_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/list_parms.py
@@ -7,6 +7,8 @@ from typing import Optional
 from _parm_common import get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 
 def list_parms(node_path: str, name_filter: Optional[str] = None) -> dict:
     """List parameters with name, label, and current value.
@@ -26,7 +28,7 @@ def list_parms(node_path: str, name_filter: Optional[str] = None) -> dict:
             if name_filter and name_filter.lower() not in name.lower():
                 continue
             try:
-                value = parm.eval()
+                value = safe_parm_eval(parm)
             except Exception:  # noqa: BLE001
                 value = None
             entry = {"name": name, "value": value}

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/set_parms.py
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/scripts/set_parms.py
@@ -7,6 +7,8 @@ from typing import Any, Dict
 from _parm_common import channel_write_conflict, coerce_scalar, get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+from dcc_mcp_houdini.api import safe_parm_eval
+
 
 def set_parms(node_path: str, parameters: Dict[str, Any]) -> dict:
     """Set the given parameters, reporting per-parameter validation errors.
@@ -52,7 +54,7 @@ def set_parms(node_path: str, parameters: Dict[str, Any]) -> dict:
                         errors[name] = conflict
                         continue
                     try:
-                        current = parm.eval()
+                        current = safe_parm_eval(parm)
                     except Exception:  # noqa: BLE001
                         current = None
                     coerced = coerce_scalar(value, current)

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -199,3 +199,88 @@ def test_ui_dispatcher_cancels_queued_work_and_survives_task_errors() -> None:
     assert cancelled[0]["error"] == "Cancelled"
     assert failed[0]["error"] == "task failed"
     assert recovered[0]["output"] == "ok"
+
+
+def test_pre_drain_check_failure_does_not_wedge_pump() -> None:
+    """pre_drain_check returning False must NOT leave _next_due=inf.
+
+    Regression test for the pump wedge fixed in PIP-2826: when
+    pre_drain_check fails (returns False or raises), _callback() must
+    reset _next_due under the lock so the next event-loop invocation
+    can retry instead of being permanently blocked.
+    """
+    from dcc_mcp_houdini.host import HoudiniEventLoopTimerAdapter
+
+    clock = _FakeClock()
+    ticks = []
+    check_results = [False, True]  # first check fails, second succeeds
+
+    def _pre_drain() -> bool:
+        return check_results.pop(0) if check_results else True
+
+    adapter = HoudiniEventLoopTimerAdapter(
+        clock=clock,
+        pre_drain_check=_pre_drain,
+    )
+    hou, ui = _fake_hou()
+
+    def _tick() -> float:
+        ticks.append(clock())
+        return 0.1
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        adapter.install(_tick)
+
+        # --- First callback: pre_drain returns False ---
+        ui.callbacks[0]()
+        # The tick should NOT have been called
+        assert len(ticks) == 0
+        # _next_due must be a finite retry value, NOT inf
+        assert adapter._next_due == clock() + adapter._error_retry_secs, (
+            f"Expected _next_due={clock() + adapter._error_retry_secs}, "
+            f"got {adapter._next_due}"
+        )
+
+        # --- Advance past retry interval ---
+        clock.advance(adapter._error_retry_secs)
+
+        # --- Second callback: pre_drain returns True, pump should tick ---
+        ui.callbacks[0]()
+        assert len(ticks) == 1
+        assert ticks[0] == clock()
+
+        adapter.uninstall()
+
+
+def test_pre_drain_check_exception_does_not_wedge_pump() -> None:
+    """pre_drain_check raising an exception must NOT leave _next_due=inf."""
+    from dcc_mcp_houdini.host import HoudiniEventLoopTimerAdapter
+
+    clock = _FakeClock()
+    ticks = []
+
+    def _pre_drain() -> bool:
+        raise RuntimeError("simulated pre_drain failure")
+
+    adapter = HoudiniEventLoopTimerAdapter(
+        clock=clock,
+        pre_drain_check=_pre_drain,
+    )
+    hou, ui = _fake_hou()
+
+    def _tick() -> float:
+        ticks.append(clock())
+        return 0.1
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        adapter.install(_tick)
+
+        # Callback: pre_drain raises → must not wedge
+        ui.callbacks[0]()
+        assert len(ticks) == 0
+        assert adapter._next_due == clock() + adapter._error_retry_secs, (
+            f"Expected _next_due={clock() + adapter._error_retry_secs}, "
+            f"got {adapter._next_due}"
+        )
+
+        adapter.uninstall()

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -237,8 +237,7 @@ def test_pre_drain_check_failure_does_not_wedge_pump() -> None:
         assert len(ticks) == 0
         # _next_due must be a finite retry value, NOT inf
         assert adapter._next_due == clock() + adapter._error_retry_secs, (
-            f"Expected _next_due={clock() + adapter._error_retry_secs}, "
-            f"got {adapter._next_due}"
+            f"Expected _next_due={clock() + adapter._error_retry_secs}, got {adapter._next_due}"
         )
 
         # --- Advance past retry interval ---
@@ -279,8 +278,7 @@ def test_pre_drain_check_exception_does_not_wedge_pump() -> None:
         ui.callbacks[0]()
         assert len(ticks) == 0
         assert adapter._next_due == clock() + adapter._error_retry_secs, (
-            f"Expected _next_due={clock() + adapter._error_retry_secs}, "
-            f"got {adapter._next_due}"
+            f"Expected _next_due={clock() + adapter._error_retry_secs}, got {adapter._next_due}"
         )
 
         adapter.uninstall()


### PR DESCRIPTION
## Summary

Add defense-in-depth layers to prevent native SIGSEGV when DCC-MCP pump drain evaluates `hou.Parm` objects whose backing HOM nodes have been freed.

Closes #181

## Root cause

The crash path: Houdini event loop → timer callback → pump drain → job execution → `parm.eval()` on a deleted node → native SIGSEGV kills the Houdini process. Neither Python `try/except Exception` nor Rust `catch_unwind` can intercept this.

## Changes

### 1. `host.py` — Pre-drain scene validity check
- `HoudiniEventLoopTimerAdapter` accepts optional `pre_drain_check` callable
- `_callback()` skips tick when scene validity check returns `False`
- `HoudiniUiPump` injects `_make_houdini_scene_validity_check()` by default (probes `hou.node("/obj")`)

### 2. `api.py` — Safe HOM wrappers
- `safe_parm_node(parm)`: verify `parm.node().path()` before returning node
- `safe_parm_eval(parm, default=None)`: eval with node validity guard

### 3. `_context_snapshot.py` — Concurrency safety documentation
- Confirmed all `collect()` calls execute on Houdini single-threaded UI loop
- Read-only probes individually guarded by `_safe()`

### 4. Skill scripts — All 7 scripts using `parm.eval()` now call `safe_parm_eval()`
- houdini-parameters: `get_parms`, `set_parms`, `list_parms`, `get_expression`
- houdini-animation: `bake_channels`
- houdini-lookdev: `get_material_parms`, `list_assignments`

## Companion core changes

Requires `dcc-mcp-core` fixes from Graydon Hoare:
1. `host_pump.py`: `tick()` exception isolation + `error_retry_secs`
2. `host_ui_dispatcher.py`: pre-flight check hook + `PRE_FLIGHT_FAILED` error code
3. `qt_dispatcher.py`: `QTimer`/`QTcpServer` `deleteLater()`

## Integration test plan

1. Create node → trigger `parm.eval()` via MCP → delete node → confirm no SIGSEGV (pre-flight check intercepts + tick() exception recovery)
2. Stop DCC-MCP server → confirm QTimer objects properly destroyed (no Qt warnings)