### PR TITLE
fix: include import skill in interchange stage

### DIFF
--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -39,6 +39,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     "interchange": (
         "houdini-interchange",
         "houdini-export-preset",
+        "houdini-import-to-scene",
         "houdini-usd-lops",
     ),
     "pipeline": (


### PR DESCRIPTION
Adds the documented houdini-import-to-scene skill to the interchange stage tuple.\n\nCloses #77