### PR TITLE
Make long Houdini cooks recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.19.69`
-- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.69,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
+- `dcc-mcp-core >= 0.19.70`
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.70,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ dcc-mcp-houdini/
 ## Requirements
 
 - Houdini with Python 3.7+ (`hython` or interactive Houdini)
-- `dcc-mcp-core >= 0.19.68`
-- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.68,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
+- `dcc-mcp-core >= 0.19.69`
+- Quickinstall bundles the latest non-prerelease `dcc-mcp-core >= 0.19.69,<1.0.0` by default, or the validated `core_version` passed to a release backfill; no old-core pin is active.
 - See `pyproject.toml` for full dependencies
 
 ## License

--- a/docs/adr/0001-isolate-long-running-houdini-jobs.md
+++ b/docs/adr/0001-isolate-long-running-houdini-jobs.md
@@ -69,6 +69,21 @@ adapter instance.
   complete without a discoverable output pattern and report output verification
   as `unavailable`; render and cache jobs continue to require updated output.
 
+## Node cook routing
+
+- One expected-short live-scene `hou.Node.cook()` is a monolithic async core
+  job. The request returns a core job id; cancellation is acknowledged only
+  after the native call returns.
+- A list of independently bounded node cooks uses the shared chunked host pump,
+  one node per event-loop tick.
+- One potentially long cook uses an isolated `hython` worker against a saved,
+  clean HIP. It returns a durable adapter job id immediately and is polled from
+  disk. The isolated result does not update the GUI scene's in-memory cook
+  cache.
+- Transport timeout, adapter unreachability, and process death are distinct.
+  Agents query existing job state before retrying and rediscover a replacement
+  instance after owner/PID death.
+
 ## Alternatives Considered
 
 - Run render calls on the host thread: rejected because it blocks interactive Houdini.

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -35,7 +35,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.19.69"
+MIN_CORE_VERSION = "0.19.70"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -35,7 +35,7 @@ from packaging.version import Version
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 CORE_PACKAGE = "dcc-mcp-core"
-MIN_CORE_VERSION = "0.19.68"
+MIN_CORE_VERSION = "0.19.69"
 PLATFORMS = ("win64", "linux", "macos")
 PYPI_URL = "https://pypi.org/pypi/{package}/json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.19.68: first release with ChunkedRunner (bounded-step main-thread work)
-    "dcc-mcp-core>=0.19.68,<1.0.0",
+    # 0.19.69: recoverable job strategies and automatic chunk scheduling.
+    "dcc-mcp-core>=0.19.69,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.19.69: recoverable job strategies and automatic chunk scheduling.
-    "dcc-mcp-core>=0.19.69,<1.0.0",
+    # 0.19.70: recoverable job strategies and automatic chunk scheduling.
+    "dcc-mcp-core>=0.19.70,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/dcc_mcp_houdini/_cook_jobs.py
+++ b/src/dcc_mcp_houdini/_cook_jobs.py
@@ -44,6 +44,11 @@ def get_cook_job(job_id: str) -> Dict[str, Any]:
     started_at = result.get("started_at")
     if result.get("state") not in _isolated_jobs._TERMINAL_STATES and isinstance(started_at, (int, float)):
         result["elapsed_secs"] = round(max(0.0, time.time() - started_at), 3)
+    if result.get("worker_liveness") == "unknown":
+        result["recovery_note"] = (
+            "Worker liveness cannot be verified after adapter restart; "
+            "poll this job_id until terminal and do not launch a duplicate cook."
+        )
     return result
 
 

--- a/src/dcc_mcp_houdini/_cook_jobs.py
+++ b/src/dcc_mcp_houdini/_cook_jobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from typing import Any, Dict
 
@@ -40,6 +41,9 @@ def get_cook_job(job_id: str) -> Dict[str, Any]:
     result = _isolated_jobs.read_job(job_id)
     if result.get("job_kind") != "node_cook":
         raise ValueError("job_id does not identify a node-cook job")
+    started_at = result.get("started_at")
+    if result.get("state") not in _isolated_jobs._TERMINAL_STATES and isinstance(started_at, (int, float)):
+        result["elapsed_secs"] = round(max(0.0, time.time() - started_at), 3)
     return result
 
 

--- a/src/dcc_mcp_houdini/_cook_jobs.py
+++ b/src/dcc_mcp_houdini/_cook_jobs.py
@@ -1,0 +1,52 @@
+"""Durable isolated Houdini node-cook jobs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from dcc_mcp_houdini import _isolated_jobs, _rop_jobs
+
+
+def launch_cook_job(hou: Any, node_path: str, force: bool = False) -> Dict[str, Any]:
+    """Launch a saved-scene cook in hython and return its durable job id."""
+    hip_path, _ = _rop_jobs._validate_saved_hip(hou)
+    executable = _rop_jobs._hython_executable()
+    initial, status_path = _isolated_jobs.create_job(
+        {
+            "job_kind": "node_cook",
+            "hip_path": str(hip_path),
+            "node_path": node_path,
+            "force": bool(force),
+        }
+    )
+    worker_path = Path(__file__).resolve().parent / "_cook_worker.py"
+    command = [
+        str(executable),
+        str(worker_path),
+        str(hip_path),
+        node_path,
+        "1" if force else "0",
+        str(status_path),
+    ]
+    child_env = dict(os.environ)
+    child_env["DCC_MCP_BACKGROUND_COOK"] = "1"
+    return _isolated_jobs.launch_job(initial["job_id"], command, child_env)
+
+
+def get_cook_job(job_id: str) -> Dict[str, Any]:
+    """Read and reconcile a durable cook job."""
+    result = _isolated_jobs.read_job(job_id)
+    if result.get("job_kind") != "node_cook":
+        raise ValueError("job_id does not identify a node-cook job")
+    return result
+
+
+def cancel_cook_job(job_id: str) -> Dict[str, Any]:
+    """Cancel a cook worker when this adapter process still owns it."""
+    result = get_cook_job(job_id)
+    if result.get("state") in _isolated_jobs._TERMINAL_STATES:
+        result["cancel_requested"] = False
+        return result
+    return _isolated_jobs.cancel_job(job_id)

--- a/src/dcc_mcp_houdini/_cook_worker.py
+++ b/src/dcc_mcp_houdini/_cook_worker.py
@@ -1,0 +1,60 @@
+"""Isolated hython worker for durable node cooks."""
+
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from dcc_mcp_houdini._status_io import read_status, write_status
+
+
+def _messages(node, method_name: str) -> list:
+    method = getattr(node, method_name, None)
+    if not callable(method):
+        return []
+    try:
+        return list(method())
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def main() -> None:
+    import hou
+
+    hip_arg, node_path, force_arg, status_arg = sys.argv[1:5]
+    status_path = Path(status_arg)
+    status = read_status(status_path)
+    status.update({"state": "running", "started_at": time.time(), "worker_pid": __import__("os").getpid()})
+    write_status(status_path, status)
+    try:
+        hou.hipFile.load(hip_arg, suppress_save_prompt=True, ignore_load_warnings=True)
+        node = hou.node(node_path)
+        if node is None:
+            raise ValueError("Houdini node does not exist: {}".format(node_path))
+        node.cook(force=force_arg == "1")
+        status.update(
+            {
+                "state": "completed",
+                "finished_at": time.time(),
+                "errors": _messages(node, "errors"),
+                "warnings": _messages(node, "warnings"),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        status.update(
+            {
+                "state": "failed",
+                "finished_at": time.time(),
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+            }
+        )
+    if "started_at" in status:
+        status["elapsed_secs"] = round(status["finished_at"] - status["started_at"], 3)
+    write_status(status_path, status)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dcc_mcp_houdini/_isolated_jobs.py
+++ b/src/dcc_mcp_houdini/_isolated_jobs.py
@@ -101,12 +101,16 @@ def launch_job(
     result["pid"] = process.pid
     with _PROCESS_LOCK:
         _PROCESS_HANDLES[job_id] = process
-    return result
+    return _with_ownership(result, True)
 
 
 def _with_ownership(status: Mapping[str, Any], owned: bool) -> Dict[str, Any]:
     result = dict(status)
     result["owned_by_current_process"] = owned
+    if result.get("state") in _TERMINAL_STATES:
+        result["worker_liveness"] = "stopped"
+    else:
+        result["worker_liveness"] = "alive" if owned else "unknown"
     return result
 
 

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -19,7 +19,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Scene lifecycle | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__open_scene` / `houdini_scene_edit__save_scene` |
 | Select & frame | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__find_nodes` → `houdini_scene_edit__set_selection` → `houdini_scene_edit__get_bounding_box` |
 | Edit existing object | `load_skill("houdini-object-ops")` → `houdini_object_ops__get_transform` → `houdini_object_ops__set_transform` → `houdini_object_ops__set_node_flags` |
-| Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → `houdini_nodes__cook_node` |
+| Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → choose `cook_node` (short monolithic), `cook_nodes_chunked` (bounded list), or `start_cook_job` + `get_cook_job` (long durable) |
 | Edit parameters & expressions | `load_skill("houdini-parameters")` → `houdini_parameters__list_parms` → `houdini_parameters__set_parms` / `houdini_parameters__set_expression` |
 | Inspect & rewire graph | `load_skill("houdini-node-graph")` → `houdini_node_graph__get_connections` → `houdini_node_graph__connect_input` / `houdini_node_graph__disconnect_input` |
 | Create & inspect geometry | `load_skill("houdini-geometry")` → `houdini_geometry__create_primitive` → `houdini_geometry__get_geometry_info` → `houdini_geometry__list_attributes` / `houdini_geometry__list_groups` |

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   export/import channel JSON; bake channels and trigger bounded
   simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   export/import channel JSON; bake channels and trigger bounded
   simulation/cache renders. The canonical timeline API.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   set timeline ranges, and build small node chains from structured specs. Use
   when orchestrating repeatable Houdini tasks. Not for inspecting a scene only.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   and report active camera/view state through typed tools. Pair with
   houdini-render for viewport capture and ROP render execution.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   export. Create and manage CHOP networks, motion clips, audio-driven
   channels, and filter effects.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-chops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   export. Create and manage CHOP networks, motion clips, audio-driven
   channels, and filter effects.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   constraints using OBJ-level blend nodes and CHOP-driven channel
   referencing. List and delete existing constraints.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-constraints/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   constraints using OBJ-level blend nodes and CHOP-driven channel
   referencing. List and delete existing constraints.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   objects/signatures/node-type categories, and inspect or trigger safe UI
   actions (headless-safe). Not for scene editing — use domain skills first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-export-preset/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   settings across a team or project. Pair with houdini-interchange for
   one-shot exports or houdini-pipeline for shot packaging.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   these typed tools to query and seed geometry before falling back to custom
   scripts. For mesh edit operations (transform/merge/blast) use houdini-mesh-ops.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   nodes, cook TOP/PDG networks, and execute ROP output-driver chains. Pair with
   houdini-hda for install/save and houdini-render for single-ROP captures.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   loading .hda/.otl assets, building reusable interfaces, or publishing an HDA
   library. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   loading .hda/.otl assets, building reusable interfaces, or publishing an HDA
   library. Not for generic node edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checkpoint/resume, scene snapshots, and husk option configuration. Pair with
   houdini-karma for renderer setup and houdini-render for viewport/ROP renders.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   checkpoint/resume, scene snapshots, and husk option configuration. Pair with
   houdini-karma for renderer setup and houdini-render for viewport/ROP renders.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   ImportToSceneResult. Use as the receiving end of the asset import pipeline
   after an asset-source skill resolves the descriptor.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-import-to-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   ImportToSceneResult. Use as the receiving end of the asset import pipeline
   after an asset-source skill resolves the descriptor.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   plus filesystem probing. Use these typed tools instead of hand-building
   ROP/LOP/SOP networks with raw scripts.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   light mixer, and image output through typed tools. Pair with houdini-render
   for full render execution and houdini-camera-light for scene setup.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-karma/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   light mixer, and image output through typed tools. Pair with houdini-render
   for full render execution and houdini-camera-light for scene setup.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   configure rig skeletons, set rig poses, capture joint skinning weights,
   and apply motion capture data via SOP-level KineFX nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   configure rig skeletons, set rig poses, capture joint skinning weights,
   and apply motion capture data via SOP-level KineFX nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   with houdini-camera-light for individual light control and houdini-render
   for render output.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.4+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-lookdev/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   assignments; and manage adapter-owned material presets. Pair with
   houdini-materials for material creation/assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   houdini-materials (create/assign) and houdini-lookdev (shader-network
   editing, adapter-owned presets).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   houdini-materials (create/assign) and houdini-lookdev (shader-network
   editing, adapter-owned presets).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   workflows from color, roughness, metallic, normal, or displacement maps. Not
   for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-materials/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   workflows from color, roughness, metallic, normal, or displacement maps. Not
   for generic node graph edits.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   triangulate, and convert. Each tool wires the new node into the network and
   returns its path for chaining. Use with houdini-geometry for inspection.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-node-graph/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use instead of arbitrary Python for wiring nodes. For parameters/expressions
   use houdini-parameters; for creating nodes use houdini-nodes.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -57,7 +57,9 @@ Typed HOM node-graph operations for agents. Prefer these tools before using
      Houdini event-loop tick.
    - `start_cook_job` for one potentially long cook in isolated `hython`.
      Save the HIP first, then poll `get_cook_job`; status remains readable
-     after transport loss or adapter restart.
+     after transport loss or adapter restart. A non-terminal result with
+     `worker_liveness: unknown` is last-known state, not proof that the worker
+     is still alive; keep polling the same `job_id` and never launch a duplicate.
 5. `layout_children`
 
 Never retry a timed-out cook blindly. Keep the returned core or isolated

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Houdini nodes through typed HOM operations. Use when building SOP/OBJ/ROP
   networks or automating graph edits. Not for arbitrary Python snippets.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 18.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:
@@ -50,5 +50,17 @@ Typed HOM node-graph operations for agents. Prefer these tools before using
 1. `create_node`
 2. `set_node_parms`
 3. `connect_nodes`
-4. `cook_node`
+4. Choose the cook contract:
+   - `cook_node` for one expected-short live-scene cook. It is an async core
+     job but native `hou.Node.cook()` remains monolithic.
+   - `cook_nodes_chunked` for several independently bounded nodes, one per
+     Houdini event-loop tick.
+   - `start_cook_job` for one potentially long cook in isolated `hython`.
+     Save the HIP first, then poll `get_cook_job`; status remains readable
+     after transport loss or adapter restart.
 5. `layout_children`
+
+Never retry a timed-out cook blindly. Keep the returned core or isolated
+`job_id`, rediscover the Houdini instance, and query status first. If Houdini
+crashed, wait for a new instance registration; persisted core jobs recover as
+`interrupted`, while isolated cook status remains available on disk.

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/cancel_cook_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/cancel_cook_job.py
@@ -1,0 +1,15 @@
+"""Cancel an owned isolated node-cook job."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+from dcc_mcp_houdini import _cook_jobs
+
+
+@skill_entry
+def main(job_id: str) -> dict:
+    try:
+        return skill_success("Processed node-cook cancellation", **_cook_jobs.cancel_cook_job(job_id))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cancel isolated Houdini node-cook job")

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/cook_nodes_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/cook_nodes_chunked.py
@@ -1,0 +1,32 @@
+"""Cook several bounded nodes one per Houdini event-loop tick."""
+
+from __future__ import annotations
+
+from dcc_mcp_core import ChunkedRunner, current_cancel_token
+from dcc_mcp_core.skill import skill_entry
+
+
+def _steps(node_paths, force):
+    import hou
+
+    for node_path in node_paths:
+
+        def _cook(path=node_path):
+            node = hou.node(path)
+            if node is None:
+                raise ValueError("Houdini node does not exist: {}".format(path))
+            node.cook(force=force)
+            return "Cooked {}".format(path)
+
+        yield _cook
+
+
+@skill_entry
+def main(node_paths: list, force: bool = False):
+    if not node_paths:
+        raise ValueError("node_paths must contain at least one node path")
+    return ChunkedRunner(
+        _steps(list(node_paths), force),
+        total=len(node_paths),
+        cancel_token=current_cancel_token(),
+    )

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/get_cook_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/get_cook_job.py
@@ -1,0 +1,15 @@
+"""Read a durable isolated node-cook job."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+from dcc_mcp_houdini import _cook_jobs
+
+
+@skill_entry
+def main(job_id: str) -> dict:
+    try:
+        return skill_success("Read isolated Houdini node-cook job", **_cook_jobs.get_cook_job(job_id))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read isolated Houdini node-cook job")

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/start_cook_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/start_cook_job.py
@@ -1,0 +1,26 @@
+"""Launch a durable isolated node cook."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+from dcc_mcp_houdini import _cook_jobs
+
+
+@skill_entry
+def main(node_path: str, force: bool = False) -> dict:
+    try:
+        import hou
+
+        job = _cook_jobs.launch_cook_job(hou, node_path, force)
+        return skill_success(
+            "Started isolated Houdini node cook",
+            **job,
+            recovery={
+                "poll_tool": "houdini_nodes__get_cook_job",
+                "cancel_tool": "houdini_nodes__cancel_cook_job",
+                "survives_transport_disconnect": True,
+            },
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to start isolated Houdini node cook")

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
@@ -159,7 +159,7 @@ tools:
     read_only: false
     destructive: false
     idempotent: false
-    execution: sync
+    execution: async
     affinity: main
     timeout_hint_secs: 300
     source_file: scripts/cook_node.py
@@ -173,6 +173,107 @@ tools:
     next-tools:
       on-failure:
         - houdini_scripting__get_session_info
+
+  - name: cook_nodes_chunked
+    description: >-
+      Cook several independently bounded Houdini nodes, advancing one node per
+      UI event-loop tick. Use this only when each individual node cook is
+      expected to stay short; use start_cook_job for one potentially long cook.
+    input_schema:
+      type: object
+      required: [node_paths]
+      properties:
+        node_paths:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        force:
+          type: boolean
+          default: false
+    read_only: false
+    destructive: false
+    idempotent: false
+    execution: async
+    job_strategy: chunked
+    affinity: main
+    timeout_hint_secs: 300
+    source_file: scripts/cook_nodes_chunked.py
+    tool_role: action
+    risk: medium
+    search_aliases: [chunked cook, batch cook nodes, responsive cook]
+
+  - name: start_cook_job
+    description: >-
+      Start one potentially long node cook in an isolated hython process and
+      return a durable job_id immediately. Requires a saved, clean HIP file and
+      does not update the live GUI scene's in-memory cook cache.
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+        force:
+          type: boolean
+          default: false
+    read_only: false
+    destructive: false
+    idempotent: false
+    execution: sync
+    job_strategy: isolated
+    affinity: main
+    timeout_hint_secs: 10
+    source_file: scripts/start_cook_job.py
+    tool_role: action
+    risk: medium
+    search_aliases: [background cook, durable cook, long cook, isolated hython cook]
+    next-tools:
+      on-success:
+        - houdini_nodes__get_cook_job
+
+  - name: get_cook_job
+    description: >-
+      Query a durable isolated node-cook job after transport disconnects or
+      adapter restart. Terminal status remains readable from disk.
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+    read_only: true
+    destructive: false
+    idempotent: true
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 5
+    source_file: scripts/get_cook_job.py
+    tool_role: read_only
+    risk: low
+    search_aliases: [cook job status, resume cook, query durable cook, recover cook job]
+
+  - name: cancel_cook_job
+    description: >-
+      Cancel an isolated node-cook job only while this adapter process still
+      owns its worker handle. After adapter restart, status stays queryable but
+      cancellation ownership is intentionally not reconstructed.
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+    read_only: false
+    destructive: true
+    idempotent: true
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 10
+    source_file: scripts/cancel_cook_job.py
+    tool_role: destructive
+    risk: high
+    search_aliases: [cancel cook, stop background cook, terminate cook job]
 
   - name: layout_children
     description: "Layout children under a Houdini network node. Mutates node positions only."

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-parameters/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   tools. Use instead of arbitrary Python for reading/setting parms, adding spare
   parms, and managing expressions. For node connections use houdini-node-graph.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-pipeline/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   shot/package manifest (frame range, cameras, output nodes, caches, written
   files). No dependency on private production services.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   hanging the host. Pair with
   houdini-camera-light to set up cameras and lights first.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene-edit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   everyday scene navigation and file operations. Not for node authoring (use
   houdini-nodes) or geometry/transform edits (use houdini-object-ops).
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   details. Not for creating geometry, sims, or exports — use authoring or
   interchange skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   session diagnostics. Not for routine scene edits — prefer houdini-scene or
   future domain skills.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   to low-res target. Pair with houdini-render for render output and
   houdini-materials for shader assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-texture-bake/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   to low-res target. Pair with houdini-render for render output and
   houdini-materials for shader assignment.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 19.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Stage. Use it to list prims, inspect one prim, or read bounded attribute
   values. Not for USD authoring, import, or export.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.68+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-usd-lops/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Stage. Use it to list prims, inspect one prim, or read bounded attribute
   values. Not for USD authoring, import, or export.
 license: MIT
-compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.69+"
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
 metadata:
   dcc-mcp:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -151,28 +151,28 @@ def test_assemble_houdini_package_can_pin_validated_core(
     dist_dir.mkdir()
     adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
     adapter_wheel.write_bytes(b"adapter")
-    core_wheel = tmp_path / "dcc_mcp_core-0.19.68-cp38-abi3-win_amd64.whl"
+    core_wheel = tmp_path / "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl"
     core_wheel.write_bytes(b"core")
 
     def fail_resolve(min_version=pkg.MIN_CORE_VERSION):
         raise AssertionError("explicit core version should skip PyPI latest resolution")
 
     def download_core_wheels(version_arg, platform, dest_dir):
-        assert version_arg == "0.19.68"
+        assert version_arg == "0.19.69"
         assert platform == "win64"
         return [core_wheel]
 
     monkeypatch.setattr(pkg, "resolve_core_version", fail_resolve)
     monkeypatch.setattr(pkg, "download_core_wheels", download_core_wheels)
 
-    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.68")
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.69")
 
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
         readme = zf.read("dcc_mcp_houdini/README.txt").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
-    assert "dcc-mcp-core wheels: 0.19.68" in readme
-    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.68." in readme
+    assert "dcc-mcp-core wheels: 0.19.69" in readme
+    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.69." in readme
 
 
 def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
@@ -186,7 +186,7 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
     )
 
     with pytest.raises(RuntimeError, match="Bundled core drift"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.68")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.69")
 
 
 def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
@@ -196,12 +196,12 @@ def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> Non
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.68-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl",
         include_scene_hook=False,
     )
 
     with pytest.raises(RuntimeError, match="/scripts/456.py"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.68")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.69")
 
 
 def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
@@ -211,13 +211,13 @@ def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.68-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl",
     )
 
-    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.68")
+    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.69")
 
     assert matrix["adapter"] == pkg.get_package_version()
-    assert matrix["core"] == "0.19.68"
+    assert matrix["core"] == "0.19.69"
     assert matrix["server"] == pkg.get_package_version()
     assert matrix["cli"] == pkg.get_package_version()
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -151,28 +151,28 @@ def test_assemble_houdini_package_can_pin_validated_core(
     dist_dir.mkdir()
     adapter_wheel = dist_dir / "dcc_mcp_houdini-{}-py3-none-any.whl".format(version)
     adapter_wheel.write_bytes(b"adapter")
-    core_wheel = tmp_path / "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl"
+    core_wheel = tmp_path / "dcc_mcp_core-0.19.70-cp38-abi3-win_amd64.whl"
     core_wheel.write_bytes(b"core")
 
     def fail_resolve(min_version=pkg.MIN_CORE_VERSION):
         raise AssertionError("explicit core version should skip PyPI latest resolution")
 
     def download_core_wheels(version_arg, platform, dest_dir):
-        assert version_arg == "0.19.69"
+        assert version_arg == "0.19.70"
         assert platform == "win64"
         return [core_wheel]
 
     monkeypatch.setattr(pkg, "resolve_core_version", fail_resolve)
     monkeypatch.setattr(pkg, "download_core_wheels", download_core_wheels)
 
-    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.69")
+    zip_path = pkg.assemble("win64", dist_dir, tmp_path / "out", core_version="0.19.70")
 
     with zipfile.ZipFile(zip_path) as zf:
         names = set(zf.namelist())
         readme = zf.read("dcc_mcp_houdini/README.txt").decode("utf-8")
     assert "dcc_mcp_houdini/wheels/{}".format(core_wheel.name) in names
-    assert "dcc-mcp-core wheels: 0.19.69" in readme
-    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.69." in readme
+    assert "dcc-mcp-core wheels: 0.19.70" in readme
+    assert "Core bundle policy: explicit validated dcc-mcp-core 0.19.70." in readme
 
 
 def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> None:
@@ -186,7 +186,7 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
     )
 
     with pytest.raises(RuntimeError, match="Bundled core drift"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.69")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.70")
 
 
 def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
@@ -196,12 +196,12 @@ def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> Non
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.70-cp38-abi3-win_amd64.whl",
         include_scene_hook=False,
     )
 
     with pytest.raises(RuntimeError, match="/scripts/456.py"):
-        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.69")
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.70")
 
 
 def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
@@ -211,13 +211,13 @@ def test_verify_quickinstall_zip_prints_version_matrix(tmp_path: Path) -> None:
     _write_quickinstall_zip(
         zip_path,
         "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
-        "dcc_mcp_core-0.19.69-cp38-abi3-win_amd64.whl",
+        "dcc_mcp_core-0.19.70-cp38-abi3-win_amd64.whl",
     )
 
-    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.69")
+    matrix = pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.70")
 
     assert matrix["adapter"] == pkg.get_package_version()
-    assert matrix["core"] == "0.19.69"
+    assert matrix["core"] == "0.19.70"
     assert matrix["server"] == pkg.get_package_version()
     assert matrix["cli"] == pkg.get_package_version()
 

--- a/tests/test_resilient_cook_jobs.py
+++ b/tests/test_resilient_cook_jobs.py
@@ -81,6 +81,22 @@ def test_get_cook_job_remains_queryable_after_adapter_ownership_is_lost(tmp_path
     assert recovered["owned_by_current_process"] is False
 
 
+def test_get_cook_job_reports_live_elapsed_time_after_disconnect() -> None:
+    status = {
+        "job_id": "b" * 32,
+        "job_kind": "node_cook",
+        "state": "running",
+        "started_at": 100.0,
+        "owned_by_current_process": False,
+    }
+    with patch.object(_cook_jobs._isolated_jobs, "read_job", return_value=status), patch.object(
+        _cook_jobs.time, "time", return_value=112.3456
+    ):
+        recovered = _cook_jobs.get_cook_job(status["job_id"])
+
+    assert recovered["elapsed_secs"] == 12.346
+
+
 def test_cook_worker_writes_terminal_status(tmp_path: Path) -> None:
     status_path = tmp_path / "status.json"
     write_status(status_path, {"job_id": "c" * 32, "job_kind": "node_cook", "state": "queued"})

--- a/tests/test_resilient_cook_jobs.py
+++ b/tests/test_resilient_cook_jobs.py
@@ -79,6 +79,7 @@ def test_get_cook_job_remains_queryable_after_adapter_ownership_is_lost(tmp_path
     assert recovered["state"] == "completed"
     assert recovered["node_path"] == "/obj/geo1/cache1"
     assert recovered["owned_by_current_process"] is False
+    assert recovered["worker_liveness"] == "stopped"
 
 
 def test_get_cook_job_reports_live_elapsed_time_after_disconnect() -> None:
@@ -88,6 +89,7 @@ def test_get_cook_job_reports_live_elapsed_time_after_disconnect() -> None:
         "state": "running",
         "started_at": 100.0,
         "owned_by_current_process": False,
+        "worker_liveness": "unknown",
     }
     with patch.object(_cook_jobs._isolated_jobs, "read_job", return_value=status), patch.object(
         _cook_jobs.time, "time", return_value=112.3456
@@ -95,6 +97,8 @@ def test_get_cook_job_reports_live_elapsed_time_after_disconnect() -> None:
         recovered = _cook_jobs.get_cook_job(status["job_id"])
 
     assert recovered["elapsed_secs"] == 12.346
+    assert recovered["worker_liveness"] == "unknown"
+    assert "do not launch a duplicate cook" in recovered["recovery_note"]
 
 
 def test_cook_worker_writes_terminal_status(tmp_path: Path) -> None:

--- a/tests/test_resilient_cook_jobs.py
+++ b/tests/test_resilient_cook_jobs.py
@@ -1,0 +1,135 @@
+"""Regression tests for chunked and durable node cooks (issue #183)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from dcc_mcp_core import ChunkedRunner, HostExecutionBridge
+from skill_loader import skill_script_import_context
+
+from dcc_mcp_houdini import _cook_jobs, _cook_worker
+from dcc_mcp_houdini._status_io import read_status, write_status
+from dcc_mcp_houdini.host import HoudiniUiDispatcher
+
+_SCRIPT = (
+    Path(__file__).parent.parent
+    / "src"
+    / "dcc_mcp_houdini"
+    / "skills"
+    / "houdini-nodes"
+    / "scripts"
+    / "cook_nodes_chunked.py"
+)
+
+
+def _load_chunked_script():
+    spec = importlib.util.spec_from_file_location("houdini_nodes_chunked_test", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+def test_launch_cook_job_returns_durable_worker_job(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    initial = {"job_id": "a" * 32, "state": "queued"}
+    with patch.object(
+        _cook_jobs._rop_jobs,
+        "_validate_saved_hip",
+        return_value=(tmp_path / "scene.hip", True),
+    ), patch.object(
+        _cook_jobs._rop_jobs,
+        "_hython_executable",
+        return_value=tmp_path / "hython",
+    ), patch.object(
+        _cook_jobs._isolated_jobs,
+        "create_job",
+        return_value=(initial, status_path),
+    ), patch.object(
+        _cook_jobs._isolated_jobs,
+        "launch_job",
+        return_value={**initial, "pid": 42},
+    ) as launch:
+        result = _cook_jobs.launch_cook_job(MagicMock(), "/obj/geo1/cache1", True)
+
+    assert result["job_id"] == "a" * 32
+    command = launch.call_args.args[1]
+    assert command[2:5] == [str(tmp_path / "scene.hip"), "/obj/geo1/cache1", "1"]
+    assert command[-1] == str(status_path)
+
+
+def test_get_cook_job_remains_queryable_after_adapter_ownership_is_lost(tmp_path: Path) -> None:
+    with patch.object(_cook_jobs._isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        status, status_path = _cook_jobs._isolated_jobs.create_job(
+            {"job_kind": "node_cook", "node_path": "/obj/geo1/cache1"}
+        )
+        status["state"] = "completed"
+        write_status(status_path, status)
+        _cook_jobs._isolated_jobs._PROCESS_HANDLES.clear()
+
+        recovered = _cook_jobs.get_cook_job(status["job_id"])
+
+    assert recovered["state"] == "completed"
+    assert recovered["node_path"] == "/obj/geo1/cache1"
+    assert recovered["owned_by_current_process"] is False
+
+
+def test_cook_worker_writes_terminal_status(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    write_status(status_path, {"job_id": "c" * 32, "job_kind": "node_cook", "state": "queued"})
+    node = MagicMock()
+    hou = SimpleNamespace(
+        hipFile=SimpleNamespace(load=MagicMock()),
+        node=lambda path: node if path == "/obj/geo1/cache1" else None,
+    )
+    argv = ["_cook_worker.py", str(tmp_path / "scene.hip"), "/obj/geo1/cache1", "1", str(status_path)]
+
+    with patch.dict(sys.modules, {"hou": hou}), patch.object(sys, "argv", argv):
+        _cook_worker.main()
+
+    terminal = read_status(status_path)
+    assert terminal["state"] == "completed"
+    node.cook.assert_called_once_with(force=True)
+    hou.hipFile.load.assert_called_once()
+
+
+def test_chunked_cook_advances_one_node_per_step() -> None:
+    first = MagicMock()
+    second = MagicMock()
+    hou = SimpleNamespace(node=lambda path: {"/obj/a": first, "/obj/b": second}.get(path))
+    with patch.dict(sys.modules, {"hou": hou}):
+        runner = _load_chunked_script().main(node_paths=["/obj/a", "/obj/b"], force=True)
+        assert runner.step()
+        first.cook.assert_called_once_with(force=True)
+        second.cook.assert_not_called()
+        assert not runner.step()
+    second.cook.assert_called_once_with(force=True)
+
+
+def test_houdini_bridge_auto_schedules_returned_chunked_runner() -> None:
+    dispatcher = HoudiniUiDispatcher()
+    bridge = HostExecutionBridge(dispatcher=dispatcher)
+    calls = []
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(
+            bridge.dispatch_callable,
+            lambda: ChunkedRunner([lambda: calls.append("a"), lambda: calls.append("b")]),
+            execution="async",
+            job_strategy="chunked",
+            job_id="job-183",
+        )
+        deadline = time.monotonic() + 2
+        while not future.done() and time.monotonic() < deadline:
+            dispatcher.drain_queue(20)
+            time.sleep(0.001)
+
+        assert future.result(timeout=0.1) == {"current": 2, "total": 2, "message": None}
+    assert calls == ["a", "b"]


### PR DESCRIPTION
## Summary
- route short live cooks through async core jobs and multi-node work through chunked UI ticks
- add isolated hython cook jobs with durable status, live elapsed time, cancellation, and explicit worker-liveness uncertainty after adapter restart
- document crash/transport recovery and require the new core contract

## Validation
- 689 passed, 1 skipped, 3 deselected
- 101 targeted recovery/render tests passed after the liveness follow-up
- Ruff checks passed
- real Houdini/hython E2E is unavailable locally; the repository E2E job currently skips because SideFX credentials are not configured

Depends on dcc-mcp/dcc-mcp-core#2036 and a released `dcc-mcp-core>=0.19.70`.

Closes #183.