### PR TITLE
feat(render): wire multi-frame ROP render into core ChunkedRunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install package with dev dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/dcc-mcp/dcc-mcp-core.git@3d3b5fad3f7e9275fbff1188c33aaff601bde792
           python -m pip install -e ".[dev]"
       - name: Ruff check
         run: ruff check src/ tests/ tools/ packaging/
@@ -70,7 +69,6 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/dcc-mcp/dcc-mcp-core.git@3d3b5fad3f7e9275fbff1188c33aaff601bde792
           python -m pip install -e ".[dev]"
       - name: Run unit tests
         run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install package with dev dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/dcc-mcp/dcc-mcp-core.git@3d3b5fad3f7e9275fbff1188c33aaff601bde792
           python -m pip install -e ".[dev]"
       - name: Ruff check
         run: ruff check src/ tests/ tools/ packaging/
@@ -69,6 +70,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/dcc-mcp/dcc-mcp-core.git@3d3b5fad3f7e9275fbff1188c33aaff601bde792
           python -m pip install -e ".[dev]"
       - name: Run unit tests
         run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.19.45`
-- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.45,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
+- `dcc-mcp-core >= 0.19.68`
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.68,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -35,7 +35,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.19.45"
+MIN_CORE_VERSION = "0.19.68"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.19.45: instance ports default to operating-system assignment.
-    "dcc-mcp-core>=0.19.45,<1.0.0",
+    # 0.19.68: first release with ChunkedRunner (bounded-step main-thread work)
+    "dcc-mcp-core>=0.19.68,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   export/import channel JSON; bake channels and trigger bounded
   simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   export. Create and manage CHOP networks, motion clips, audio-driven
   channels, and filter effects.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   constraints using OBJ-level blend nodes and CHOP-driven channel
   referencing. List and delete existing constraints.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   loading .hda/.otl assets, building reusable interfaces, or publishing an HDA
   library. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checkpoint/resume, scene snapshots, and husk option configuration. Pair with
   houdini-karma for renderer setup and houdini-render for viewport/ROP renders.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   ImportToSceneResult. Use as the receiving end of the asset import pipeline
   after an asset-source skill resolves the descriptor.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   light mixer, and image output through typed tools. Pair with houdini-render
   for full render execution and houdini-camera-light for scene setup.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   configure rig skeletons, set rig poses, capture joint skinning weights,
   and apply motion capture data via SOP-level KineFX nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   houdini-materials (create/assign) and houdini-lookdev (shader-network
   editing, adapter-owned presets).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   workflows from color, roughness, metallic, normal, or displacement maps. Not
   for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
@@ -64,6 +64,64 @@ def _set_single_frame_range(rop: Any, frame: float) -> None:
                 pass
 
 
+def _snapshot_frame_parms(rop: Any) -> Dict[str, Any]:
+    """Snapshot frame-range parms before the chunked render mutates them.
+
+    Returns a dict that can be passed to :func:`_restore_frame_parms`.
+    """
+    snapshot: Dict[str, Any] = {}
+
+    trange = rop.parm("trange")
+    if trange is not None:
+        try:
+            snapshot["trange"] = trange.eval()
+        except Exception:  # noqa: BLE001
+            pass
+
+    f_parm = rop.parmTuple("f")
+    if f_parm is not None:
+        try:
+            snapshot["f"] = list(f_parm.eval())
+        except Exception:  # noqa: BLE001
+            pass
+    else:
+        for name in ("f1", "f2", "f3"):
+            parm = rop.parm(name)
+            if parm is not None:
+                try:
+                    snapshot[name] = parm.eval()
+                except Exception:  # noqa: BLE001
+                    pass
+
+    return snapshot
+
+
+def _restore_frame_parms(rop: Any, snapshot: Dict[str, Any]) -> None:
+    """Restore frame-range parms from a prior snapshot."""
+    if "trange" in snapshot:
+        try:
+            rop.parm("trange").set(snapshot["trange"])
+        except Exception:  # noqa: BLE001
+            pass
+
+    if "f" in snapshot:
+        try:
+            f_parm = rop.parmTuple("f")
+            if f_parm is not None:
+                f_parm.set(tuple(snapshot["f"]))
+        except Exception:  # noqa: BLE001
+            pass
+    else:
+        for name in ("f1", "f2", "f3"):
+            if name in snapshot:
+                try:
+                    parm = rop.parm(name)
+                    if parm is not None:
+                        parm.set(snapshot[name])
+                except Exception:  # noqa: BLE001
+                    pass
+
+
 def _eval_output_pattern(rop: Any) -> Optional[str]:
     """Evaluate the first available output parm on a ROP."""
     output_parms = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
@@ -141,11 +199,13 @@ def create_rop_chunks(
         raise ValueError(f"Node is not a render node: {rop_path}")
 
     output_pattern = _eval_output_pattern(rop)
+    parm_snapshot = _snapshot_frame_parms(rop)
 
     metadata: Dict[str, Any] = {
         "frame_range": [start, end, increment],
         "rop_path": rop_path,
         "output_pattern": output_pattern,
+        "parm_snapshot": parm_snapshot,
     }
 
     # Build one callable per frame
@@ -237,20 +297,23 @@ def launch_rop_job(
         "runner": runner,
         "token": token,
         "rop_path": rop_path,
+        "rop": rop,
         "frame_range": metadata["frame_range"],
         "output_pattern": metadata.get("output_pattern"),
+        "parm_snapshot": metadata.get("parm_snapshot", {}),
         "total_frames": len(chunks),
     }
 
     # Drive the runner from Houdini's event loop: each pump tick
     # executes one bounded frame step. The callback removes itself
-    # when the runner reaches a terminal state.
+    # and restores original parms when the runner reaches a terminal state.
     def _pump_callback() -> None:
         job = _rop_jobs.get(job_id)
         if job is None:
             return
         r: ChunkedRunner = job["runner"]
         if r.is_terminal:
+            _restore_frame_parms(job["rop"], job.get("parm_snapshot", {}))
             try:
                 hou.ui.removeEventLoopCallback(_pump_callback)
             except Exception:  # noqa: BLE001
@@ -258,6 +321,7 @@ def launch_rop_job(
             return
         r.step()
         if r.is_terminal:
+            _restore_frame_parms(job["rop"], job.get("parm_snapshot", {}))
             try:
                 hou.ui.removeEventLoopCallback(_pump_callback)
             except Exception:  # noqa: BLE001

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
@@ -242,6 +242,29 @@ def launch_rop_job(
         "total_frames": len(chunks),
     }
 
+    # Drive the runner from Houdini's event loop: each pump tick
+    # executes one bounded frame step. The callback removes itself
+    # when the runner reaches a terminal state.
+    def _pump_callback() -> None:
+        job = _rop_jobs.get(job_id)
+        if job is None:
+            return
+        r: ChunkedRunner = job["runner"]
+        if r.is_terminal:
+            try:
+                hou.ui.removeEventLoopCallback(_pump_callback)
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        r.step()
+        if r.is_terminal:
+            try:
+                hou.ui.removeEventLoopCallback(_pump_callback)
+            except Exception:  # noqa: BLE001
+                pass
+
+    hou.ui.addEventLoopCallback(_pump_callback)
+
     return {
         "success": True,
         "job_id": job_id,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
@@ -290,7 +290,7 @@ def launch_rop_job(
         }
 
     token = CancelToken()
-    runner = ChunkedRunner(chunks, cancel_token=token, total=len(chunks))
+    runner = ChunkedRunner(chunks, cancel_token=token)
     job_id = f"rop-{uuid.uuid4().hex[:12]}"
 
     _rop_jobs[job_id] = {

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_rop_chunked.py
@@ -1,0 +1,330 @@
+"""Chunked ROP runner — bounded frame-by-frame ROP render.
+
+Wraps the core ChunkedRunner contract so that each frame is a single
+bounded step: one ``rop.render()`` call per frame with per-frame
+parm overrides. This gives the host event-loop a checkpoint between
+frames, making cancellation observable, progress monotonic, and the
+terminal outcome publishable exactly once.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from dcc_mcp_core.cancellation import CancelToken
+from dcc_mcp_core.chunked_runner import ChunkedRunner
+
+# ---------------------------------------------------------------------------
+# ROP job registry — shared state for launch / poll / cancel
+# ---------------------------------------------------------------------------
+
+_rop_jobs: Dict[str, Dict[str, Any]] = {}
+
+
+def _normalize_frame_range(frame_range: List[float]) -> Tuple[float, float, float]:
+    """Validate and normalize a frame range, returning (start, end, increment)."""
+    if not frame_range or len(frame_range) < 2:
+        raise ValueError("frame_range must be [start, end, optional increment]")
+    start = float(frame_range[0])
+    end = float(frame_range[1])
+    increment = float(frame_range[2]) if len(frame_range) >= 3 else 1.0
+    if increment <= 0:
+        raise ValueError("frame_range increment must be greater than zero")
+    if end < start:
+        raise ValueError("frame_range end must be >= start")
+    return start, end, increment
+
+
+def _set_single_frame_range(rop: Any, frame: float) -> None:
+    """Set a ROP's frame range parms to render only *frame*."""
+    # Some ROPs use `f` (tuple), others use `f1`/`f2`/`f3` scalars.
+    # Setting trange=1 enables explicit frame range mode.
+    try:
+        rop.parm("trange").set(1)
+    except Exception:  # noqa: BLE001
+        pass
+
+    f_parm = rop.parmTuple("f")
+    if f_parm is not None:
+        try:
+            f_parm.set((frame, frame, 1.0))
+            return
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Fallback to individual parms
+    for name, value in (("f1", frame), ("f2", frame), ("f3", 1.0)):
+        parm = rop.parm(name)
+        if parm is not None:
+            try:
+                parm.set(value)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _eval_output_pattern(rop: Any) -> Optional[str]:
+    """Evaluate the first available output parm on a ROP."""
+    output_parms = ("picture", "vm_picture", "lopoutput", "sopoutput", "filename", "outputimage")
+    for name in output_parms:
+        parm = rop.parm(name)
+        if parm is not None:
+            try:
+                val = parm.eval()
+                if val:
+                    return str(val)
+            except Exception:  # noqa: BLE001
+                continue
+    return None
+
+
+def _expand_frame_path(output_path: str, frame: float) -> str:
+    """Replace Houdini frame tokens with an exact frame number."""
+    for token in ("$F4", "$F3", "$F2", "$F"):
+        if token in output_path:
+            if len(token) > 2:
+                width = int(token[2:])
+            else:
+                width = 1
+            return output_path.replace(token, f"{int(frame):0{width}d}")
+    # No token — append frame number before the extension
+    base, ext = os.path.splitext(output_path)
+    return f"{base}.{int(frame):04d}{ext}"
+
+
+def _render_single_rop_frame(rop: Any, frame: float) -> Optional[str]:
+    """Render one ROP frame. Returns an error message or None on success."""
+    _set_single_frame_range(rop, frame)
+    try:
+        rop.render(verbose=False)
+    except TypeError:
+        rop.render()
+    except Exception as exc:
+        return f"{type(exc).__name__}: {exc}"
+    return None
+
+
+def _make_frame_chunk(rop: Any, frame: float) -> Callable[[], None]:
+    """Return a closure that renders one ROP frame.
+
+    Late-binding is avoided by capturing the values as default arguments.
+    """
+
+    def _chunk() -> None:
+        error = _render_single_rop_frame(rop, frame)
+        if error is not None:
+            raise RuntimeError(f"ROP frame {frame} render failed: {error}")
+
+    _chunk._frame = frame  # type: ignore[attr-defined]
+    return _chunk
+
+
+def create_rop_chunks(
+    hou: Any,
+    rop_path: str,
+    frame_range: List[float],
+) -> Tuple[List[Callable[[], Any]], Any, Dict[str, Any]]:
+    """Create a list of callables for ChunkedRunner, one per ROP frame.
+
+    Returns:
+        (chunks, rop, metadata) where:
+        - chunks: list of callables for ChunkedRunner
+        - rop: the resolved ROP node
+        - metadata: dict with frame_range, rop_path, output_pattern
+    """
+    start, end, increment = _normalize_frame_range(frame_range)
+    rop = hou.node(rop_path)
+    if rop is None:
+        raise ValueError(f"ROP node not found: {rop_path}")
+    if not hasattr(rop, "render"):
+        raise ValueError(f"Node is not a render node: {rop_path}")
+
+    output_pattern = _eval_output_pattern(rop)
+
+    metadata: Dict[str, Any] = {
+        "frame_range": [start, end, increment],
+        "rop_path": rop_path,
+        "output_pattern": output_pattern,
+    }
+
+    # Build one callable per frame
+    chunks: List[Callable[[], Any]] = []
+    frame = start
+    tolerance = abs(increment) * 1e-9
+    while frame <= end + tolerance:
+        chunks.append(_make_frame_chunk(rop=rop, frame=frame))
+        frame += increment
+
+    return chunks, rop, metadata
+
+
+def _collect_written_files(
+    output_pattern: Optional[str],
+    completed: int,
+    frame_range: List[float],
+) -> List[str]:
+    """Return the list of written files after *completed* frames."""
+    if not output_pattern:
+        return []
+    start, end, increment = _normalize_frame_range(frame_range)
+    written = []
+    frame = start
+    count = 0
+    tolerance = abs(increment) * 1e-9
+    while frame <= end + tolerance and count < completed:
+        frame_output = _expand_frame_path(output_pattern, frame)
+        if os.path.isfile(frame_output):
+            written.append(frame_output)
+        frame += increment
+        count += 1
+    return written
+
+
+def _collect_skipped_frames(
+    output_pattern: Optional[str],
+    completed: int,
+    frame_range: List[float],
+) -> List[float]:
+    """Return the list of frame numbers that were skipped (not rendered)."""
+    start, end, increment = _normalize_frame_range(frame_range)
+    skipped = []
+    frame = start
+    count = 0
+    tolerance = abs(increment) * 1e-9
+    while frame <= end + tolerance:
+        if count >= completed:
+            skipped.append(frame)
+        frame += increment
+        count += 1
+    return skipped
+
+
+# ---------------------------------------------------------------------------
+# Launch / poll / cancel
+# ---------------------------------------------------------------------------
+
+
+def launch_rop_job(
+    rop_path: str,
+    frame_range: List[float],
+) -> Dict[str, Any]:
+    """Launch a chunked ROP render job. Returns a job descriptor dict.
+
+    The returned dict contains ``job_id`` for polling via
+    :func:`get_rop_job` and cancelling via :func:`cancel_rop_job`.
+    """
+    import hou  # noqa: PLC0415
+
+    try:
+        chunks, rop, metadata = create_rop_chunks(
+            hou=hou,
+            rop_path=rop_path,
+            frame_range=frame_range,
+        )
+    except (ValueError, RuntimeError) as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "job_id": None,
+        }
+
+    token = CancelToken()
+    runner = ChunkedRunner(chunks, cancel_token=token, total=len(chunks))
+    job_id = f"rop-{uuid.uuid4().hex[:12]}"
+
+    _rop_jobs[job_id] = {
+        "runner": runner,
+        "token": token,
+        "rop_path": rop_path,
+        "frame_range": metadata["frame_range"],
+        "output_pattern": metadata.get("output_pattern"),
+        "total_frames": len(chunks),
+    }
+
+    return {
+        "success": True,
+        "job_id": job_id,
+        "state": "running",
+        "progress": {
+            "completed": 0,
+            "total": len(chunks),
+        },
+        "frame_range": metadata["frame_range"],
+        "rop_path": rop_path,
+        "output_pattern": metadata.get("output_pattern"),
+    }
+
+
+def get_rop_job(job_id: str) -> Dict[str, Any]:
+    """Read the current state of a ROP render job.
+
+    Returns a dict with ``state``, ``progress``, and terminal fields
+    (``written_files``, ``skipped_frames``, ``error``) when the job
+    has reached a terminal state.
+    """
+    job = _rop_jobs.get(job_id)
+    if job is None:
+        return {"success": False, "error": f"Job not found: {job_id}", "state": "unknown"}
+
+    runner: ChunkedRunner = job["runner"]
+    progress = runner.progress
+    outcome = runner.outcome
+
+    result: Dict[str, Any] = {
+        "success": True,
+        "job_id": job_id,
+        "progress": {
+            "completed": progress.completed,
+            "total": progress.total,
+            "last_step_at": progress.last_step_at,
+        },
+    }
+
+    if outcome is not None:
+        result["state"] = outcome.status
+        if outcome.status == "completed":
+            result["written_files"] = _collect_written_files(
+                job["output_pattern"],
+                progress.completed,
+                job["frame_range"],
+            )
+            result["skipped_frames"] = []
+        elif outcome.status == "cancelled":
+            result["written_files"] = _collect_written_files(
+                job["output_pattern"],
+                progress.completed,
+                job["frame_range"],
+            )
+            result["skipped_frames"] = _collect_skipped_frames(
+                job["output_pattern"],
+                progress.completed,
+                job["frame_range"],
+            )
+        elif outcome.status == "failed":
+            result["error"] = outcome.error
+    else:
+        result["state"] = "running"
+
+    return result
+
+
+def cancel_rop_job(job_id: str) -> Dict[str, Any]:
+    """Cancel a running ROP render job. Repeated calls are safe."""
+    job = _rop_jobs.get(job_id)
+    if job is None:
+        return {"success": False, "error": f"Job not found: {job_id}", "state": "unknown"}
+
+    runner: ChunkedRunner = job["runner"]
+    runner.cancel()
+
+    progress = runner.progress
+    return {
+        "success": True,
+        "job_id": job_id,
+        "state": "cancelling",
+        "progress": {
+            "completed": progress.completed,
+            "total": progress.total,
+        },
+    }

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -123,8 +123,8 @@ def render_rop(
 
 
 def render_rop_chunked(
-    rop_path: str,
-    frame_range: List[float],
+    rop_path: Optional[str] = None,
+    frame_range: Optional[List[float]] = None,
     action: str = "launch",
     job_id: Optional[str] = None,
 ) -> dict:
@@ -132,12 +132,12 @@ def render_rop_chunked(
 
     Parameters
     ----------
-    rop_path : str
-        Path to the ROP node.
-    frame_range : list of float
-        ``[start, end]`` or ``[start, end, increment]``.
     action : str
         ``"launch"`` (default), ``"poll"``, or ``"cancel"``.
+    rop_path : str, optional
+        Path to the ROP node. Required for ``"launch"``.
+    frame_range : list of float, optional
+        ``[start, end]`` or ``[start, end, increment]``. Required for ``"launch"``.
     job_id : str, optional
         Required for ``"poll"`` and ``"cancel"`` actions.
 
@@ -156,7 +156,7 @@ def render_rop_chunked(
         result = cancel_rop_job(job_id)
         if result["success"]:
             return skill_success("ROP chunked job cancel requested", **result)
-        return skill_error(result["error"], job_id=job_id)
+        return skill_error("Cancel failed", result["error"], job_id=job_id)
 
     if action == "poll":
         if not job_id:
@@ -164,9 +164,11 @@ def render_rop_chunked(
         result = get_rop_job(job_id)
         if result["success"]:
             return skill_success("ROP chunked job status", **result)
-        return skill_error(result["error"], job_id=job_id)
+        return skill_error("Poll failed", result["error"], job_id=job_id)
 
     # action == "launch"
+    if not rop_path:
+        return skill_error("Missing rop_path", "rop_path is required for launch action")
     if not frame_range or len(frame_range) < 2:
         return skill_error(
             "Invalid frame range",

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -1,4 +1,4 @@
-"""Render a ROP node and report written files, elapsed time, and diagnostics."""
+"""Render a ROP node — blocking, background, and chunked variants."""
 
 from __future__ import annotations
 
@@ -115,6 +115,68 @@ def render_rop(
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to render ROP")
+
+
+# ---------------------------------------------------------------------------
+# Chunked ROP — launch / poll / cancel via core ChunkedRunner
+# ---------------------------------------------------------------------------
+
+
+def render_rop_chunked(
+    rop_path: str,
+    frame_range: List[float],
+    action: str = "launch",
+    job_id: Optional[str] = None,
+) -> dict:
+    """Render a ROP node with per-frame chunked execution via core ChunkedRunner.
+
+    Parameters
+    ----------
+    rop_path : str
+        Path to the ROP node.
+    frame_range : list of float
+        ``[start, end]`` or ``[start, end, increment]``.
+    action : str
+        ``"launch"`` (default), ``"poll"``, or ``"cancel"``.
+    job_id : str, optional
+        Required for ``"poll"`` and ``"cancel"`` actions.
+
+    Returns
+    -------
+    dict
+        For ``launch``: ``{success, job_id, state, progress, frame_range, ...}``
+        For ``poll``: ``{success, job_id, state, progress, written_files, ...}``
+        For ``cancel``: ``{success, job_id, state, progress}``
+    """
+    from _rop_chunked import cancel_rop_job, get_rop_job, launch_rop_job  # noqa: E402, PLC0415
+
+    if action == "cancel":
+        if not job_id:
+            return skill_error("Missing job_id", "job_id is required for cancel action")
+        result = cancel_rop_job(job_id)
+        if result["success"]:
+            return skill_success("ROP chunked job cancel requested", **result)
+        return skill_error(result["error"], job_id=job_id)
+
+    if action == "poll":
+        if not job_id:
+            return skill_error("Missing job_id", "job_id is required for poll action")
+        result = get_rop_job(job_id)
+        if result["success"]:
+            return skill_success("ROP chunked job status", **result)
+        return skill_error(result["error"], job_id=job_id)
+
+    # action == "launch"
+    if not frame_range or len(frame_range) < 2:
+        return skill_error(
+            "Invalid frame range",
+            "frame_range must be [start, end, optional increment]",
+        )
+
+    result = launch_rop_job(rop_path=rop_path, frame_range=frame_range)
+    if result["success"]:
+        return skill_success("ROP chunked job launched", **result)
+    return skill_error(result["error"], rop_path=rop_path)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -249,9 +249,9 @@ tools:
             exact ROP output parameter and creates same-directory staging names;
             the source HIP and final paths are never changed or overwritten.
           properties:
-          mode:
-            type: string
-            enum: [staged_no_clobber]
+            mode:
+              type: string
+              enum: [staged_no_clobber]
   - name: render_rop_chunked
     description: >-
       Render a ROP/output driver using per-frame chunked execution via the core

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -249,9 +249,46 @@ tools:
             exact ROP output parameter and creates same-directory staging names;
             the source HIP and final paths are never changed or overwritten.
           properties:
-            mode:
-              type: string
-              enum: [staged_no_clobber]
+          mode:
+            type: string
+            enum: [staged_no_clobber]
+  - name: render_rop_chunked
+    description: >-
+      Render a ROP/output driver using per-frame chunked execution via the core
+      ChunkedRunner. Each frame is a bounded step — UI stays interactive,
+      cancellation is observable at checkpoints, and only partial outputs are
+      reported on cancel. Supports launch/poll/cancel via the ``action`` param.
+    source_file: scripts/render_rop.py
+    entry_point: render_rop_chunked
+    execution: async
+    affinity: main
+    timeout_hint_secs: 7200
+    group: render
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [rop_path, frame_range]
+      properties:
+        rop_path:
+          type: string
+        frame_range:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 3
+        action:
+          type: string
+          enum: [launch, poll, cancel]
+          default: launch
+        job_id:
+          type: string
+          description: "Required for poll/cancel actions."
   - name: get_render_job
     description: >-
       Read bounded status, output progress, elapsed time, and ETA for a background

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -273,22 +273,23 @@ tools:
       idempotent_hint: false
     input_schema:
       type: object
-      required: [rop_path, frame_range]
+      required: [action]
       properties:
+        action:
+          type: string
+          enum: [launch, poll, cancel]
         rop_path:
           type: string
+          description: "Required for launch action."
         frame_range:
           type: array
           items: {type: number}
           minItems: 2
           maxItems: 3
-        action:
-          type: string
-          enum: [launch, poll, cancel]
-          default: launch
+          description: "Required for launch action. [start, end] or [start, end, increment]."
         job_id:
           type: string
-          description: "Required for poll/cancel actions."
+          description: "Required for poll and cancel actions."
   - name: get_render_job
     description: >-
       Read bounded status, output progress, elapsed time, and ETA for a background

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   to low-res target. Pair with houdini-render for render output and
   houdini-materials for shader assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Stage. Use it to list prims, inspect one prim, or read bounded attribute
   values. Not for USD authoring, import, or export.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.45+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -151,28 +151,28 @@ def test_assemble_houdini_package_can_pin_validated_core(
     dist_dir.mkdir()
     adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
     adapter_wheel.write_bytes(b"adapter")
-    core_wheel = tmp_path / "dcc_mcp_core-0.19.45-cp38-abi3-win_amd64.whl"
+    core_wheel = tmp_path / "dcc_mcp_core-0.19.68-cp38-abi3-win_amd64.whl"
     core_wheel.write_bytes(b"core")
 
     def fail_resolve(min_version=pkg.MIN_CORE_VERSION):
         raise AssertionError("explicit core version should skip PyPI latest resolution")
 
     def download_core_wheels(version_arg, platform, dest_dir):
-        assert version_arg == "0.19.45"
+        assert version_arg == "0.19.68"
         assert platform == "win64"
         return [core_wheel]
 
     monkeypatch.setattr(pkg, "resolve_core_version", fail_resolve)
     monkeypatch.setattr(pkg, "download_core_wheels", download_core_wheels)
 
-    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.45")
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.68")
 
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
         readme = zf.read("dcc_mcp_houdini/README.txt").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
-    assert "dcc-mcp-core wheels: 0.19.45" in readme
-    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.45." in readme
+    assert "dcc-mcp-core wheels: 0.19.68" in readme
+    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.68." in readme
 
 
 def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
@@ -186,7 +186,7 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
     )
 
     with pytest.raises(RuntimeError, match="Bundled core drift"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.45")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.68")
 
 
 def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
@@ -196,12 +196,12 @@ def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> Non
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.45-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.68-cp38-abi3-win_amd64.whl",
         include_scene_hook=False,
     )
 
     with pytest.raises(RuntimeError, match="/scripts/456.py"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.45")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.68")
 
 
 def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
@@ -211,13 +211,13 @@ def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.45-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.68-cp38-abi3-win_amd64.whl",
     )
 
-    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.45")
+    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.68")
 
     assert matrix["adapter"] == pkg.get_package_version()
-    assert matrix["core"] == "0.19.45"
+    assert matrix["core"] == "0.19.68"
     assert matrix["server"] == pkg.get_package_version()
     assert matrix["cli"] == pkg.get_package_version()
 

--- a/tests/test_rop_chunked.py
+++ b/tests/test_rop_chunked.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from skill_loader import skill_script_import_context
@@ -20,9 +20,7 @@ _SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skill
 
 def _load_script(skill_name: str, script_name: str):
     path = _SKILLS_ROOT / skill_name / "scripts" / script_name
-    spec = importlib.util.spec_from_file_location(
-        f"{skill_name}_{path.stem}", path
-    )
+    spec = importlib.util.spec_from_file_location(f"{skill_name}_{path.stem}", path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -125,7 +123,7 @@ class TestCreateRopChunks:
     def test_set_single_frame_range_mutates_parms(self) -> None:
         mod = _load_script("houdini-render", "_rop_chunked.py")
         rop = _mock_rop()
-        hou = _mock_hou(rop)
+        _ = _mock_hou(rop)  # registers mock hou in sys.modules
 
         mod._set_single_frame_range(rop, 7.0)
         # After setting, f1/f2 should be 7.0, f3 should be 1.0
@@ -139,7 +137,7 @@ class TestCreateRopChunks:
     def test_snapshot_restore_roundtrip(self) -> None:
         mod = _load_script("houdini-render", "_rop_chunked.py")
         rop = _mock_rop()
-        hou = _mock_hou(rop)
+        _ = _mock_hou(rop)  # registers mock hou in sys.modules
 
         # Snapshot original values
         snapshot = mod._snapshot_frame_parms(rop)
@@ -162,7 +160,6 @@ class TestCreateRopChunks:
 
 
 class TestRenderRopChunkedDispatch:
-
     @pytest.fixture(autouse=True)
     def _preload(self) -> None:
         """Ensure _rop_chunked is importable by render_rop's lazy import."""
@@ -176,9 +173,7 @@ class TestRenderRopChunkedDispatch:
         hou = _mock_hou(rop)
 
         with patch.dict(sys.modules, {"hou": hou}):
-            result = mod.render_rop_chunked(
-                rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch"
-            )
+            result = mod.render_rop_chunked(rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch")
 
         assert result["success"] is True
         assert result["context"]["job_id"] is not None
@@ -190,14 +185,10 @@ class TestRenderRopChunkedDispatch:
         hou = _mock_hou(rop)
 
         with patch.dict(sys.modules, {"hou": hou}):
-            launch_result = mod.render_rop_chunked(
-                rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch"
-            )
+            launch_result = mod.render_rop_chunked(rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch")
             job_id = launch_result["context"]["job_id"]
 
-            poll_result = mod.render_rop_chunked(
-                action="poll", job_id=job_id
-            )
+            poll_result = mod.render_rop_chunked(action="poll", job_id=job_id)
 
         assert poll_result["success"] is True
         assert poll_result["context"]["state"] == "running"
@@ -205,9 +196,7 @@ class TestRenderRopChunkedDispatch:
     def test_poll_unknown_job(self) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
 
-        result = mod.render_rop_chunked(
-            action="poll", job_id="rop-nonexistent"
-        )
+        result = mod.render_rop_chunked(action="poll", job_id="rop-nonexistent")
 
         assert result["success"] is False
         assert "not found" in result["error"].lower()
@@ -218,14 +207,10 @@ class TestRenderRopChunkedDispatch:
         hou = _mock_hou(rop)
 
         with patch.dict(sys.modules, {"hou": hou}):
-            launch_result = mod.render_rop_chunked(
-                rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch"
-            )
+            launch_result = mod.render_rop_chunked(rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch")
             job_id = launch_result["context"]["job_id"]
 
-            cancel_result = mod.render_rop_chunked(
-                action="cancel", job_id=job_id
-            )
+            cancel_result = mod.render_rop_chunked(action="cancel", job_id=job_id)
 
         assert cancel_result["success"] is True
         assert cancel_result["context"]["state"] == "cancelling"
@@ -233,9 +218,7 @@ class TestRenderRopChunkedDispatch:
     def test_cancel_unknown_job(self) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
 
-        result = mod.render_rop_chunked(
-            action="cancel", job_id="rop-ghost"
-        )
+        result = mod.render_rop_chunked(action="cancel", job_id="rop-ghost")
 
         assert result["success"] is False
         assert "not found" in result["error"].lower()
@@ -264,9 +247,7 @@ class TestRenderRopChunkedDispatch:
     def test_launch_missing_frame_range(self) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
 
-        result = mod.render_rop_chunked(
-            action="launch", rop_path="/out/mantra1"
-        )
+        result = mod.render_rop_chunked(action="launch", rop_path="/out/mantra1")
         assert result["success"] is False
         assert "frame_range" in result["error"].lower()
 
@@ -422,7 +403,7 @@ class TestChunkedRunnerIntegration:
         assert len(result["skipped_frames"]) == 8  # frames 3-10
 
     def test_generator_failure(self) -> None:
-        mod = _load_script("houdini-render", "_rop_chunked.py")
+        _ = _load_script("houdini-render", "_rop_chunked.py")  # ensure module loaded
 
         from dcc_mcp_core.chunked_runner import ChunkedRunner
 

--- a/tests/test_rop_chunked.py
+++ b/tests/test_rop_chunked.py
@@ -1,0 +1,515 @@
+"""Mock-hou unit tests for chunked ROP render (_rop_chunked.py).
+
+These tests exercise launch/poll/cancel, step-through completion,
+cancellation with partial outputs, terminal idempotence, parm
+snapshot/restore, and event-loop callback removal.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from skill_loader import skill_script_import_context
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(skill_name: str, script_name: str):
+    path = _SKILLS_ROOT / skill_name / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(
+        f"{skill_name}_{path.stem}", path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _mock_rop(path: str = "/out/mantra1") -> MagicMock:
+    """Create a mock ROP node with parm access."""
+    rop = MagicMock()
+    rop.path.return_value = path
+
+    # Default parm values for trange/f1/f2/f3
+    _parms: dict = {"trange": 1, "f1": 1.0, "f2": 10.0, "f3": 1.0}
+
+    def _parm_side_effect(name):
+        parm = MagicMock()
+        parm.eval.return_value = _parms.get(name, 0)
+        parm.set.side_effect = lambda v: _parms.update({name: v})
+        return parm
+
+    rop.parm.side_effect = _parm_side_effect
+    # f tuple returns None by default (force scalar fallback path)
+    rop.parmTuple.return_value = None
+    return rop
+
+
+def _mock_hou(rop: MagicMock | None = None) -> MagicMock:
+    """Create a mock hou module with a node resolver."""
+    hou = MagicMock()
+    if rop is not None:
+        hou.node.return_value = rop
+    return hou
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_rop_chunks + per-frame helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRopChunks:
+    def test_creates_correct_number_of_chunks(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        chunks, _, metadata = mod.create_rop_chunks(hou, "/out/mantra1", [1, 5, 1])
+        assert len(chunks) == 5
+        assert metadata["frame_range"] == [1.0, 5.0, 1.0]
+        assert metadata["rop_path"] == "/out/mantra1"
+
+    def test_chunks_have_frame_metadata(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        chunks, _, _ = mod.create_rop_chunks(hou, "/out/mantra1", [1, 3, 1])
+        assert chunks[0]._frame == 1.0  # type: ignore[attr-defined]
+        assert chunks[1]._frame == 2.0  # type: ignore[attr-defined]
+        assert chunks[2]._frame == 3.0  # type: ignore[attr-defined]
+
+    def test_rejects_missing_rop(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        hou = MagicMock()
+        hou.node.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            mod.create_rop_chunks(hou, "/out/ghost", [1, 5, 1])
+
+    def test_rejects_non_render_node(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = MagicMock()
+        rop.path.return_value = "/obj/geo1"
+        del rop.render  # remove render attribute
+        hou = _mock_hou(rop)
+
+        with pytest.raises(ValueError, match="not a render node"):
+            mod.create_rop_chunks(hou, "/obj/geo1", [1, 5, 1])
+
+    def test_rejects_invalid_frame_range(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with pytest.raises(ValueError, match="end must be >= start"):
+            mod.create_rop_chunks(hou, "/out/mantra1", [5, 1, 1])
+
+    def test_snapshots_parms(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        _, _, metadata = mod.create_rop_chunks(hou, "/out/mantra1", [1, 5, 1])
+        assert "parm_snapshot" in metadata
+        snapshot = metadata["parm_snapshot"]
+        assert "trange" in snapshot
+        assert snapshot["trange"] == 1
+
+    def test_set_single_frame_range_mutates_parms(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        mod._set_single_frame_range(rop, 7.0)
+        # After setting, f1/f2 should be 7.0, f3 should be 1.0
+        f1 = rop.parm("f1").eval()
+        f2 = rop.parm("f2").eval()
+        f3 = rop.parm("f3").eval()
+        assert f1 == 7.0
+        assert f2 == 7.0
+        assert f3 == 1.0
+
+    def test_snapshot_restore_roundtrip(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        # Snapshot original values
+        snapshot = mod._snapshot_frame_parms(rop)
+        assert snapshot["trange"] == 1
+        assert "f1" in snapshot
+        orig_f1 = snapshot["f1"]
+
+        # Mutate
+        mod._set_single_frame_range(rop, 42.0)
+        assert rop.parm("f1").eval() == 42.0
+
+        # Restore
+        mod._restore_frame_parms(rop, snapshot)
+        assert rop.parm("f1").eval() == orig_f1
+
+
+# ---------------------------------------------------------------------------
+# Tests: launch / poll / cancel (schema dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderRopChunkedDispatch:
+
+    @pytest.fixture(autouse=True)
+    def _preload(self) -> None:
+        """Ensure _rop_chunked is importable by render_rop's lazy import."""
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        # Also register under the bare name that render_rop.py imports
+        sys.modules["_rop_chunked"] = mod
+
+    def test_launch_returns_job_id(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            result = mod.render_rop_chunked(
+                rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch"
+            )
+
+        assert result["success"] is True
+        assert result["context"]["job_id"] is not None
+        assert result["context"]["state"] == "running"
+
+    def test_poll_returns_status(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.render_rop_chunked(
+                rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch"
+            )
+            job_id = launch_result["context"]["job_id"]
+
+            poll_result = mod.render_rop_chunked(
+                action="poll", job_id=job_id
+            )
+
+        assert poll_result["success"] is True
+        assert poll_result["context"]["state"] == "running"
+
+    def test_poll_unknown_job(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+
+        result = mod.render_rop_chunked(
+            action="poll", job_id="rop-nonexistent"
+        )
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_cancel_sets_cancelling_state(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.render_rop_chunked(
+                rop_path="/out/mantra1", frame_range=[1, 5, 1], action="launch"
+            )
+            job_id = launch_result["context"]["job_id"]
+
+            cancel_result = mod.render_rop_chunked(
+                action="cancel", job_id=job_id
+            )
+
+        assert cancel_result["success"] is True
+        assert cancel_result["context"]["state"] == "cancelling"
+
+    def test_cancel_unknown_job(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+
+        result = mod.render_rop_chunked(
+            action="cancel", job_id="rop-ghost"
+        )
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_poll_missing_job_id(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+
+        result = mod.render_rop_chunked(action="poll")
+        assert result["success"] is False
+        assert "job_id" in result["error"].lower()
+
+    def test_cancel_missing_job_id(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+
+        result = mod.render_rop_chunked(action="cancel")
+        assert result["success"] is False
+        assert "job_id" in result["error"].lower()
+
+    def test_launch_missing_rop_path(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+
+        result = mod.render_rop_chunked(action="launch")
+        assert result["success"] is False
+        assert "rop_path" in result["error"].lower()
+
+    def test_launch_missing_frame_range(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+
+        result = mod.render_rop_chunked(
+            action="launch", rop_path="/out/mantra1"
+        )
+        assert result["success"] is False
+        assert "frame_range" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: ChunkedRunner step-through, cancel, terminal idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestChunkedRunnerIntegration:
+    def test_step_through_all_frames(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 4, 1])
+
+        assert launch_result["success"] is True
+        job_id = launch_result["job_id"]
+
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        # Step 1
+        assert runner.step() is True
+        assert runner.progress.completed == 1
+
+        # Step 2
+        assert runner.step() is True
+        assert runner.progress.completed == 2
+
+        # Step 3
+        assert runner.step() is True
+        assert runner.progress.completed == 3
+
+        # Step 4 (terminal)
+        assert runner.step() is False
+        assert runner.outcome is not None
+        assert runner.outcome.status == "completed"
+
+        # Post-terminal step is no-op
+        assert runner.step() is False
+
+    def test_cancel_mid_sequence(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 10, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        # Run 3 frames
+        for _ in range(3):
+            assert runner.step() is True
+        assert runner.progress.completed == 3
+
+        # Cancel
+        cancel_result = mod.cancel_rop_job(job_id)
+        assert cancel_result["success"] is True
+        assert cancel_result["state"] == "cancelling"
+
+        # Next step observes cancellation
+        assert runner.step() is False
+        assert runner.outcome.status == "cancelled"
+        assert runner.progress.completed == 3
+
+    def test_cancel_before_first_step(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 5, 1])
+
+        job_id = launch_result["job_id"]
+        mod.cancel_rop_job(job_id)
+
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+        assert runner.step() is False
+        assert runner.outcome.status == "cancelled"
+        assert runner.progress.completed == 0
+
+    def test_terminal_idempotence(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 2, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        # Complete all steps
+        assert runner.step() is True
+        assert runner.step() is False  # terminal
+
+        # Post-terminal ops are safe
+        assert runner.step() is False
+        mod.cancel_rop_job(job_id)  # should not raise
+        assert runner.outcome.status == "completed"
+        assert runner.progress.completed == 2
+
+    def test_poll_after_completion(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 3, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        # Step through all
+        while runner.step():
+            pass
+
+        result = mod.get_rop_job(job_id)
+        assert result["state"] == "completed"
+        assert result["progress"]["completed"] == 3
+        assert result["skipped_frames"] == []
+
+    def test_poll_after_cancellation(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 10, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        # Run 2 frames then cancel
+        runner.step()
+        runner.step()
+        mod.cancel_rop_job(job_id)
+        runner.step()  # observes cancel
+
+        result = mod.get_rop_job(job_id)
+        assert result["state"] == "cancelled"
+        assert result["progress"]["completed"] == 2
+        assert len(result["skipped_frames"]) == 8  # frames 3-10
+
+    def test_generator_failure(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+
+        from dcc_mcp_core.chunked_runner import ChunkedRunner
+
+        def _failing_step() -> None:
+            raise RuntimeError("render aborted")
+
+        runner = ChunkedRunner([_failing_step], total=1)
+        assert runner.step() is False
+        assert runner.outcome.status == "failed"
+        assert "RuntimeError: render aborted" in (runner.outcome.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Tests: parm snapshot/restore
+# ---------------------------------------------------------------------------
+
+
+class TestParmSnapshotRestore:
+    def test_launch_snapshots_parms(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 5, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        assert "parm_snapshot" in job
+        assert "trange" in job["parm_snapshot"]
+
+    def test_restore_called_on_completion(self) -> None:
+        """Parm restore is called when runner reaches terminal via pump callback."""
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        # Record original values before launch
+        orig_f1 = rop.parm("f1").eval()
+        orig_f2 = rop.parm("f2").eval()
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 3, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        # Step through all frames (each step mutates parms via _set_single_frame_range)
+        while runner.step():
+            pass
+
+        # Manually simulate the pump callback's restore path
+        mod._restore_frame_parms(rop, job["parm_snapshot"])
+
+        assert rop.parm("f1").eval() == orig_f1
+        assert rop.parm("f2").eval() == orig_f2
+
+    def test_restore_called_on_cancel(self) -> None:
+        """Parm restore is called when runner is cancelled."""
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = _mock_rop()
+        hou = _mock_hou(rop)
+
+        orig_f1 = rop.parm("f1").eval()
+
+        with patch.dict(sys.modules, {"hou": hou}):
+            launch_result = mod.launch_rop_job("/out/mantra1", [1, 5, 1])
+
+        job_id = launch_result["job_id"]
+        job = mod._rop_jobs[job_id]
+        runner = job["runner"]
+
+        runner.step()  # mutates to frame 1
+        runner.cancel()
+        runner.step()  # observes cancel
+
+        mod._restore_frame_parms(rop, job["parm_snapshot"])
+        assert rop.parm("f1").eval() == orig_f1
+
+    def test_restore_handles_missing_parms_gracefully(self) -> None:
+        mod = _load_script("houdini-render", "_rop_chunked.py")
+        rop = MagicMock()
+        rop.parm.return_value = None
+        rop.parmTuple.return_value = None
+
+        # Should not raise
+        snapshot = mod._snapshot_frame_parms(rop)
+        assert snapshot == {}
+        mod._restore_frame_parms(rop, snapshot)  # no-op, no crash

--- a/tests/test_rop_chunked.py
+++ b/tests/test_rop_chunked.py
@@ -410,7 +410,7 @@ class TestChunkedRunnerIntegration:
         def _failing_step() -> None:
             raise RuntimeError("render aborted")
 
-        runner = ChunkedRunner([_failing_step], total=1)
+        runner = ChunkedRunner([_failing_step])
         assert runner.step() is False
         assert runner.outcome.status == "failed"
         assert "RuntimeError: render aborted" in (runner.outcome.error or "")


### PR DESCRIPTION
Replace the monolithic foreground HOM call with per-frame bounded steps driven by dcc-mcp-core ChunkedRunner.

## What changed

- **New** `_rop_chunked.py` — per-frame chunked ROP execution with parm snapshot/restore to prevent scene-state corruption
- **Updated** `render_rop.py` — adds `render_rop_chunked(action, rop_path, frame_range, job_id)` with launch/poll/cancel dispatch. `rop_path` and `frame_range` only required for launch; poll/cancel only need `job_id`.
- **Updated** `tools.yaml` — registers `render_rop_chunked` with `required: [action]` (action-specific validation)

## Design

- `_snapshot_frame_parms()` snapshots `trange`/`f`/`f1`/`f2`/`f3` at launch; `_restore_frame_parms()` called on terminal state (complete/fail/cancel) to prevent scene-state corruption.
- `tools.yaml` requires only `action`; `rop_path`/`frame_range` are optional in the schema (launch validates its own inputs in code).
- 28 focused tests covering create_rop_chunks validation, parm snapshot/restore roundtrip, launch/poll/cancel schema dispatch, ChunkedRunner step-through/cancel/idempotence, partial outputs, and graceful handling of missing parms.

## References

- [Houdini issue #103](https://github.com/dcc-mcp/dcc-mcp-houdini/issues/103)
- [Core chunked runner commit `3d3b5fa`](https://github.com/dcc-mcp/dcc-mcp-core/commit/3d3b5fad3f7e9275fbff1188c33aaff601bde792)