### PR TITLE
fix(render): resolve effective Solaris settings

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_render_settings.py
@@ -12,6 +12,150 @@ from _render_common import (  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _json_value(value):
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)) or hasattr(value, "__iter__"):
+        try:
+            return [_json_value(item) for item in value]
+        except TypeError:
+            pass
+    return str(value)
+
+
+def _usd_value(prim, name):
+    attribute = prim.GetAttribute(name)
+    return _json_value(attribute.Get()) if attribute else None
+
+
+def _usd_targets(prim, name):
+    relationship = prim.GetRelationship(name)
+    return list(relationship.GetTargets()) if relationship else []
+
+
+def _render_settings_prim(stage):
+    path = stage.GetMetadata("renderSettingsPrimPath")
+    if path:
+        prim = stage.GetPrimAtPath(path)
+        if prim:
+            return prim
+    return next((prim for prim in stage.Traverse() if str(prim.GetTypeName()) == "RenderSettings"), None)
+
+
+def _solaris_settings(hou, rop):
+    loppath = eval_first_parm(rop, ("loppath",))
+    lop = hou.node(loppath) if loppath else None
+    if lop is None:
+        inputs = getattr(rop, "inputs", None)
+        lop = (
+            next((node for node in inputs() if callable(getattr(node, "stage", None))), None)
+            if callable(inputs)
+            else None
+        )
+    if lop is None or not callable(getattr(lop, "stage", None)):
+        raise ValueError("USD Render ROP has no resolvable LOP stage")
+
+    stage = lop.stage()
+    settings = _render_settings_prim(stage) if stage is not None else None
+    if settings is None:
+        raise ValueError("LOP stage has no active RenderSettings prim")
+
+    settings_camera = next((str(path) for path in _usd_targets(settings, "camera")), None)
+    settings_resolution = _usd_value(settings, "resolution")
+    product_paths = _usd_targets(settings, "products")
+    products = []
+    aovs = []
+    for product_path in product_paths:
+        product = stage.GetPrimAtPath(product_path)
+        if not product:
+            continue
+        var_paths = _usd_targets(product, "orderedVars")
+        product_aovs = []
+        for var_path in var_paths:
+            render_var = stage.GetPrimAtPath(var_path)
+            if not render_var:
+                continue
+            summary = {
+                "path": str(var_path),
+                "source_name": _usd_value(render_var, "sourceName"),
+                "source_type": _usd_value(render_var, "sourceType"),
+                "data_type": _usd_value(render_var, "dataType"),
+            }
+            product_aovs.append(summary)
+            aovs.append(summary)
+        product_camera = next((str(path) for path in _usd_targets(product, "camera")), None)
+        products.append(
+            {
+                "path": str(product_path),
+                "output_path": _usd_value(product, "productName"),
+                "camera": product_camera or settings_camera,
+                "resolution": _usd_value(product, "resolution") or settings_resolution,
+                "aovs": product_aovs,
+            }
+        )
+
+    primary = products[0] if products else {}
+    camera = primary.get("camera") or settings_camera
+    resolution = primary.get("resolution") or settings_resolution
+    output_patterns = [product["output_path"] for product in products if product.get("output_path")]
+    attributes = {
+        str(attribute.GetName()): _json_value(attribute.Get())
+        for attribute in settings.GetAttributes()
+        if "sample" in str(attribute.GetName()).lower()
+    }
+    delegate = eval_first_parm(rop, ("renderer", "renderdelegate", "delegate"))
+    if delegate in (None, "", "default"):
+        delegate = _usd_value(settings, "husk:default_delegate")
+    engine = _usd_value(settings, "karma:global:engine") or _usd_value(settings, "karma:global:renderengine")
+    frame_range = eval_first_parm(rop, ("f",)) or [float(hou.frame()), float(hou.frame()), 1.0]
+    renderer = "karma" if engine is not None else delegate
+    unresolved = [
+        name
+        for name, value in (
+            ("camera", camera),
+            ("resolution", resolution),
+            ("output_path", output_patterns),
+            ("renderer", renderer),
+            ("delegate", delegate),
+            ("samples", attributes),
+            ("aovs", aovs),
+        )
+        if not value
+    ]
+    resolved_paths = [
+        hou.text.expandStringAtFrame(pattern, float(hou.frame()))
+        if "$F" in str(pattern) and callable(getattr(hou.text, "expandStringAtFrame", None))
+        else pattern
+        for pattern in output_patterns
+    ]
+    intermediate_name, intermediate_pattern = eval_first_parm_named(rop, ("lopoutput",), preserve_string=True)
+    return {
+        "rop": node_summary(rop),
+        "renderer": renderer or rop.type().name(),
+        "delegate": delegate,
+        "engine": engine,
+        "camera": camera,
+        "resolution": list(resolution) if resolution is not None else None,
+        "frame_range": list(frame_range),
+        "output_parm_name": "productName" if output_patterns else None,
+        "output_path": resolved_paths,
+        "output_path_pattern": output_patterns,
+        "output_path_resolution": {"frame": float(hou.frame()), "paths": resolved_paths},
+        "intermediate_usd": {
+            "parm_name": intermediate_name,
+            "path": eval_first_parm(rop, ("lopoutput",)),
+            "path_pattern": intermediate_pattern,
+        },
+        "render_settings_prim": str(settings.GetPath()),
+        "render_products": products,
+        "samples": attributes,
+        "aovs": aovs,
+        "image_format": None,
+        "unresolved": unresolved,
+        "unsupported": [],
+    }
+
+
 def get_render_settings(rop_path: str) -> dict:
     """Return structured render settings read from the ROP at *rop_path*."""
     try:
@@ -21,6 +165,8 @@ def get_render_settings(rop_path: str) -> dict:
 
     try:
         rop = get_node(hou, rop_path)
+        if rop.type().name().split("::", 1)[0] == "usdrender_rop":
+            return skill_success("Read effective Solaris render settings", **_solaris_settings(hou, rop))
         res_x = eval_first_parm(rop, ("res_overridex", "resx", "vm_resx"))
         res_y = eval_first_parm(rop, ("res_overridey", "resy", "vm_resy"))
         output_frame = float(hou.frame())

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -117,7 +117,9 @@ tools:
       Read renderer, camera, resolution, frame range, output path, and image
       format from a ROP node. Preserves the existing resolved output_path and
       also reports its raw tokenized pattern plus the frame-to-path resolution
-      used for that value. Read-only.
+      used for that value. For a Solaris USD Render ROP, resolves the composed
+      RenderSettings, RenderProducts, samples, and AOVs without treating the
+      intermediate USD export as the rendered image. Read-only.
     source_file: scripts/get_render_settings.py
     execution: sync
     affinity: main

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -753,6 +753,114 @@ class TestViewportCapture:
 
 
 class TestRenderSettings:
+    def test_get_render_settings_resolves_effective_solaris_products(self) -> None:
+        mod = _load_script("houdini-render", "get_render_settings.py")
+
+        def attribute(name, value):
+            result = MagicMock()
+            result.GetName.return_value = name
+            result.Get.return_value = value
+            return result
+
+        def prim(path, type_name, attributes=None, relationships=None):
+            result = MagicMock()
+            result.GetPath.return_value = path
+            result.GetTypeName.return_value = type_name
+            attributes = attributes or {}
+            relationships = relationships or {}
+            result.GetAttribute.side_effect = lambda name: attributes.get(name)
+            result.GetAttributes.return_value = list(attributes.values())
+
+            def relationship(name):
+                targets = relationships.get(name)
+                if targets is None:
+                    return None
+                value = MagicMock()
+                value.GetTargets.return_value = targets
+                return value
+
+            result.GetRelationship.side_effect = relationship
+            return result
+
+        render_var = prim(
+            "/Render/Vars/beauty",
+            "RenderVar",
+            {
+                "sourceName": attribute("sourceName", "C"),
+                "sourceType": attribute("sourceType", "raw"),
+                "dataType": attribute("dataType", "color3f"),
+            },
+        )
+        product = prim(
+            "/Render/Products/beauty",
+            "RenderProduct",
+            {"productName": attribute("productName", "/renders/beauty.$F4.exr")},
+            {"orderedVars": ["/Render/Vars/beauty"]},
+        )
+        settings = prim(
+            "/Render/Settings",
+            "RenderSettings",
+            {
+                "resolution": attribute("resolution", (1920, 1080)),
+                "karma:global:engine": attribute("karma:global:engine", "xpu"),
+                "karma:global:pathsamples": attribute("karma:global:pathsamples", 64),
+            },
+            {
+                "camera": ["/cameras/shot"],
+                "products": ["/Render/Products/beauty"],
+            },
+        )
+        stage = MagicMock()
+        stage.GetMetadata.return_value = "/Render/Settings"
+        stage.GetPrimAtPath.side_effect = {
+            "/Render/Settings": settings,
+            "/Render/Products/beauty": product,
+            "/Render/Vars/beauty": render_var,
+        }.get
+        lop = _node("/stage/karma_settings", "karma_settings", "karmarendersettings")
+        lop.stage.return_value = stage
+        rop = _node("/out/usdrender1", "usdrender1", "usdrender_rop")
+        rop.parm.side_effect = lambda name: {
+            "loppath": _scalar_parm("/stage/karma_settings"),
+            "renderer": _scalar_parm("Karma"),
+            "lopoutput": _scalar_parm("C:/tmp/__render__.usd"),
+        }.get(name)
+        frame_tuple = MagicMock()
+        frame_tuple.eval.return_value = (1, 24, 2)
+        rop.parmTuple.side_effect = lambda name: frame_tuple if name == "f" else None
+        mock_hou = MagicMock()
+        mock_hou.frame.return_value = 7.0
+        mock_hou.node.side_effect = lambda path: {
+            "/out/usdrender1": rop,
+            "/stage/karma_settings": lop,
+        }.get(path)
+        mock_hou.text.expandStringAtFrame.return_value = "/renders/beauty.0007.exr"
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_render_settings("/out/usdrender1")
+
+        context = result["context"]
+        assert context["camera"] == "/cameras/shot"
+        assert context["resolution"] == [1920, 1080]
+        assert context["frame_range"] == [1, 24, 2]
+        assert context["output_path_pattern"] == ["/renders/beauty.$F4.exr"]
+        assert context["output_path"] == ["/renders/beauty.0007.exr"]
+        assert "__render__.usd" not in str(context["output_path"])
+        assert context["intermediate_usd"]["path"] == "C:/tmp/__render__.usd"
+        assert context["renderer"] == "karma"
+        assert context["delegate"] == "Karma"
+        assert context["engine"] == "xpu"
+        assert context["samples"] == {"karma:global:pathsamples": 64}
+        assert context["aovs"] == [
+            {
+                "path": "/Render/Vars/beauty",
+                "source_name": "C",
+                "source_type": "raw",
+                "data_type": "color3f",
+            }
+        ]
+        assert context["unresolved"] == []
+
     def test_get_render_settings_reports_raw_pattern_and_resolution_frame(self) -> None:
         mod = _load_script("houdini-render", "get_render_settings.py")
         pattern = "$HIP/renders/beauty.$F4.exr"


### PR DESCRIPTION
## Summary\n- read effective RenderSettings, RenderProducts, camera, resolution, samples, and RenderVars from the composed LOP stage\n- keep the intermediate USD export separate from image outputs\n- preserve traditional ROP behavior\n\n## Validation\n- 95 render skill tests\n- Ruff check and format\n- 31 bundled skills validated\n- Python 3.7 syntax check\n\nA real hython Solaris smoke was not available in this checkout environment.\n\nCloses #132