### PR TITLE
feat(vex): add typed VEX workflow module for Houdini adapter

### DIFF
--- a/src/dcc_mcp_houdini/_vex_executor.py
+++ b/src/dcc_mcp_houdini/_vex_executor.py
@@ -21,7 +21,6 @@ from dcc_mcp_houdini._vex_types import (
     CookDiagnostic,
     VexContext,
     VexSnippet,
-    VexSyntaxError,
     WrangleInfo,
     WrangleNodeSpec,
     WrangleType,

--- a/src/dcc_mcp_houdini/_vex_executor.py
+++ b/src/dcc_mcp_houdini/_vex_executor.py
@@ -1,0 +1,558 @@
+"""Safe VEX Wrangle execution — create, update, cook, diagnose.
+
+This is the ONLY module that mutates the Houdini scene graph for VEX
+operations.  Every call that touches ``hou`` objects is wrapped so it can
+be dispatched through the Houdini main-thread queue.
+
+Hard constraints:
+- VEX code is set via ``hou.Parm.set()``, NOT via Python ``exec``/``eval``.
+- All ``hou`` calls are gated through the dispatcher (main-thread affinity).
+- Timeout and cancel boundaries are explicit — cooks are launched as
+  durable isolated jobs when timeouts are set.
+- This module NEVER constructs arbitrary Python from VEX strings.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+from dcc_mcp_houdini._vex_types import (
+    CookDiagnostic,
+    VexContext,
+    VexSnippet,
+    VexSyntaxError,
+    WrangleInfo,
+    WrangleNodeSpec,
+    WrangleType,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# VEX snippet limit: Houdini's internal limit is much larger, but we cap
+# agent-authored snippets to prevent Denial-of-Memory attacks.
+_MAX_VEX_LINES = 2000
+_MAX_VEX_CHARS = 64 * 1024  # 64KB
+
+# Default cook timeout for in-process cooks (no isolated job).
+_DEFAULT_COOK_TIMEOUT_SECS = 60.0
+
+# Threshold beyond which a cook is launched as an isolated hython job.
+_ISOLATED_COOK_THRESHOLD_SECS = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Core operations (each expects ``hou`` as an explicit parameter)
+# ---------------------------------------------------------------------------
+
+
+def create_wrangle(hou: Any, spec: WrangleNodeSpec) -> Dict[str, Any]:
+    """Create a Wrangle SOP node from a typed specification.
+
+    This is the ONLY entry point for creating Wrangle nodes.  The *spec*
+    carries a validated :class:`VexSnippet` — raw strings are rejected.
+
+    Args:
+        hou: The ``hou`` module (lazy import from the caller).
+        spec: A fully validated :class:`WrangleNodeSpec`.
+
+    Returns:
+        A dict with ``success``, ``node_path``, ``node_name``, ``wrangle_type``,
+        and any errors.
+    """
+    # ── Pre-flight validation ──────────────────────────────────────────
+    if spec.snippet is not None:
+        if len(spec.snippet.code) > _MAX_VEX_CHARS:
+            return _fail("VEX snippet exceeds 64KB limit")
+        if spec.snippet.line_count > _MAX_VEX_LINES:
+            return _fail("VEX snippet exceeds 2000-line limit")
+
+    try:
+        parent = _resolve_node(hou, spec.parent_path)
+    except ValueError as exc:
+        return _fail(str(exc))
+
+    sop_type = spec.wrangle_type.value
+    node = parent.createNode(sop_type, node_name=spec.node_name)
+
+    if node is None:
+        return _fail(f"Failed to create {sop_type} node under {spec.parent_path}")
+
+    # ── Set run-over context ───────────────────────────────────────────
+    _set_run_over(node, spec.run_over)
+
+    # ── Set VEX snippet ────────────────────────────────────────────────
+    if spec.snippet is not None:
+        snip_parm = node.parm("snippet")
+        if snip_parm is None:
+            return _fail(
+                f"Wrangle node {node.path()} has no 'snippet' parameter",
+                node_path=node.path(),
+            )
+        snip_parm.set(spec.snippet.code)
+
+        # Apply user-defined parameter values (e.g. group, etc.).
+        for parm_name, value in spec.snippet.parameter_values.items():
+            parm = node.parm(parm_name)
+            if parm is not None:
+                try:
+                    parm.set(value)
+                except Exception:
+                    pass  # Non-critical: the cook will surface real issues.
+
+    # ── Bindings ───────────────────────────────────────────────────────
+    if spec.snippet is not None and spec.snippet.bindings:
+        bindings_str = _encode_bindings(spec.snippet.bindings)
+        bind_parm = node.parm("bindings")
+        if bind_parm is not None:
+            bind_parm.set(bindings_str)
+
+    # ── Display / Render flags ─────────────────────────────────────────
+    if spec.set_display and hasattr(node, "setDisplayFlag"):
+        node.setDisplayFlag(True)
+    if spec.set_render and hasattr(node, "setRenderFlag"):
+        node.setRenderFlag(True)
+
+    return {
+        "success": True,
+        "node_path": node.path(),
+        "node_name": node.name(),
+        "wrangle_type": sop_type,
+        "run_over": spec.run_over.value,
+        "has_snippet": spec.snippet is not None,
+    }
+
+
+def update_vex_snippet(
+    hou: Any,
+    node_path: str,
+    snippet: VexSnippet,
+) -> Dict[str, Any]:
+    """Update the VEX snippet on an existing Wrangle node.
+
+    The *snippet* must be a validated :class:`VexSnippet` — raw strings
+    are rejected at the type level.
+
+    Args:
+        hou: The ``hou`` module.
+        node_path: Path to an existing Wrangle node.
+        snippet: The validated VEX snippet to set.
+
+    Returns:
+        Dict with ``success``, ``node_path``, and ``previous_snippet_preview``.
+    """
+    try:
+        node = _resolve_node(hou, node_path)
+    except ValueError as exc:
+        return _fail(str(exc))
+
+    snip_parm = node.parm("snippet")
+    if snip_parm is None:
+        return _fail(f"Node {node_path} has no 'snippet' parameter", node_path=node_path)
+
+    # Capture the old snippet for the audit trail.
+    try:
+        previous = snip_parm.evalAsString() or ""
+        previous_preview = previous[:200]
+    except Exception:
+        previous_preview = "<unreadable>"
+
+    if len(snippet.code) > _MAX_VEX_CHARS:
+        return _fail("VEX snippet exceeds 64KB limit", node_path=node_path)
+    if snippet.line_count > _MAX_VEX_LINES:
+        return _fail("VEX snippet exceeds 2000-line limit", node_path=node_path)
+
+    snip_parm.set(snippet.code)
+
+    # Update run-over if context changed.
+    _set_run_over(node, snippet.context)
+
+    # Apply bindings.
+    if snippet.bindings:
+        bind_parm = node.parm("bindings")
+        if bind_parm is not None:
+            bind_parm.set(_encode_bindings(snippet.bindings))
+
+    # Apply parameter values.
+    for parm_name, value in snippet.parameter_values.items():
+        parm = node.parm(parm_name)
+        if parm is not None:
+            try:
+                parm.set(value)
+            except Exception:
+                pass
+
+    return {
+        "success": True,
+        "node_path": node.path(),
+        "previous_snippet_preview": previous_preview,
+        "line_count": snippet.line_count,
+    }
+
+
+def cook_and_diagnose(
+    hou: Any,
+    node_path: str,
+    force: bool = False,
+    timeout_secs: Optional[float] = None,
+) -> CookDiagnostic:
+    """Cook a Wrangle node and collect geometry diagnostics.
+
+    For cooks that may exceed the timeout threshold, use
+    :func:`launch_durable_cook` instead.
+
+    Args:
+        hou: The ``hou`` module.
+        node_path: Path to the Wrangle node.
+        force: Force a recook even if already cooked.
+        timeout_secs: Soft timeout (best-effort; Houdini cooks cannot be
+            interrupted mid-cook from Python).
+
+    Returns:
+        A :class:`CookDiagnostic` with cook status and geometry stats.
+    """
+    t0 = time.monotonic()
+
+    try:
+        node = _resolve_node(hou, node_path)
+    except ValueError as exc:
+        return CookDiagnostic(
+            node_path=node_path,
+            cooked=False,
+            cook_error=str(exc),
+            elapsed_secs=0.0,
+        )
+
+    # ── Cook ───────────────────────────────────────────────────────────
+    cook_error: Optional[str] = None
+    try:
+        node.cook(force=force)
+    except Exception as exc:
+        cook_error = str(exc)
+
+    # ── Collect errors and warnings ────────────────────────────────────
+    errors: List[str] = []
+    warnings_list: List[str] = []
+    if hasattr(node, "errors"):
+        try:
+            errors = list(node.errors())
+        except Exception:
+            pass
+    if hasattr(node, "warnings"):
+        try:
+            warnings_list = list(node.warnings())
+        except Exception:
+            pass
+
+    # ── Geometry diagnostics ───────────────────────────────────────────
+    geo = None
+    if hasattr(node, "geometry"):
+        try:
+            geo = node.geometry()
+        except Exception:
+            pass
+
+    point_count: Optional[int] = None
+    prim_count: Optional[int] = None
+    vertex_count: Optional[int] = None
+    attr_names: List[str] = []
+    group_names: List[str] = []
+
+    if geo is not None:
+        if hasattr(geo, "points"):
+            try:
+                point_count = len(geo.points())
+            except Exception:
+                pass
+        if hasattr(geo, "prims"):
+            try:
+                prim_count = len(geo.prims())
+            except Exception:
+                pass
+        if hasattr(geo, "iterVertices"):
+            try:
+                vertex_count = sum(1 for _ in geo.iterVertices())
+            except Exception:
+                pass
+
+        # Attribute names.
+        for attr_list_fn_name in ("pointAttribs", "primAttribs", "vertexAttribs", "globalAttribs"):
+            fn = getattr(geo, attr_list_fn_name, None)
+            if fn is None:
+                continue
+            try:
+                for attrib in fn():
+                    name = getattr(attrib, "name", None)
+                    if callable(name):
+                        name = name()
+                    if name:
+                        attr_names.append(str(name))
+            except Exception:
+                pass
+
+        # Group names.
+        for group_fn_name in ("pointGroups", "primGroups", "edgeGroups"):
+            fn = getattr(geo, group_fn_name, None)
+            if fn is None:
+                continue
+            try:
+                for grp in fn():
+                    name = getattr(grp, "name", None)
+                    if callable(name):
+                        name = name()
+                    if name:
+                        group_names.append(str(name))
+            except Exception:
+                pass
+
+    elapsed = time.monotonic() - t0
+
+    return CookDiagnostic(
+        node_path=node.path(),
+        cooked=cook_error is None,
+        cook_error=cook_error,
+        errors=errors,
+        warnings=warnings_list,
+        point_count=point_count,
+        primitive_count=prim_count,
+        vertex_count=vertex_count,
+        attribute_names=sorted(set(attr_names)),
+        group_names=sorted(set(group_names)),
+        elapsed_secs=elapsed,
+    )
+
+
+def get_wrangle_info(hou: Any, node_path: str) -> WrangleInfo:
+    """Extract read-only metadata from an existing Wrangle node.
+
+    This is a read-only operation — it never cooks or mutates the node.
+    """
+    try:
+        node = _resolve_node(hou, node_path)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+    type_name = ""
+    if hasattr(node, "type"):
+        try:
+            type_name = str(node.type().name())
+        except Exception:
+            type_name = "unknown"
+
+    run_over = ""
+    run_over_parm = node.parm("class")
+    if run_over_parm is not None:
+        try:
+            run_over = str(run_over_parm.evalAsString())
+        except Exception:
+            pass
+
+    snippet_preview = ""
+    has_snippet = False
+    snip_parm = node.parm("snippet")
+    if snip_parm is not None:
+        try:
+            raw = snip_parm.evalAsString() or ""
+            has_snippet = bool(raw.strip())
+            snippet_preview = raw[:200]
+        except Exception:
+            pass
+
+    cook_state = "unknown"
+    try:
+        if hasattr(node, "isCooked"):
+            cook_state = "cooked" if node.isCooked() else "uncooked"
+    except Exception:
+        pass
+
+    input_count = 0
+    output_count = 0
+    if hasattr(node, "inputs"):
+        try:
+            input_count = len(node.inputs())
+        except Exception:
+            pass
+    if hasattr(node, "outputs"):
+        try:
+            output_count = len(node.outputs())
+        except Exception:
+            pass
+
+    return WrangleInfo(
+        node_path=node.path(),
+        node_name=str(node.name()) if hasattr(node, "name") else "",
+        wrangle_type=type_name,
+        run_over=run_over,
+        snippet_preview=snippet_preview,
+        has_snippet=has_snippet,
+        cook_state=cook_state,
+        input_count=input_count,
+        output_count=output_count,
+    )
+
+
+def list_wrangles(hou: Any, parent_path: str = "/obj") -> List[Dict[str, str]]:
+    """List all Wrangle-type nodes under *parent_path* recursively.
+
+    Returns a list of ``{node_path, node_name, wrangle_type}`` dicts.
+    """
+    try:
+        parent = _resolve_node(hou, parent_path)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+    wrangle_type_names = {wt.value for wt in WrangleType}
+    results: List[Dict[str, str]] = []
+
+    def _walk(node: Any) -> None:
+        try:
+            type_name = str(node.type().name()) if hasattr(node, "type") else ""
+        except Exception:
+            type_name = ""
+        if type_name in wrangle_type_names:
+            results.append(
+                {
+                    "node_path": node.path(),
+                    "node_name": str(node.name()) if hasattr(node, "name") else "",
+                    "wrangle_type": type_name,
+                }
+            )
+        if hasattr(node, "children"):
+            try:
+                for child in node.children():
+                    _walk(child)
+            except Exception:
+                pass
+
+    _walk(parent)
+    return results
+
+
+def locate_wrangle_failure(diagnostic: CookDiagnostic) -> Dict[str, Any]:
+    """Analyse a failed :class:`CookDiagnostic` and suggest failure location.
+
+    This combines:
+    - Cook error messages (Houdini native errors)
+    - VEX compile errors (from ``node.errors()``)
+    - Geometry statistics (missing attributes, zero geometry)
+
+    Returns a dict with ``likely_cause``, ``error_location``, ``suggested_fix``.
+    """
+    result: Dict[str, Any] = {
+        "node_path": diagnostic.node_path,
+        "cooked": diagnostic.cooked,
+    }
+
+    if diagnostic.cooked:
+        result["likely_cause"] = "none"
+        result["summary"] = "Node cooked successfully"
+        return result
+
+    # ── Heuristic analysis ──────────────────────────────────────────────
+    all_messages = diagnostic.errors + [diagnostic.cook_error] if diagnostic.cook_error else diagnostic.errors
+
+    # VEX compile errors typically contain specific patterns.
+    vex_compile_markers = [
+        "syntax error",
+        "undefined variable",
+        "type mismatch",
+        "invalid type",
+        "cannot convert",
+        "no matching function",
+        "unexpected",
+        "unknown attribute",
+        "undefined function",
+        "incompatible",
+    ]
+
+    for msg in all_messages:
+        msg_lower = msg.lower() if isinstance(msg, str) else ""
+        for marker in vex_compile_markers:
+            if marker in msg_lower:
+                result["likely_cause"] = "vex_compile_error"
+                result["error_location"] = str(msg)
+                result["suggested_fix"] = _suggest_fix_for_marker(marker, msg)
+                return result
+
+    # Geometry issues.
+    if diagnostic.cook_error and "geometry" in str(diagnostic.cook_error).lower():
+        result["likely_cause"] = "geometry_error"
+        result["error_location"] = diagnostic.cook_error
+        result["suggested_fix"] = "Check input geometry — it may be empty or corrupted"
+        return result
+
+    # Cook timeout or process failure.
+    if diagnostic.cook_error and (
+        "timeout" in str(diagnostic.cook_error).lower()
+        or "timed out" in str(diagnostic.cook_error).lower()
+    ):
+        result["likely_cause"] = "cook_timeout"
+        result["error_location"] = diagnostic.cook_error
+        result["suggested_fix"] = "Simplify the VEX snippet or reduce input geometry complexity"
+        return result
+
+    # Fallback: unknown error.
+    result["likely_cause"] = "unknown"
+    result["error_location"] = diagnostic.cook_error or "; ".join(map(str, diagnostic.errors))
+    result["suggested_fix"] = "Inspect the VEX snippet and geometry manually"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_node(hou: Any, path: str) -> Any:
+    """Resolve a node path, raising ``ValueError`` if not found."""
+    node = hou.node(path)
+    if node is None:
+        raise ValueError(f"Houdini node not found: {path}")
+    return node
+
+
+def _set_run_over(node: Any, context: VexContext) -> None:
+    """Set the run-over (class) parameter on a Wrangle node."""
+    parm = node.parm("class")
+    if parm is None:
+        return
+    from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
+
+    class_value = vex_context_to_attrib_class(context)
+    try:
+        parm.set(class_value)
+    except Exception:
+        pass
+
+
+def _encode_bindings(bindings: Dict[str, str]) -> str:
+    """Encode attribute bindings dict into the Houdini bindings string format."""
+    # Houdini expects bindings as "name=attribute type" separated by spaces.
+    parts = [f"{name}={attr_type}" for name, attr_type in sorted(bindings.items())]
+    return " ".join(parts)
+
+
+def _fail(message: str, **extra: Any) -> Dict[str, Any]:
+    """Return a failure dict."""
+    result: Dict[str, Any] = {"success": False, "error": message}
+    result.update(extra)
+    return result
+
+
+def _suggest_fix_for_marker(marker: str, error_message: str) -> str:
+    """Suggest a human-readable fix based on the error marker."""
+    suggestions = {
+        "syntax error": "Check for missing semicolons, mismatched braces, or invalid VEX syntax",
+        "undefined variable": "Ensure all variables are declared before use (e.g. 'int x; x = 1;')",
+        "type mismatch": "Cast values explicitly (e.g. 'int(x)' or 'float(x)')",
+        "invalid type": "Use VEX-compatible types: int, float, vector, vector2, vector4, matrix, string",
+        "cannot convert": "Add explicit type casts between incompatible types",
+        "no matching function": "Check function name spelling and argument types",
+        "unexpected": "Verify the expression or statement is valid VEX syntax",
+        "unknown attribute": "The referenced attribute does not exist on the input geometry — create it first or use hasattrib()",
+        "undefined function": "The function name is not a VEX builtin — check spelling or use a vop_ equivalent",
+        "incompatible": "The operation is not valid for the given types — add explicit casts",
+    }
+    return suggestions.get(marker, "Review the VEX snippet and input geometry")

--- a/src/dcc_mcp_houdini/_vex_executor.py
+++ b/src/dcc_mcp_houdini/_vex_executor.py
@@ -484,8 +484,7 @@ def locate_wrangle_failure(diagnostic: CookDiagnostic) -> Dict[str, Any]:
 
     # Cook timeout or process failure.
     if diagnostic.cook_error and (
-        "timeout" in str(diagnostic.cook_error).lower()
-        or "timed out" in str(diagnostic.cook_error).lower()
+        "timeout" in str(diagnostic.cook_error).lower() or "timed out" in str(diagnostic.cook_error).lower()
     ):
         result["likely_cause"] = "cook_timeout"
         result["error_location"] = diagnostic.cook_error

--- a/src/dcc_mcp_houdini/_vex_types.py
+++ b/src/dcc_mcp_houdini/_vex_types.py
@@ -1,0 +1,232 @@
+"""Typed contracts for the Houdini VEX workflow.
+
+This module defines the typed enums, dataclasses, and validation contracts
+that form the safe boundary between user-facing MCP tools and the Houdini
+Wrangle node manipulation.  No raw dicts or untyped strings cross this
+boundary — every VEX operation is validated against these types.
+
+Hard constraint: this module is Python-only.  It does NOT import ``hou``
+and runs in any environment (tests, CI, linting).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class VexContext(str, Enum):
+    """VEX geometry context — maps to the Wrangle node's run-over mode."""
+
+    POINTS = "points"
+    PRIMITIVES = "prims"
+    VERTICES = "verts"
+    DETAIL = "detail"
+    GLOBAL_VERTICES = "global"
+    ATTRIBUTES = "attribs"
+    NUMBERS = "numbers"
+
+
+class WrangleType(str, Enum):
+    """Houdini Wrangle SOP types that carry VEX snippets."""
+
+    ATTRIB_WRANGLE = "attribwrangle"
+    VOLUME_WRANGLE = "volumewrangle"
+    ATTRIB_VOP = "attribvop"
+    GEOMETRY_WRANGLE = "geometrywrangle"
+    POINT_WRANGLE = "pointwrangle"
+    PRIMITIVE_WRANGLE = "primitivewrangle"
+    VERTEX_WRANGLE = "vertexwrangle"
+    DETAIL_WRANGLE = "detailwrangle"
+    TOPOLOGY_WRANGLE = "topologywrangle"
+
+    @classmethod
+    def default_for_context(cls, context: VexContext) -> "WrangleType":
+        """Return the most appropriate wrangle type for a give context."""
+        _context_map: dict[VexContext, WrangleType] = {
+            VexContext.POINTS: cls.POINT_WRANGLE,
+            VexContext.PRIMITIVES: cls.PRIMITIVE_WRANGLE,
+            VexContext.VERTICES: cls.VERTEX_WRANGLE,
+            VexContext.DETAIL: cls.DETAIL_WRANGLE,
+            VexContext.GLOBAL_VERTICES: cls.ATTRIB_WRANGLE,
+            VexContext.ATTRIBUTES: cls.ATTRIB_WRANGLE,
+            VexContext.NUMBERS: cls.ATTRIB_WRANGLE,
+        }
+        return _context_map.get(context, cls.ATTRIB_WRANGLE)
+
+
+class VexSeverity(str, Enum):
+    """Severity levels for VEX diagnostics."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses — immutable typed contracts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VexSyntaxError:
+    """A single VEX compile diagnostic with file-like location."""
+
+    message: str
+    severity: VexSeverity = VexSeverity.ERROR
+    line: Optional[int] = None
+    column: Optional[int] = None
+    snippet_context: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "message": self.message,
+            "severity": self.severity.value,
+        }
+        if self.line is not None:
+            result["line"] = self.line
+        if self.column is not None:
+            result["column"] = self.column
+        if self.snippet_context is not None:
+            result["snippet_context"] = self.snippet_context
+        return result
+
+
+@dataclass(frozen=True)
+class VexSnippet:
+    """A validated VEX code fragment with its bindings and metadata.
+
+    This is the ONLY type that carries VEX code across module boundaries.
+    Code that is not wrapped in a :class:`VexSnippet` must never be set on
+    a Wrangle node.
+    """
+
+    code: str
+    context: VexContext
+    bindings: Dict[str, str] = field(default_factory=dict)
+    parameter_values: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.code, str) or not self.code.strip():
+            raise ValueError("VEX snippet code must be a non-empty string")
+        if not isinstance(self.context, VexContext):
+            raise ValueError(f"context must be a VexContext, got {type(self.context)}")
+
+    @property
+    def line_count(self) -> int:
+        """Number of non-empty lines in the snippet."""
+        return len([ln for ln in self.code.splitlines() if ln.strip()])
+
+
+@dataclass(frozen=True)
+class WrangleNodeSpec:
+    """Specification for creating or updating a Wrangle node."""
+
+    parent_path: str
+    node_name: Optional[str] = None
+    wrangle_type: WrangleType = WrangleType.ATTRIB_WRANGLE
+    run_over: VexContext = VexContext.POINTS
+    snippet: Optional[VexSnippet] = None
+    set_display: bool = True
+    set_render: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.parent_path or not isinstance(self.parent_path, str):
+            raise ValueError("parent_path must be a non-empty string")
+        if not isinstance(self.wrangle_type, WrangleType):
+            raise ValueError(f"wrangle_type must be a WrangleType, got {type(self.wrangle_type)}")
+        if self.snippet is not None and not isinstance(self.snippet, VexSnippet):
+            raise ValueError(f"snippet must be a VexSnippet, got {type(self.snippet)}")
+
+
+# Mapping from VexContext to Houdini's numeric class parameter value
+# (hou.attribType enum values).
+_VEX_CONTEXT_TO_ATTRIB_CLASS: Dict[VexContext, int] = {
+    VexContext.POINTS: 0,
+    VexContext.PRIMITIVES: 1,
+    VexContext.VERTICES: 2,
+    VexContext.DETAIL: 3,
+    VexContext.GLOBAL_VERTICES: 0,
+    VexContext.ATTRIBUTES: 0,
+    VexContext.NUMBERS: 0,
+}
+
+
+def vex_context_to_attrib_class(context: VexContext) -> int:
+    """Map a :class:`VexContext` to the ``hou.attribType`` enum value."""
+    return _VEX_CONTEXT_TO_ATTRIB_CLASS.get(context, 0)
+
+
+@dataclass(frozen=True)
+class CookDiagnostic:
+    """The result of cooking a Wrangle node, including geometry diagnostics."""
+
+    node_path: str
+    cooked: bool
+    cook_error: Optional[str] = None
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    point_count: Optional[int] = None
+    primitive_count: Optional[int] = None
+    vertex_count: Optional[int] = None
+    attribute_names: List[str] = field(default_factory=list)
+    group_names: List[str] = field(default_factory=list)
+    elapsed_secs: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict for MCP tool responses."""
+        result: Dict[str, Any] = {
+            "node_path": self.node_path,
+            "cooked": self.cooked,
+            "errors": self.errors,
+            "warnings": self.warnings,
+        }
+        if self.cook_error:
+            result["cook_error"] = self.cook_error
+        if self.point_count is not None:
+            result["point_count"] = self.point_count
+        if self.primitive_count is not None:
+            result["primitive_count"] = self.primitive_count
+        if self.vertex_count is not None:
+            result["vertex_count"] = self.vertex_count
+        if self.attribute_names:
+            result["attribute_names"] = self.attribute_names
+        if self.group_names:
+            result["group_names"] = self.group_names
+        if self.elapsed_secs is not None:
+            result["elapsed_secs"] = round(self.elapsed_secs, 3)
+        return result
+
+
+@dataclass(frozen=True)
+class WrangleInfo:
+    """Read-only info extracted from an existing Wrangle node."""
+
+    node_path: str
+    node_name: str
+    wrangle_type: str
+    run_over: str
+    snippet_preview: str
+    has_snippet: bool
+    cook_state: str
+    input_count: int
+    output_count: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "node_path": self.node_path,
+            "node_name": self.node_name,
+            "wrangle_type": self.wrangle_type,
+            "run_over": self.run_over,
+            "snippet_preview": self.snippet_preview,
+            "has_snippet": self.has_snippet,
+            "cook_state": self.cook_state,
+            "input_count": self.input_count,
+            "output_count": self.output_count,
+        }

--- a/src/dcc_mcp_houdini/_vex_types.py
+++ b/src/dcc_mcp_houdini/_vex_types.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------

--- a/src/dcc_mcp_houdini/_vex_validator.py
+++ b/src/dcc_mcp_houdini/_vex_validator.py
@@ -1,0 +1,335 @@
+"""Pre-cook VEX validation: syntax, bindings, parameters.
+
+This module validates VEX code and Wrangle parameters BEFORE they are
+committed to Houdini.  All validation is read-only — it never modifies
+the scene graph and never executes VEX.
+
+Hard constraints:
+- Does NOT import ``hou`` at module level (testable without Houdini).
+- All ``hou``-dependent checks receive the module as an explicit parameter.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from dcc_mcp_houdini._vex_types import VexContext, VexSeverity, VexSyntaxError, WrangleType
+
+
+# ---------------------------------------------------------------------------
+# Client-side (no hou) validation
+# ---------------------------------------------------------------------------
+
+
+# Restrictive VEX allowlist: the ONLY permitted VEX constructs.
+# This is the first defense against arbitrary script execution through VEX.
+_ALLOWED_VEX_PATTERNS: List[re.Pattern] = [
+    # — Data types —
+    re.compile(r"\b(vector|vector2|vector4|matrix|matrix2|matrix3|int|float|string|int64)\b"),
+    # — Attribute access (read) —
+    re.compile(r"@(P|N|Cd|uv|v|id|ptnum|primnum|vtxnum|numpt|numprim|numvtx|Time|Frame|elemnum|numelem)\b"),
+    # — Attribute access (generic) —
+    re.compile(r"@[\w_]+"),
+    # — Function calls (VEX builtins only) —
+    re.compile(
+        r"\b("
+        r"addattribute|addvariablename|ambient|anoise|area|array|atan2|attrib|attribclass|"
+        r"bbox|cbrt|ceil|ch|chv|clamp|concat|cross|curlnoise|deg|degrees|"
+        r"determinant|diagonalizesymmetric|dihedral|distance|dot|"
+        r"du|dv|dPdx|dPdy|dPdz|"
+        r"error|exp|explodematrix|export|"
+        r"filterstep|fit|fit01|fit10|fit11|flownoise|floor|frac|fresnel|fromNDC|"
+        r"frontface|getattribute|getbbox|getblur|getcomp|getderiv|getmatrix|"
+        r"getneighbour|getneighbourcount|getneighbourindex|getneighbourrow|"
+        r"getneighbourcolumn|getneighboursurface|"
+        r"getneighbourcount2|getneighbourindex2|getneighbourrow2|getneighbourcolumn2|"
+        r"getneighbourcount3|getneighbourindex3|getneighbourrow3|getneighbourcolumn3|"
+        r"ident|illuminance|import|importdetail|importpoint|importprim|importvertex|"
+        r"invert|irradiance|isfinite|isinf|isnan|"
+        r"length|length2|lerp|lighter|lookat|"
+        r"match|max|min|minpos|mspace|nearpoint|nearpoints|neighbour|neighbourcount|"
+        r"neighbours|noise|normalize|ntransform|"
+        r"occlusion|onoise|outerproduct|ow_space|"
+        r"pbrspecular|pcfilter|pgfind|pgnext|planepointdistance|planeside|"
+        r"pop|pow|prim|primgrouplist|primindex|primintrinsic|primuv|"
+        r"print|printf|ptlined|"
+        r"radians|random|raw_noise|reflect|refract|relbbox|relpointbbox|"
+        r"removeattrib|removepoint|removeprim|removevertex|"
+        r"renderstate|rgbtohsv|rotate|"
+        r"sample|sample_geometry|sample_discrete|"
+        r"set|setattrib|setattribtypeinfo|setcomp|setdetailattrib|setpointattrib|"
+        r"setpointgroup|setprimattrib|setprimgroup|setvertexattrib|setvertexgroup|"
+        r"shadow|shimport|shimportfunctions|smooth|snoise|"
+        r"specular|spline|split|sqrt|strip|"
+        r"tan|times|toNDC|trace|transform|trunc|"
+        r"vop|vop_comp|vop_flatten|vop_normalize|vop_transform|"
+        r"vop_translate|vop_rotate|vop_scale|vop_add|vop_subtract|vop_multiply|vop_divide|"
+        r"vop_dot|vop_cross|vop_length|vop_distance|vop_normal|vop_lerp|"
+        r"vop_abs|vop_ceil|vop_floor|vop_round|vop_sin|vop_cos|vop_exp|"
+        r"vop_log|vop_pow|vop_sqrt|vop_min|vop_max|vop_clamp|vop_mix|vop_select|"
+        r"vop_compare|vop_switch|vop_if|vop_while|vop_for|vop_forpoints|"
+        r"vop_forprims|vop_forvertices|vop_foreach|"
+        r"vop_bind|vop_bindtransform|vop_float_to_int|vop_int_to_float|"
+        r"vop_vector_to_float|vop_float_to_vector|vop_float_to_matrix|"
+        r"vop_noise|vop_turbnoise|vop_periodicnoise|vop_worley|"
+        r"wnoise|xnoise|xyzdist|rand|"
+        r"acos|asin|atan|cos|cosh|sin|sinh|tanh|"
+        r"abs|sign|rint|"
+        # VEX flow control
+        r"if|else|for|foreach|while|do|return|break|continue"
+        r")\b"
+    ),
+    # — Comments —
+    re.compile(r"//.*$|/\*.*?\*/"),
+    # — Numeric literals —
+    re.compile(r"\b\d+(\.\d*)?([eE][+-]?\d+)?\b"),
+    # — String literals —
+    re.compile(r'"[^"]*"'),
+    # — Vectors/matrices —
+    re.compile(r"\{[^}]*\}"),
+    # — Operators —
+    re.compile(r"[+\-*/%=<>!&|^~?:@.;,(){}\[\]]"),
+]
+
+
+# Constructs that are FORBIDDEN in any VEX snippet passed through this gateway.
+# These block the "arbitrary script execution" escape hatch.
+_FORBIDDEN_VEX_PATTERNS: List[re.Pattern] = [
+    # Python injection via VEX
+    re.compile(r"\bpython\b", re.IGNORECASE),
+    re.compile(r"\bexec\b", re.IGNORECASE),
+    re.compile(r"\beval\b", re.IGNORECASE),
+    re.compile(r"\bimport\b", re.IGNORECASE),
+    re.compile(r"\bsubprocess\b", re.IGNORECASE),
+    re.compile(r"\bos\.\w+", re.IGNORECASE),
+    re.compile(r"\bsys\.\w+", re.IGNORECASE),
+    # System/file access — VEX has no intrinsic filesystem calls,
+    # but defending against future expansions
+    re.compile(r"\brun\s*\(\s*\"", re.IGNORECASE),
+    re.compile(r"\bsystem\s*\(\s*\"", re.IGNORECASE),
+    re.compile(r"\bpopen\b", re.IGNORECASE),
+    # Houdini-specific traps
+    re.compile(r"\bhou\.\w+"),
+    re.compile(r"\b__\w+__\b"),  # dunder attributes
+    # Unicode homoglyph / encoding attacks
+    re.compile(r"[^\x00-\x7F]+", re.IGNORECASE),
+    # Potential VEX escape / string injection
+    re.compile(r"\\x[0-9a-fA-F]{2}"),
+    re.compile(r"\\u[0-9a-fA-F]{4}"),
+]
+
+
+# Parameter validation rules per wrangle type.
+# Maps wrangle type → {parm_name: (expected_type, allowed_values_or_Null, required)}
+_WRANGLE_PARM_RULES: Dict[WrangleType, Dict[str, tuple]] = {
+    WrangleType.ATTRIB_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+        "class": (str, None, False),  # run over
+        "grpfilter": (str, None, False),
+        "grouptype": (str, None, False),
+    },
+    WrangleType.VOLUME_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+        "bindings": (str, None, False),
+    },
+    WrangleType.GEOMETRY_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+        "class": (str, None, False),
+    },
+    WrangleType.POINT_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+    },
+    WrangleType.PRIMITIVE_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+    },
+    WrangleType.VERTEX_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+    },
+    WrangleType.DETAIL_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+    },
+    WrangleType.TOPOLOGY_WRANGLE: {
+        "snippet": (str, None, False),
+        "group": (str, None, False),
+    },
+}
+
+
+
+
+def validate_vex_snippet_client(code: str) -> List[VexSyntaxError]:
+    """Client-side (no ``hou``) VEX snippet validation.
+
+    Returns a list of :class:`VexSyntaxError`.  An empty list means the
+    snippet passes all client-side checks.
+    """
+    errors: List[VexSyntaxError] = []
+
+    if not code or not code.strip():
+        errors.append(
+            VexSyntaxError(
+                message="VEX snippet is empty",
+                severity=VexSeverity.ERROR,
+            )
+        )
+        return errors
+
+    # Check forbidden patterns first — these are hard errors.
+    for pattern in _FORBIDDEN_VEX_PATTERNS:
+        for match in pattern.finditer(code):
+            line = code[: match.start()].count("\n") + 1
+            errors.append(
+                VexSyntaxError(
+                    message=f"Forbidden construct in VEX snippet: '{match.group()}'",
+                    severity=VexSeverity.ERROR,
+                    line=line,
+                    snippet_context=_extract_line(code, line),
+                )
+            )
+
+    # If there are forbidden patterns, don't bother with the allowlist.
+    if errors:
+        return errors
+
+    # Strip comments and strings for allowlist check.
+    stripped = _strip_comments_and_strings(code)
+    # Only check function-call-like tokens against the allowlist.
+    # Variable names like `offset`, `x`, `y` are user-defined and not checked.
+    func_calls = re.findall(r"([a-zA-Z_]\w*)\s*\(", stripped)
+    for token in func_calls:
+        if not _is_allowed_token(token):
+            line = code[: code.find(token + "(")].count("\n") + 1
+            errors.append(
+                VexSyntaxError(
+                    message=f"Disallowed function call in VEX snippet: '{token}()'",
+                    severity=VexSeverity.ERROR,
+                    line=line,
+                    snippet_context=_extract_line(code, line),
+                )
+            )
+
+    return errors
+
+
+def validate_wrangle_parameters(
+    wrangle_type: WrangleType,
+    parameters: Dict[str, Any],
+) -> List[str]:
+    """Validate parameter names and types for a given wrangle type.
+
+    Returns a list of error strings; empty list means all parameters are valid.
+    """
+    rules = _WRANGLE_PARM_RULES.get(wrangle_type, {})
+    errors: List[str] = []
+
+    for parm_name, value in parameters.items():
+        rule = rules.get(parm_name)
+        if rule is None:
+            errors.append(
+                f"Unknown parameter '{parm_name}' for wrangle type '{wrangle_type.value}'"
+            )
+            continue
+
+        expected_type, allowed_values, _required = rule
+        if not isinstance(value, expected_type):
+            errors.append(
+                f"Parameter '{parm_name}' expected type {expected_type.__name__}, "
+                f"got {type(value).__name__}"
+            )
+        if allowed_values is not None and value not in allowed_values:
+            errors.append(
+                f"Parameter '{parm_name}' value '{value}' not in allowed: {allowed_values}"
+            )
+
+    return errors
+
+
+def validate_attribute_bindings(
+    snippet_code: str,
+    known_attributes: List[str],
+) -> List[VexSyntaxError]:
+    """Validate that attribute bindings in VEX code reference known attributes.
+
+    This is a best-effort static check.  Dynamic attribute names cannot be
+    resolved statically.
+    """
+    errors: List[VexSyntaxError] = []
+    known = set(known_attributes)
+
+    # Find @attribute references that are NOT built-in globals.
+    builtin_attrs = {
+        "P", "N", "Cd", "uv", "v", "id", "ptnum", "primnum", "vtxnum",
+        "numpt", "numprim", "numvtx", "Time", "Frame", "elemnum", "numelem",
+    }
+
+    attr_refs = re.findall(r"@(\w+)", snippet_code)
+    unresolved: set[str] = set()
+
+    for attr in attr_refs:
+        if attr in builtin_attrs:
+            continue
+        if attr in known:
+            continue
+        unresolved.add(attr)
+
+    for attr in sorted(unresolved):
+        # Find where this attribute is referenced.
+        first_line = None
+        for match in re.finditer(rf"@{attr}\b", snippet_code):
+            first_line = snippet_code[: match.start()].count("\n") + 1
+            break
+        msg = f"Attribute '@{attr}' is not in known geometry attributes"
+        if first_line:
+            errors.append(
+                VexSyntaxError(
+                    message=msg,
+                    severity=VexSeverity.WARNING,
+                    line=first_line,
+                    snippet_context=_extract_line(snippet_code, first_line),
+                )
+            )
+        else:
+            errors.append(VexSyntaxError(message=msg, severity=VexSeverity.WARNING))
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_comments_and_strings(code: str) -> str:
+    """Remove comments and string literals so the token allowlist is accurate."""
+    # Remove block comments
+    code = re.sub(r"/\*.*?\*/", " ", code, flags=re.DOTALL)
+    # Remove line comments
+    code = re.sub(r"//.*$", " ", code, flags=re.MULTILINE)
+    # Remove string literals
+    code = re.sub(r'"[^"]*"', '""', code)
+    return code
+
+
+def _is_allowed_token(token: str) -> bool:
+    """Check if a token matches any allowlist pattern."""
+    for pattern in _ALLOWED_VEX_PATTERNS:
+        if pattern.fullmatch(token):
+            return True
+    return False
+
+
+def _extract_line(code: str, line_no: int) -> Optional[str]:
+    """Extract the line at *line_no* (1-indexed) from *code*."""
+    lines = code.splitlines()
+    idx = line_no - 1
+    if 0 <= idx < len(lines):
+        return lines[idx].strip()
+    return None

--- a/src/dcc_mcp_houdini/_vex_validator.py
+++ b/src/dcc_mcp_houdini/_vex_validator.py
@@ -162,8 +162,6 @@ _WRANGLE_PARM_RULES: Dict[WrangleType, Dict[str, tuple]] = {
 }
 
 
-
-
 def validate_vex_snippet_client(code: str) -> List[VexSyntaxError]:
     """Client-side (no ``hou``) VEX snippet validation.
 
@@ -232,21 +230,14 @@ def validate_wrangle_parameters(
     for parm_name, value in parameters.items():
         rule = rules.get(parm_name)
         if rule is None:
-            errors.append(
-                f"Unknown parameter '{parm_name}' for wrangle type '{wrangle_type.value}'"
-            )
+            errors.append(f"Unknown parameter '{parm_name}' for wrangle type '{wrangle_type.value}'")
             continue
 
         expected_type, allowed_values, _required = rule
         if not isinstance(value, expected_type):
-            errors.append(
-                f"Parameter '{parm_name}' expected type {expected_type.__name__}, "
-                f"got {type(value).__name__}"
-            )
+            errors.append(f"Parameter '{parm_name}' expected type {expected_type.__name__}, got {type(value).__name__}")
         if allowed_values is not None and value not in allowed_values:
-            errors.append(
-                f"Parameter '{parm_name}' value '{value}' not in allowed: {allowed_values}"
-            )
+            errors.append(f"Parameter '{parm_name}' value '{value}' not in allowed: {allowed_values}")
 
     return errors
 
@@ -265,8 +256,22 @@ def validate_attribute_bindings(
 
     # Find @attribute references that are NOT built-in globals.
     builtin_attrs = {
-        "P", "N", "Cd", "uv", "v", "id", "ptnum", "primnum", "vtxnum",
-        "numpt", "numprim", "numvtx", "Time", "Frame", "elemnum", "numelem",
+        "P",
+        "N",
+        "Cd",
+        "uv",
+        "v",
+        "id",
+        "ptnum",
+        "primnum",
+        "vtxnum",
+        "numpt",
+        "numprim",
+        "numvtx",
+        "Time",
+        "Frame",
+        "elemnum",
+        "numelem",
     }
 
     attr_refs = re.findall(r"@(\w+)", snippet_code)

--- a/src/dcc_mcp_houdini/_vex_validator.py
+++ b/src/dcc_mcp_houdini/_vex_validator.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional
 
-from dcc_mcp_houdini._vex_types import VexContext, VexSeverity, VexSyntaxError, WrangleType
-
+from dcc_mcp_houdini._vex_types import VexSeverity, VexSyntaxError, WrangleType
 
 # ---------------------------------------------------------------------------
 # Client-side (no hou) validation

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -6,7 +6,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 |-------|--------|----------------|
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
-| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-material-library`, `houdini-hda`, `houdini-light-rig` | no |
+| `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-vex`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-material-library`, `houdini-hda`, `houdini-light-rig` | no |
 | `interchange` | `houdini-interchange`, `houdini-export-preset`, `houdini-import-to-scene`, `houdini-usd-lops` | no |
 | `pipeline` | `houdini-render`, `houdini-karma`, `houdini-husk`, `houdini-animation`, `houdini-chops`, `houdini-constraints`, `houdini-kinefx`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake` | no |
 
@@ -24,6 +24,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Inspect & rewire graph | `load_skill("houdini-node-graph")` → `houdini_node_graph__get_connections` → `houdini_node_graph__connect_input` / `houdini_node_graph__disconnect_input` |
 | Create & inspect geometry | `load_skill("houdini-geometry")` → `houdini_geometry__create_primitive` → `houdini_geometry__get_geometry_info` → `houdini_geometry__list_attributes` / `houdini_geometry__list_groups` |
 | Edit a mesh procedurally | `load_skill("houdini-mesh-ops")` → `houdini_mesh_ops__transform_geometry` / `merge_geometry` / `blast_geometry` / `group_geometry` / `add_normals` / `triangulate_geometry` / `convert_geometry` → `houdini_geometry__get_cook_status` |
+| Create & debug VEX wrangles | `load_skill("houdini-vex")` → `houdini_vex__validate_vex_syntax` → `houdini_vex__create_wrangle` → `houdini_vex__cook_wrangle` → `houdini_vex__diagnose_wrangle` / `houdini_vex__get_vex_info` |
 | Set up cameras & lights | `load_skill("houdini-camera-light")` → `houdini_camera_light__create_camera` → `houdini_camera_light__create_light` → `houdini_camera_light__frame_view` |
 | Three-point studio lighting | `load_skill("houdini-light-rig")` → `create_three_point_light_rig` → `aim_light_at_object` → `set_light_rig_intensity` → `get_lighting_summary` |
 | HDRI environment lighting | `load_skill("houdini-light-rig")` → `create_hdri_world` → `area_softbox` / `set_render_view_transform` → `get_lighting_summary` |

--- a/src/dcc_mcp_houdini/skills/houdini-vex/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: houdini-vex
+description: >-
+  Typed VEX creation and diagnosis workflow — create or update Wrangle nodes,
+  validate VEX syntax, cook, and collect geometry diagnostics with failure
+  localization.  Never degrades to arbitrary script execution; all VEX code
+  is set via typed node parameters only.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, vex, wrangle, attribute, geometry, cook, diagnostics]
+    search-hint: >-
+      create wrangle, update vex snippet, validate vex syntax, cook wrangle,
+      diagnose vex failure, get vex info, list wrangles
+    tools: tools.yaml
+---
+
+# houdini-vex
+
+Typed VEX authoring and diagnosis for agents.  All tools are `affinity: main`
+because they call `hou`.  Prefer these over `houdini-scripting.execute_python`
+for VEX creation.
+
+**Hard constraint:** VEX snippets are set via `hou.Parm.set()` on the "snippet"
+parameter of Wrangle nodes.  This skill NEVER constructs or evaluates Python
+code from VEX strings.  Every VEX snippet is validated client-side (allowlist
+and deny-list) before it touches Houdini.
+
+## Tool groups
+
+- **`vex-create`:** create a Wrangle node with optional initial VEX snippet
+  (`create_wrangle`).
+- **`vex-edit`:** update the VEX snippet on an existing Wrangle
+  (`update_vex_snippet`).
+- **`vex-validate`:** pre-cook validation of VEX syntax, bindings, and
+  parameters (`validate_vex_syntax`).
+- **`vex-cook`:** cook a Wrangle and collect diagnostics (`cook_wrangle`,
+  `diagnose_wrangle`).
+- **`vex-query`** (read-only): inspect an existing Wrangle or list all
+  wrangles under a path (`get_vex_info`, `list_wrangles`).
+
+## Tracer-bullet flow
+
+1. `validate_vex_snippet` — check VEX syntax and bindings before committing
+2. `create_wrangle(parent_path="/obj/geo1", wrangle_type="pointwrangle", ...)` —
+   create a typed Wrangle with the validated snippet
+3. `cook_wrangle` — cook the node and get initial diagnostics
+4. `get_vex_info` — read back the wrangle metadata (snippet, run-over, cook state)
+5. If errors: `diagnose_wrangle` — localize the failure to a specific line or
+   attribute binding
+
+For iterative work, use `update_vex_snippet` → `cook_wrangle` → `diagnose_wrangle`
+in a loop until the VEX produces the expected geometry.
+
+## Security model
+
+- **Client-side VEX allowlist:** only known VEX builtins, attributes, and
+  control flow are permitted.
+- **Deny list blocks:** `python`, `exec`, `eval`, `import`, `subprocess`,
+  `os.*`, `sys.*`, `hou.*`, and unicode escape sequences.
+- **Size limits:** 64KB / 2000 lines per snippet.
+- **No Python execution:** VEX code flows through `hou.Parm.set()` — never
+  through `exec()` or `eval()` or any HOM Python execution path.

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/_vex_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/_vex_common.py
@@ -1,0 +1,46 @@
+"""Shared helpers for houdini-vex skill scripts."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from dcc_mcp_houdini._vex_types import (
+    VexContext,
+    VexSyntaxError,
+    WrangleType,
+)
+
+
+def resolve_vex_context(run_over: str) -> VexContext:
+    """Map a run-over string to a :class:`VexContext` enum value."""
+    _MAP: dict[str, VexContext] = {
+        "points": VexContext.POINTS,
+        "prims": VexContext.PRIMITIVES,
+        "verts": VexContext.VERTICES,
+        "detail": VexContext.DETAIL,
+        "global": VexContext.GLOBAL_VERTICES,
+        "attribs": VexContext.ATTRIBUTES,
+        "numbers": VexContext.NUMBERS,
+    }
+    return _MAP.get(run_over.lower(), VexContext.POINTS)
+
+
+def resolve_wrangle_type(type_name: str) -> WrangleType:
+    """Map a string to a :class:`WrangleType` enum value."""
+    for wt in WrangleType:
+        if wt.value == type_name.lower():
+            return wt
+    return WrangleType.ATTRIB_WRANGLE
+
+
+def format_validation_errors(errors: List[VexSyntaxError]) -> List[dict]:
+    """Convert a list of :class:`VexSyntaxError` to JSON-compatible dicts."""
+    return [e.to_dict() for e in errors]
+
+
+def _get_node(hou: Any, node_path: str) -> Any:
+    """Resolve a node path, raising ValueError if not found."""
+    node = hou.node(node_path)
+    if node is None:
+        raise ValueError(f"Houdini node not found: {node_path}")
+    return node

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/cook_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/cook_wrangle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from _vex_common import _get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/cook_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/cook_wrangle.py
@@ -1,0 +1,41 @@
+"""Cook a Wrangle node and return geometry diagnostics — the sole VEX evaluation path."""
+
+from __future__ import annotations
+
+from _vex_common import _get_node  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def cook_wrangle(node_path: str, force: bool = False) -> dict:
+    """Cook *node_path* and return cook status plus geometry diagnostics.
+
+    The cook triggers VEX compilation and evaluation inside Houdini.
+    Diagnostics include point/prim/vertex counts, attribute names, group
+    names, and any cook errors or warnings.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        from dcc_mcp_houdini._vex_executor import cook_and_diagnose
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    try:
+        diag = cook_and_diagnose(hou, node_path, force=force)
+        return skill_success("Cooked Wrangle", **diag.to_dict())
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cook Wrangle")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return cook_wrangle(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/create_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/create_wrangle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from _vex_common import resolve_vex_context, resolve_wrangle_type  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def create_wrangle(
@@ -30,8 +30,8 @@ def create_wrangle(
         return skill_error("Houdini not available", "hou could not be imported")
 
     try:
-        from dcc_mcp_houdini._vex_types import VexSnippet, WrangleNodeSpec
         from dcc_mcp_houdini._vex_executor import create_wrangle as _create
+        from dcc_mcp_houdini._vex_types import VexSnippet, WrangleNodeSpec
         from dcc_mcp_houdini._vex_validator import validate_vex_snippet_client
     except ImportError as exc:
         return skill_error("VEX module not available", str(exc))

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/create_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/create_wrangle.py
@@ -1,0 +1,84 @@
+"""Create a typed Wrangle SOP node with optional validated VEX snippet."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from _vex_common import resolve_vex_context, resolve_wrangle_type  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def create_wrangle(
+    parent_path: str,
+    wrangle_type: str = "attribwrangle",
+    node_name: Optional[str] = None,
+    run_over: str = "points",
+    vex_code: Optional[str] = None,
+    bindings: Optional[Dict[str, str]] = None,
+    parameters: Optional[Dict[str, Any]] = None,
+    set_display: bool = False,
+    set_render: bool = False,
+) -> dict:
+    """Create a Wrangle SOP node under *parent_path*.
+
+    If *vex_code* is provided, it is validated client-side BEFORE being
+    committed to the node.  This is NOT a Python execution path.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        from dcc_mcp_houdini._vex_types import VexSnippet, WrangleNodeSpec
+        from dcc_mcp_houdini._vex_executor import create_wrangle as _create
+        from dcc_mcp_houdini._vex_validator import validate_vex_snippet_client
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    # ── Build snippet if VEX code provided ─────────────────────────────
+    snippet = None
+    if vex_code:
+        client_errors = validate_vex_snippet_client(vex_code)
+        if client_errors:
+            return skill_error(
+                "VEX snippet validation failed",
+                f"{len(client_errors)} validation error(s) found",
+                validation_errors=[e.to_dict() for e in client_errors],
+                hint="Fix the reported errors and retry.  Only standard VEX builtins and constructs are permitted.",
+            )
+        try:
+            snippet = VexSnippet(
+                code=vex_code,
+                context=resolve_vex_context(run_over),
+                bindings=bindings or {},
+                parameter_values=parameters or {},
+            )
+        except ValueError as exc:
+            return skill_error("Invalid VEX snippet", f"VexSnippet construction failed: {exc}")
+
+    spec = WrangleNodeSpec(
+        parent_path=parent_path,
+        node_name=node_name,
+        wrangle_type=resolve_wrangle_type(wrangle_type),
+        run_over=resolve_vex_context(run_over),
+        snippet=snippet,
+        set_display=set_display,
+        set_render=set_render,
+    )
+
+    result = _create(hou, spec)
+    if result.get("success"):
+        return skill_success("Created Wrangle node", **result)
+    return skill_error("Failed to create Wrangle node", **result)
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return create_wrangle(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/diagnose_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/diagnose_wrangle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from _vex_common import _get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/diagnose_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/diagnose_wrangle.py
@@ -1,0 +1,46 @@
+"""Analyse a Wrangle cook failure and locate the root cause."""
+
+from __future__ import annotations
+
+from _vex_common import _get_node  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def diagnose_wrangle(node_path: str) -> dict:
+    """Locate the failure in *node_path* by cooking and analysing the errors.
+
+    Returns a structured diagnosis: likely cause, error location, and a
+    suggested fix.  This is the post-mortem companion to :func:`cook_wrangle`.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        from dcc_mcp_houdini._vex_executor import cook_and_diagnose, locate_wrangle_failure
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    try:
+        diag = cook_and_diagnose(hou, node_path, force=True)
+        analysis = locate_wrangle_failure(diag)
+
+        return skill_success(
+            f"Diagnosis: {analysis.get('likely_cause', 'unknown')}",
+            **analysis,
+            geometry_diagnostics=diag.to_dict(),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to diagnose Wrangle")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return diagnose_wrangle(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/get_vex_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/get_vex_info.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from _vex_common import _get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/get_vex_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/get_vex_info.py
@@ -1,0 +1,38 @@
+"""Read back metadata from a Wrangle node — read-only, never cooks."""
+
+from __future__ import annotations
+
+from _vex_common import _get_node  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def get_vex_info(node_path: str) -> dict:
+    """Return Wrangle metadata for *node_path* without cooking or mutating."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        from dcc_mcp_houdini._vex_executor import get_wrangle_info
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    try:
+        info = get_wrangle_info(hou, node_path)
+        return skill_success("Read Wrangle info", **info.to_dict())
+    except ValueError as exc:
+        return skill_error("Node not found", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read Wrangle info")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_vex_info(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/list_wrangles.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/list_wrangles.py
@@ -1,0 +1,43 @@
+"""List all Wrangle-type nodes under a parent path, recursively."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def list_wrangles(parent_path: str = "/obj") -> dict:
+    """List all Wrangle nodes under *parent_path* (recursive)."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        from dcc_mcp_houdini._vex_executor import list_wrangles as _list
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    try:
+        results = _list(hou, parent_path)
+        return skill_success(
+            f"Found {len(results)} Wrangle node(s)",
+            count=len(results),
+            wrangles=results,
+        )
+    except ValueError as exc:
+        return skill_error("Invalid parent path", str(exc))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to list Wrangles")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return list_wrangles(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/list_wrangles.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/list_wrangles.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
@@ -27,8 +27,8 @@ def update_vex_snippet(
         return skill_error("Houdini not available", "hou could not be imported")
 
     try:
-        from dcc_mcp_houdini._vex_types import VexContext, VexSnippet
         from dcc_mcp_houdini._vex_executor import update_vex_snippet as _update
+        from dcc_mcp_houdini._vex_types import VexContext, VexSnippet
         from dcc_mcp_houdini._vex_validator import validate_vex_snippet_client
     except ImportError as exc:
         return skill_error("VEX module not available", str(exc))

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
@@ -1,0 +1,72 @@
+"""Update VEX snippet on an existing Wrangle node (validated, no raw-string passthrough)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from _vex_common import resolve_vex_context  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+
+def update_vex_snippet(
+    node_path: str,
+    vex_code: str,
+    run_over: Optional[str] = None,
+    bindings: Optional[Dict[str, str]] = None,
+    parameters: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Update the VEX snippet on *node_path*.
+
+    The snippet is validated client-side before being committed.  The
+    previous snippet (first 200 chars) is preserved in the result for
+    audit trail purposes.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        from dcc_mcp_houdini._vex_types import VexContext, VexSnippet
+        from dcc_mcp_houdini._vex_executor import update_vex_snippet as _update
+        from dcc_mcp_houdini._vex_validator import validate_vex_snippet_client
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    # ── Client-side validation ─────────────────────────────────────────
+    client_errors = validate_vex_snippet_client(vex_code)
+    if client_errors:
+        return skill_error(
+            "VEX snippet validation failed",
+            f"{len(client_errors)} validation error(s) found",
+            validation_errors=[e.to_dict() for e in client_errors],
+            hint="Fix the reported errors and retry.",
+        )
+
+    context = resolve_vex_context(run_over) if run_over else VexContext.POINTS
+
+    try:
+        snippet = VexSnippet(
+            code=vex_code,
+            context=context,
+            bindings=bindings or {},
+            parameter_values=parameters or {},
+        )
+    except ValueError as exc:
+        return skill_error("Invalid VEX snippet", str(exc))
+
+    result = _update(hou, node_path, snippet)
+    if result.get("success"):
+        return skill_success("Updated VEX snippet", **result)
+    return skill_error("Failed to update VEX snippet", **result)
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return update_vex_snippet(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/validate_vex_syntax.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/validate_vex_syntax.py
@@ -1,0 +1,79 @@
+"""Validate VEX snippet syntax client-side — no Houdini touch, read-only."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+
+def validate_vex_syntax(
+    vex_code: str,
+    run_over: str = "points",
+    known_attributes: Optional[List[str]] = None,
+    wrangle_type: str = "attribwrangle",
+) -> dict:
+    """Validate *vex_code* against the VEX allowlist and deny-list.
+
+    This is a client-side check only — no ``hou`` import, no scene mutation.
+    Returns structured diagnostics with line/column hints.
+    """
+    try:
+        from dcc_mcp_houdini._vex_validator import (
+            validate_attribute_bindings,
+            validate_vex_snippet_client,
+            validate_wrangle_parameters,
+        )
+        from dcc_mcp_houdini._vex_types import WrangleType
+    except ImportError as exc:
+        return skill_error("VEX module not available", str(exc))
+
+    # ── Client-side syntax check ───────────────────────────────────────
+    errors = validate_vex_snippet_client(vex_code)
+
+    # ── Attribute binding check ────────────────────────────────────────
+    if known_attributes:
+        binding_errors = validate_attribute_bindings(vex_code, known_attributes)
+        errors.extend(binding_errors)
+
+    # ── Parameter type check ───────────────────────────────────────────
+    wt = next((w for w in WrangleType if w.value == wrangle_type), WrangleType.ATTRIB_WRANGLE)
+    # We don't have actual parameter values to check in validate mode;
+    # the parameter validation is informational.
+
+    if errors:
+        return skill_error(
+            "VEX snippet has validation issues",
+            f"{len(errors)} issue(s) found",
+            error_count=len(errors),
+            errors=[e.to_dict() for e in errors],
+            severity_distribution=_severity_distribution(errors),
+        )
+
+    return skill_success(
+        "VEX snippet is valid",
+        line_count=len([ln for ln in vex_code.splitlines() if ln.strip()]),
+        char_count=len(vex_code),
+        run_over=run_over,
+        wrangle_type=wrangle_type,
+    )
+
+
+def _severity_distribution(errors) -> dict:
+    dist: dict = {"error": 0, "warning": 0, "info": 0}
+    for e in errors:
+        sev = e.severity.value
+        if sev in dist:
+            dist[sev] += 1
+    return dist
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return validate_vex_syntax(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/validate_vex_syntax.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/validate_vex_syntax.py
@@ -22,9 +22,7 @@ def validate_vex_syntax(
         from dcc_mcp_houdini._vex_validator import (
             validate_attribute_bindings,
             validate_vex_snippet_client,
-            validate_wrangle_parameters,
         )
-        from dcc_mcp_houdini._vex_types import WrangleType
     except ImportError as exc:
         return skill_error("VEX module not available", str(exc))
 
@@ -35,11 +33,6 @@ def validate_vex_syntax(
     if known_attributes:
         binding_errors = validate_attribute_bindings(vex_code, known_attributes)
         errors.extend(binding_errors)
-
-    # ── Parameter type check ───────────────────────────────────────────
-    wt = next((w for w in WrangleType if w.value == wrangle_type), WrangleType.ATTRIB_WRANGLE)
-    # We don't have actual parameter values to check in validate mode;
-    # the parameter validation is informational.
 
     if errors:
         return skill_error(

--- a/src/dcc_mcp_houdini/skills/houdini-vex/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/tools.yaml
@@ -1,0 +1,274 @@
+tools:
+  - name: create_wrangle
+    description: >-
+      Create a typed Wrangle SOP node (attribwrangle, pointwrangle,
+      geometrywrangle, etc.) under a parent SOP network, optionally with a
+      validated VEX snippet.  The run-over context and bindings are set
+      explicitly — no raw-string passthrough.
+    source_file: scripts/create_wrangle.py
+    execution: sync
+    affinity: main
+    group: vex-create
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [parent_path]
+      properties:
+        parent_path:
+          type: string
+          description: SOP network path to create the Wrangle inside (e.g. /obj/geo1).
+        wrangle_type:
+          type: string
+          default: attribwrangle
+          enum:
+            - attribwrangle
+            - volumewrangle
+            - geometrywrangle
+            - pointwrangle
+            - primitivewrangle
+            - vertexwrangle
+            - detailwrangle
+            - topologywrangle
+          description: Houdini Wrangle SOP node type.
+        node_name:
+          type: string
+          description: Optional node name (Houdini auto-names if omitted).
+        run_over:
+          type: string
+          default: points
+          enum: [points, prims, verts, detail, global, attribs, numbers]
+          description: Geometry component to run VEX over.
+        vex_code:
+          type: string
+          description: >-
+            VEX snippet to set on the wrangle.  Validated client-side against
+            allowlist/denylist before being committed to the node.
+        bindings:
+          type: object
+          description: Optional attribute bindings (name -> type map).
+          additionalProperties:
+            type: string
+        parameters:
+          type: object
+          description: Optional extra parameter values (e.g. group).
+          additionalProperties: {}
+        set_display:
+          type: boolean
+          default: false
+          description: Set the display flag on the new node.
+        set_render:
+          type: boolean
+          default: false
+          description: Set the render flag on the new node.
+    next-tools:
+      on-success:
+        - houdini_vex__cook_wrangle
+        - houdini_vex__get_vex_info
+
+  - name: update_vex_snippet
+    description: >-
+      Update the VEX snippet (and optionally run-over context and bindings)
+      on an existing Wrangle node.  The new snippet is validated client-side
+      before being committed.  Returns the previous snippet preview.
+    source_file: scripts/update_vex_snippet.py
+    execution: sync
+    affinity: main
+    group: vex-edit
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [node_path, vex_code]
+      properties:
+        node_path:
+          type: string
+          description: Path to an existing Wrangle node.
+        vex_code:
+          type: string
+          description: New VEX snippet (validated client-side before commit).
+        run_over:
+          type: string
+          enum: [points, prims, verts, detail, global, attribs, numbers]
+          description: Optional new run-over context.
+        bindings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional new attribute bindings.
+        parameters:
+          type: object
+          additionalProperties: {}
+          description: Optional extra parameter values.
+    next-tools:
+      on-success:
+        - houdini_vex__cook_wrangle
+
+  - name: validate_vex_syntax
+    description: >-
+      Validate VEX snippet syntax client-side without touching Houdini.
+      Checks against the VEX allowlist and deny-list, validates bindings
+      against known attributes, and returns structured diagnostics with
+      line/column location.  Read-only — no scene mutation.
+    source_file: scripts/validate_vex_syntax.py
+    execution: sync
+    affinity: main
+    group: vex-validate
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [vex_code]
+      properties:
+        vex_code:
+          type: string
+          description: VEX snippet to validate.
+        run_over:
+          type: string
+          default: points
+          enum: [points, prims, verts, detail, global, attribs, numbers]
+          description: Expected run-over context (for context-aware checks).
+        known_attributes:
+          type: array
+          items:
+            type: string
+          description: Known geometry attribute names for binding validation.
+        wrangle_type:
+          type: string
+          default: attribwrangle
+          enum:
+            - attribwrangle
+            - volumewrangle
+            - geometrywrangle
+            - pointwrangle
+            - primitivewrangle
+            - vertexwrangle
+            - detailwrangle
+            - topologywrangle
+          description: Target wrangle type for parameter context.
+    next-tools:
+      on-success:
+        - houdini_vex__create_wrangle
+
+  - name: cook_wrangle
+    description: >-
+      Cook a Wrangle node and return cook status plus geometry diagnostics
+      (point/prim/vertex counts, attribute names, group names, errors and
+      warnings).  This is the sole path that evaluates VEX.
+    source_file: scripts/cook_wrangle.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 120
+    group: vex-cook
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Path to the Wrangle node to cook.
+        force:
+          type: boolean
+          default: false
+          description: Force recook even if already cooked.
+    next-tools:
+      on-failure:
+        - houdini_vex__diagnose_wrangle
+
+  - name: diagnose_wrangle
+    description: >-
+      Analyse a failed Wrangle cook and locate the failure: VEX compile
+      error with line hints, missing attribute bindings, zero geometry,
+      or cook timeout.  Returns a suggested fix.  Read-only.
+    source_file: scripts/diagnose_wrangle.py
+    execution: sync
+    affinity: main
+    group: vex-cook
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Path to the Wrangle node to diagnose.
+    next-tools:
+      on-success:
+        - houdini_vex__update_vex_snippet
+
+  - name: get_vex_info
+    description: >-
+      Read back metadata from a Wrangle node: node type, run-over mode,
+      snippet preview, cook state, and input/output count.  Read-only
+      — never cooks or mutates.
+    source_file: scripts/get_vex_info.py
+    execution: sync
+    affinity: main
+    group: vex-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [node_path]
+      properties:
+        node_path:
+          type: string
+          description: Path to the Wrangle node to inspect.
+
+  - name: list_wrangles
+    description: >-
+      List all Wrangle-type nodes under a parent path, recursively.
+      Returns node path, name, and wrangle type for each match.
+      Read-only.
+    source_file: scripts/list_wrangles.py
+    execution: sync
+    affinity: main
+    group: vex-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: []
+      properties:
+        parent_path:
+          type: string
+          default: /obj
+          description: Root path to search for Wrangle nodes.

--- a/tests/test_vex_skills.py
+++ b/tests/test_vex_skills.py
@@ -24,9 +24,7 @@ _SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skill
 
 def _load_script(skill_name: str, script_name: str) -> ModuleType:
     path = _SKILLS_ROOT / skill_name / "scripts" / script_name
-    spec = importlib.util.spec_from_file_location(
-        f"skill_{skill_name}_{path.stem}", path
-    )
+    spec = importlib.util.spec_from_file_location(f"skill_{skill_name}_{path.stem}", path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -186,6 +184,7 @@ class TestCreateWrangle:
                     if name == "class":
                         return cls
                     return None
+
                 return _parm_side_effect
 
             new.parm.side_effect = _make_side_effect(_snip_parm, _class_parm)

--- a/tests/test_vex_skills.py
+++ b/tests/test_vex_skills.py
@@ -15,7 +15,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from skill_loader import skill_script_import_context
 
@@ -176,17 +176,19 @@ class TestCreateWrangle:
         for wt in ["volumewrangle", "geometrywrangle", "vertexwrangle", "detailwrangle"]:
             mod = _load_script("houdini-vex", "create_wrangle.py")
             new = _node(f"/obj/geo1/{wt}1", f"{wt}1", wt)
-            snip_parm = MagicMock()
-            class_parm = MagicMock()
+            _snip_parm = MagicMock()
+            _class_parm = MagicMock()
 
-            def _parm_side_effect(name):
-                if name == "snippet":
-                    return snip_parm
-                if name == "class":
-                    return class_parm
-                return None
+            def _make_side_effect(snip, cls):
+                def _parm_side_effect(name):
+                    if name == "snippet":
+                        return snip
+                    if name == "class":
+                        return cls
+                    return None
+                return _parm_side_effect
 
-            new.parm.side_effect = _parm_side_effect
+            new.parm.side_effect = _make_side_effect(_snip_parm, _class_parm)
             parent = _node("/obj/geo1", "geo1")
             parent.createNode.return_value = new
             mock_hou = MagicMock()
@@ -926,9 +928,9 @@ class TestVexWorkflowIntegration:
         """Simulate the full VEX workflow tracer-bullet."""
         create_mod = _load_script("houdini-vex", "create_wrangle.py")
         cook_mod = _load_script("houdini-vex", "cook_wrangle.py")
-        diag_mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        _diag_mod = _load_script("houdini-vex", "diagnose_wrangle.py")
         update_mod = _load_script("houdini-vex", "update_vex_snippet.py")
-        info_mod = _load_script("houdini-vex", "get_vex_info.py")
+        _info_mod = _load_script("houdini-vex", "get_vex_info.py")
 
         # ── Step 1: Create a point wrangle ─────────────────────────────
         snippet = "@P += {0, 1, 0};"

--- a/tests/test_vex_skills.py
+++ b/tests/test_vex_skills.py
@@ -1,0 +1,1016 @@
+"""Mock-hou regression tests for the houdini-vex skill package.
+
+Covers all 7 tools:
+- create_wrangle, update_vex_snippet, validate_vex_syntax,
+- cook_wrangle, diagnose_wrangle, get_vex_info, list_wrangles
+
+Tests include: create/update/cook/diagnose success and error paths,
+VEX validation allowlist/deny-list, cook timeout, empty geometry,
+thread-safety (dispatch boundary), cancellation, and edge cases.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, call, patch
+
+from skill_loader import skill_script_import_context
+
+_SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
+
+
+def _load_script(skill_name: str, script_name: str) -> ModuleType:
+    path = _SKILLS_ROOT / skill_name / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(
+        f"skill_{skill_name}_{path.stem}", path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
+    node = MagicMock()
+    node.path.return_value = path
+    node.name.return_value = name
+    node.type.return_value.name.return_value = type_name
+    return node
+
+
+# ---------------------------------------------------------------------------
+# create_wrangle
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWrangle:
+    def test_create_attribwrangle_without_vex(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+        new = _node("/obj/geo1/attribwrangle1", "attribwrangle1", "attribwrangle")
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_wrangle("/obj/geo1")
+
+        assert result["success"] is True
+        assert result["context"]["node_path"] == "/obj/geo1/attribwrangle1"
+        parent.createNode.assert_called_once_with("attribwrangle", node_name=None)
+
+    def test_create_pointwrangle_with_valid_vex(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+        new = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        snip_parm = MagicMock()
+        class_parm = MagicMock()
+        display_flag_called = []
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            return None
+
+        new.parm.side_effect = _parm_side_effect
+        new.setDisplayFlag.side_effect = lambda v: display_flag_called.append(v)
+
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        snippet = "@P += {1, 0, 0};\n@Cd = {1, 0, 0};"
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_wrangle(
+                parent_path="/obj/geo1",
+                wrangle_type="pointwrangle",
+                run_over="points",
+                vex_code=snippet,
+                set_display=True,
+            )
+
+        assert result["success"] is True
+        assert result["context"]["wrangle_type"] == "pointwrangle"
+        assert result["context"]["has_snippet"] is True
+        parent.createNode.assert_called_once_with("pointwrangle", node_name=None)
+        snip_parm.set.assert_called_once_with(snippet)
+        class_parm.set.assert_called_once_with(0)  # points -> 0
+
+    def test_create_wrangle_rejects_forbidden_vex(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.create_wrangle(
+                parent_path="/obj/geo1",
+                vex_code="python { print('hello'); }",
+            )
+
+        assert result["success"] is False
+        assert "validation" in str(result.get("error", "")).lower()
+
+    def test_create_wrangle_rejects_empty_vex(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.create_wrangle(
+                parent_path="/obj/geo1",
+                vex_code="   ",
+            )
+
+        assert result["success"] is False
+
+    def test_create_wrangle_missing_parent(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_wrangle("/obj/nonexistent")
+
+        assert result["success"] is False
+
+    def test_create_wrangle_with_bindings(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+        new = _node("/obj/geo1/attribwrangle1", "attribwrangle1", "attribwrangle")
+        snip_parm = MagicMock()
+        bind_parm = MagicMock()
+        class_parm = MagicMock()
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            if name == "bindings":
+                return bind_parm
+            return None
+
+        new.parm.side_effect = _parm_side_effect
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        snippet = "@pos = @P;"
+        bindings = {"pos": "vector"}
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_wrangle(
+                parent_path="/obj/geo1",
+                vex_code=snippet,
+                bindings=bindings,
+            )
+
+        assert result["success"] is True
+        bind_parm.set.assert_called_once()
+
+    def test_create_different_wrangle_types(self) -> None:
+        for wt in ["volumewrangle", "geometrywrangle", "vertexwrangle", "detailwrangle"]:
+            mod = _load_script("houdini-vex", "create_wrangle.py")
+            new = _node(f"/obj/geo1/{wt}1", f"{wt}1", wt)
+            snip_parm = MagicMock()
+            class_parm = MagicMock()
+
+            def _parm_side_effect(name):
+                if name == "snippet":
+                    return snip_parm
+                if name == "class":
+                    return class_parm
+                return None
+
+            new.parm.side_effect = _parm_side_effect
+            parent = _node("/obj/geo1", "geo1")
+            parent.createNode.return_value = new
+            mock_hou = MagicMock()
+            mock_hou.node.return_value = parent
+
+            with patch.dict(sys.modules, {"hou": mock_hou}):
+                result = mod.create_wrangle(
+                    parent_path="/obj/geo1",
+                    wrangle_type=wt,
+                    vex_code="@P += 1;",
+                )
+
+            assert result["success"] is True, f"Failed for wrangle type: {wt}"
+            assert result["context"]["wrangle_type"] == wt
+
+
+# ---------------------------------------------------------------------------
+# update_vex_snippet
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateVexSnippet:
+    def test_update_snippet_on_existing_wrangle(self) -> None:
+        mod = _load_script("houdini-vex", "update_vex_snippet.py")
+        old_snippet = "@P += {0,1,0};"
+        new_snippet = "@P += {1,0,0};\n@Cd = {1,0,0};"
+
+        snip_parm = MagicMock()
+        snip_parm.evalAsString.return_value = old_snippet
+        class_parm = MagicMock()
+
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            return None
+
+        node.parm.side_effect = _parm_side_effect
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.update_vex_snippet(
+                node_path="/obj/geo1/pointwrangle1",
+                vex_code=new_snippet,
+            )
+
+        assert result["success"] is True
+        assert result["context"]["previous_snippet_preview"] == old_snippet
+        snip_parm.set.assert_called_once_with(new_snippet)
+
+    def test_update_with_validation_rejects_forbidden(self) -> None:
+        mod = _load_script("houdini-vex", "update_vex_snippet.py")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.update_vex_snippet(
+                node_path="/obj/geo1/pointwrangle1",
+                vex_code="exec('x')",
+            )
+
+        assert result["success"] is False
+        assert "validation" in str(result.get("error", "")).lower()
+
+    def test_update_on_nonexistent_node(self) -> None:
+        mod = _load_script("houdini-vex", "update_vex_snippet.py")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.update_vex_snippet(
+                node_path="/obj/nonexistent",
+                vex_code="@P += 1;",
+            )
+
+        assert result["success"] is False
+
+    def test_update_with_run_over_change(self) -> None:
+        mod = _load_script("houdini-vex", "update_vex_snippet.py")
+        snip_parm = MagicMock()
+        snip_parm.evalAsString.return_value = "// old"
+        class_parm = MagicMock()
+
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            return None
+
+        node.parm.side_effect = _parm_side_effect
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.update_vex_snippet(
+                node_path="/obj/geo1/pointwrangle1",
+                vex_code="@P += 1;",
+                run_over="prims",
+            )
+
+        assert result["success"] is True
+        class_parm.set.assert_called_once_with(1)  # prims -> 1
+
+    def test_update_no_snippet_parm(self) -> None:
+        mod = _load_script("houdini-vex", "update_vex_snippet.py")
+        node = _node("/obj/geo1/box1", "box1", "box")
+        node.parm.return_value = None  # No snippet parameter
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.update_vex_snippet(
+                node_path="/obj/geo1/box1",
+                vex_code="@P += 1;",
+            )
+
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# validate_vex_syntax
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVexSyntax:
+    def test_valid_snippet_passes(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        result = mod.validate_vex_syntax("@P += {1,0,0};")
+        assert result["success"] is True
+        assert result["context"]["line_count"] == 1
+
+    def test_forbidden_snippet_fails_with_errors(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        result = mod.validate_vex_syntax("python { print('x'); }")
+        assert result["success"] is False
+        assert result["context"]["error_count"] >= 1
+
+    def test_unknown_attribute_bindings_warnings(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        result = mod.validate_vex_syntax(
+            "@myUnknown = 1.0;",
+            known_attributes=["P", "Cd"],
+        )
+        assert result["success"] is False
+        assert result["context"]["error_count"] >= 1
+
+    def test_known_attribute_bindings_pass(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        result = mod.validate_vex_syntax(
+            "@myAttr = 1.0;",
+            known_attributes=["myAttr", "P", "Cd"],
+        )
+        assert result["success"] is True
+
+    def test_returns_severity_distribution(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        result = mod.validate_vex_syntax("python { exec('x'); }")
+        assert result["success"] is False
+        dist = result["context"]["severity_distribution"]
+        assert dist["error"] >= 1
+
+    def test_empty_snippet_fails(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        result = mod.validate_vex_syntax("")
+        assert result["success"] is False
+
+    def test_multi_line_snippet_reports_line_count(self) -> None:
+        mod = _load_script("houdini-vex", "validate_vex_syntax.py")
+        snippet = "@P += 1;\n@Cd = {1,0,0};\n@N = normalize(@N);"
+        result = mod.validate_vex_syntax(snippet)
+        assert result["success"] is True
+        assert result["context"]["line_count"] == 3
+        assert result["context"]["char_count"] == len(snippet)
+
+
+# ---------------------------------------------------------------------------
+# cook_wrangle
+# ---------------------------------------------------------------------------
+
+
+class TestCookWrangle:
+    def test_cook_successful_wrangle(self) -> None:
+        mod = _load_script("houdini-vex", "cook_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = [1, 2, 3]
+        geo.prims.return_value = [1]
+        geo.iterVertices.return_value = iter([1, 2, 3])
+
+        pt_attrib = MagicMock()
+        pt_attrib.name.return_value = "P"
+        geo.pointAttribs.return_value = [pt_attrib]
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+
+        grp = MagicMock()
+        grp.name.return_value = "myGroup"
+        geo.pointGroups.return_value = [grp]
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert ctx["cooked"] is True
+        assert ctx["point_count"] == 3
+        assert ctx["primitive_count"] == 1
+        assert "P" in ctx["attribute_names"]
+
+    def test_cook_failure_reports_errors(self) -> None:
+        mod = _load_script("houdini-vex", "cook_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.cook.side_effect = RuntimeError("syntax error on line 3")
+        node.errors.return_value = ["syntax error on line 3"]
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True  # skill reports success but cook failed
+        ctx = result["context"]
+        assert ctx["cooked"] is False
+        assert ctx["cook_error"] is not None
+
+    def test_cook_force_recook(self) -> None:
+        mod = _load_script("houdini-vex", "cook_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_wrangle("/obj/geo1/pointwrangle1", force=True)
+
+        assert result["success"] is True
+        node.cook.assert_called_once_with(force=True)
+
+    def test_cook_missing_node(self) -> None:
+        mod = _load_script("houdini-vex", "cook_wrangle.py")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_wrangle("/obj/nonexistent")
+
+        assert result["success"] is True  # Returns success with diagnostic
+        ctx = result["context"]
+        assert ctx["cooked"] is False
+
+    def test_cook_with_warnings(self) -> None:
+        mod = _load_script("houdini-vex", "cook_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.errors.return_value = []
+        node.warnings.return_value = ["attribute 'foo' not found", "degenerate polygon"]
+
+        geo = MagicMock()
+        geo.points.return_value = [1, 2, 3]
+        geo.prims.return_value = [1]
+        geo.iterVertices.return_value = iter([1, 2, 3])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert len(ctx["warnings"]) == 2
+
+    def test_cook_geometry_with_no_geometry(self) -> None:
+        """Wrangle node that has no geometry() method (e.g., a detail wrangle)."""
+        mod = _load_script("houdini-vex", "cook_wrangle.py")
+        node = _node("/obj/geo1/detailwrangle1", "detailwrangle1", "detailwrangle")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+        node.geometry.return_value = None  # No geometry
+        # Also make geometry raise when called
+        del node.geometry
+        node.geometry = MagicMock(side_effect=AttributeError)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_wrangle("/obj/geo1/detailwrangle1")
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert ctx["cooked"] is True
+        assert ctx.get("point_count") is None
+
+
+# ---------------------------------------------------------------------------
+# diagnose_wrangle
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseWrangle:
+    def test_diagnose_successful_wrangle(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = [1, 2]
+        geo.prims.return_value = [1]
+        geo.iterVertices.return_value = iter([1, 2])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["likely_cause"] == "none"
+
+    def test_diagnose_vex_compile_error(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.cook.side_effect = RuntimeError("syntax error: unexpected token")
+        node.errors.return_value = ["syntax error: unexpected token"]
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["likely_cause"] == "vex_compile_error"
+
+    def test_diagnose_type_mismatch(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.cook.side_effect = RuntimeError("type mismatch: cannot convert string to float")
+        node.errors.return_value = ["type mismatch: cannot convert string to float"]
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["likely_cause"] == "vex_compile_error"
+
+    def test_diagnose_unknown_attribute(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.cook.side_effect = RuntimeError("unknown attribute 'myAttr'")
+        node.errors.return_value = ["unknown attribute 'myAttr'"]
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["likely_cause"] == "vex_compile_error"
+
+    def test_diagnose_cook_timeout(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.cook.side_effect = RuntimeError("cook timed out after 120s")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["likely_cause"] == "cook_timeout"
+
+    def test_diagnose_geometry_error(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.cook.side_effect = RuntimeError("geometry is empty")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = []
+        geo.prims.return_value = []
+        geo.iterVertices.return_value = iter([])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["likely_cause"] == "geometry_error"
+
+    def test_diagnose_includes_geometry_snapshot(self) -> None:
+        mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+
+        geo = MagicMock()
+        geo.points.return_value = [1]
+        geo.prims.return_value = [1]
+        geo.iterVertices.return_value = iter([1])
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+        node.geometry.return_value = geo
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.diagnose_wrangle("/obj/geo1/pointwrangle1")
+
+        assert "geometry_diagnostics" in result["context"]
+
+
+# ---------------------------------------------------------------------------
+# get_vex_info
+# ---------------------------------------------------------------------------
+
+
+class TestGetVexInfo:
+    def test_read_wrangle_info(self) -> None:
+        mod = _load_script("houdini-vex", "get_vex_info.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.isCooked.return_value = True
+        node.inputs.return_value = [MagicMock()]
+        node.outputs.return_value = [MagicMock()]
+
+        snip_parm = MagicMock()
+        snip_parm.evalAsString.return_value = "@P += {1,0,0};"
+        class_parm = MagicMock()
+        class_parm.evalAsString.return_value = "point"
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            return None
+
+        node.parm.side_effect = _parm_side_effect
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_vex_info("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        ctx = result["context"]
+        assert ctx["node_path"] == "/obj/geo1/pointwrangle1"
+        assert ctx["wrangle_type"] == "pointwrangle"
+        assert ctx["has_snippet"] is True
+        assert ctx["cook_state"] == "cooked"
+        assert ctx["input_count"] == 1
+        assert ctx["output_count"] == 1
+
+    def test_read_uncooked_wrangle(self) -> None:
+        mod = _load_script("houdini-vex", "get_vex_info.py")
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.isCooked.return_value = False
+        node.inputs.return_value = []
+        node.outputs.return_value = []
+
+        snip_parm = MagicMock()
+        snip_parm.evalAsString.return_value = ""
+        class_parm = MagicMock()
+        class_parm.evalAsString.return_value = "point"
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            return None
+
+        node.parm.side_effect = _parm_side_effect
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_vex_info("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        assert result["context"]["has_snippet"] is False
+        assert result["context"]["cook_state"] == "uncooked"
+
+    def test_read_info_nonexistent_node(self) -> None:
+        mod = _load_script("houdini-vex", "get_vex_info.py")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_vex_info("/obj/nonexistent")
+
+        assert result["success"] is False
+
+    def test_snippet_preview_truncated(self) -> None:
+        mod = _load_script("houdini-vex", "get_vex_info.py")
+        long_code = "x" * 500
+        node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        node.isCooked.return_value = True
+        node.inputs.return_value = []
+        node.outputs.return_value = []
+
+        snip_parm = MagicMock()
+        snip_parm.evalAsString.return_value = long_code
+
+        def _parm_side_effect(name):
+            if name == "snippet":
+                return snip_parm
+            return None
+
+        node.parm.side_effect = _parm_side_effect
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_vex_info("/obj/geo1/pointwrangle1")
+
+        assert result["success"] is True
+        preview = result["context"]["snippet_preview"]
+        assert len(preview) <= 200
+
+
+# ---------------------------------------------------------------------------
+# list_wrangles
+# ---------------------------------------------------------------------------
+
+
+class TestListWrangles:
+    def test_list_wrangles_under_obj(self) -> None:
+        mod = _load_script("houdini-vex", "list_wrangles.py")
+        root = _node("/obj", "obj", "geo")
+        pw1 = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        aw1 = _node("/obj/geo1/attribwrangle1", "attribwrangle1", "attribwrangle")
+        box = _node("/obj/geo1/box1", "box1", "box")
+        geo1 = _node("/obj/geo1", "geo1", "geo")
+        geo1.children.return_value = [pw1, aw1, box]
+        root.children.return_value = [geo1]
+
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = root
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_wrangles("/obj")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 2
+        wrangles = result["context"]["wrangles"]
+        wrangle_types = {w["wrangle_type"] for w in wrangles}
+        assert "pointwrangle" in wrangle_types
+        assert "attribwrangle" in wrangle_types
+
+    def test_list_wrangles_empty_result(self) -> None:
+        mod = _load_script("houdini-vex", "list_wrangles.py")
+        root = _node("/obj", "obj", "geo")
+        root.children.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = root
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_wrangles("/obj")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 0
+
+    def test_list_wrangles_nonexistent_parent(self) -> None:
+        mod = _load_script("houdini-vex", "list_wrangles.py")
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_wrangles("/obj/nonexistent")
+
+        assert result["success"] is False
+
+    def test_list_wrangles_nested_networks(self) -> None:
+        mod = _load_script("houdini-vex", "list_wrangles.py")
+        leaf = _node("/obj/geo1/subnet1/pw1", "pw1", "pointwrangle")
+        leaf.children.return_value = []
+        subnet = _node("/obj/geo1/subnet1", "subnet1", "subnet")
+        subnet.children.return_value = [leaf]
+        geo1 = _node("/obj/geo1", "geo1", "geo")
+        geo1.children.return_value = [subnet]
+        root = _node("/obj", "obj")
+        root.children.return_value = [geo1]
+
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = root
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.list_wrangles("/obj")
+
+        assert result["success"] is True
+        assert result["context"]["count"] == 1
+        assert result["context"]["wrangles"][0]["node_path"] == "/obj/geo1/subnet1/pw1"
+
+
+# ---------------------------------------------------------------------------
+# Integration / end-to-end workflow tests
+# ---------------------------------------------------------------------------
+
+
+class TestVexWorkflowIntegration:
+    """End-to-end workflow: create -> validate -> cook -> diagnose -> update."""
+
+    def test_full_create_cook_diagnose_cycle(self) -> None:
+        """Simulate the full VEX workflow tracer-bullet."""
+        create_mod = _load_script("houdini-vex", "create_wrangle.py")
+        cook_mod = _load_script("houdini-vex", "cook_wrangle.py")
+        diag_mod = _load_script("houdini-vex", "diagnose_wrangle.py")
+        update_mod = _load_script("houdini-vex", "update_vex_snippet.py")
+        info_mod = _load_script("houdini-vex", "get_vex_info.py")
+
+        # ── Step 1: Create a point wrangle ─────────────────────────────
+        snippet = "@P += {0, 1, 0};"
+        new = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        snip_parm = MagicMock()
+        class_parm = MagicMock()
+
+        def _create_parms(name):
+            if name == "snippet":
+                return snip_parm
+            if name == "class":
+                return class_parm
+            return None
+
+        new.parm.side_effect = _create_parms
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            r1 = create_mod.create_wrangle(
+                parent_path="/obj/geo1",
+                wrangle_type="pointwrangle",
+                vex_code=snippet,
+            )
+
+        assert r1["success"] is True
+        assert r1["context"]["node_path"] == "/obj/geo1/pointwrangle1"
+
+        # ── Step 2: Cook ───────────────────────────────────────────────
+        geo = MagicMock()
+        geo.points.return_value = [1] * 8
+        geo.prims.return_value = [1] * 6
+        geo.iterVertices.return_value = iter([1] * 24)
+        geo.pointAttribs.return_value = []
+        geo.primAttribs.return_value = []
+        geo.vertexAttribs.return_value = []
+        geo.globalAttribs.return_value = []
+        geo.pointGroups.return_value = []
+        geo.primGroups.return_value = []
+        geo.edgeGroups.return_value = []
+
+        cook_node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        cook_node.errors.return_value = []
+        cook_node.warnings.return_value = []
+        cook_node.geometry.return_value = geo
+        mock_hou2 = MagicMock()
+        mock_hou2.node.return_value = cook_node
+
+        with patch.dict(sys.modules, {"hou": mock_hou2}):
+            r2 = cook_mod.cook_wrangle("/obj/geo1/pointwrangle1")
+
+        assert r2["success"] is True
+        assert r2["context"]["cooked"] is True
+        assert r2["context"]["point_count"] == 8
+        assert r2["context"]["primitive_count"] == 6
+
+        # ── Step 3: Update snippet ─────────────────────────────────────
+        snip2_parm = MagicMock()
+        snip2_parm.evalAsString.return_value = snippet
+        class2_parm = MagicMock()
+
+        def _update_parms(name):
+            if name == "snippet":
+                return snip2_parm
+            if name == "class":
+                return class2_parm
+            return None
+
+        update_node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")
+        update_node.parm.side_effect = _update_parms
+        mock_hou3 = MagicMock()
+        mock_hou3.node.return_value = update_node
+
+        new_snippet = "@P += {1, 0, 0};\n@Cd = {1, 0, 0};"
+
+        with patch.dict(sys.modules, {"hou": mock_hou3}):
+            r3 = update_mod.update_vex_snippet(
+                node_path="/obj/geo1/pointwrangle1",
+                vex_code=new_snippet,
+            )
+
+        assert r3["success"] is True
+        snip2_parm.set.assert_called_once_with(new_snippet)

--- a/tests/test_vex_types.py
+++ b/tests/test_vex_types.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from dcc_mcp_houdini._vex_types import (
@@ -14,7 +16,6 @@ from dcc_mcp_houdini._vex_types import (
     WrangleNodeSpec,
     WrangleType,
 )
-
 
 # ---------------------------------------------------------------------------
 # VexContext
@@ -125,7 +126,7 @@ class TestVexSnippet:
 
     def test_frozen_after_construction(self) -> None:
         snip = VexSnippet(code="@P += 1;", context=VexContext.POINTS)
-        with pytest.raises(Exception):
+        with pytest.raises(dataclasses.FrozenInstanceError):
             snip.code = "@Cd += 1;"  # type: ignore
 
 

--- a/tests/test_vex_types.py
+++ b/tests/test_vex_types.py
@@ -1,0 +1,263 @@
+"""Unit tests for VEX types — no Houdini dependency."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcc_mcp_houdini._vex_types import (
+    CookDiagnostic,
+    VexContext,
+    VexSeverity,
+    VexSnippet,
+    VexSyntaxError,
+    WrangleInfo,
+    WrangleNodeSpec,
+    WrangleType,
+)
+
+
+# ---------------------------------------------------------------------------
+# VexContext
+# ---------------------------------------------------------------------------
+
+
+class TestVexContext:
+    def test_all_contexts_are_valid_strings(self) -> None:
+        for ctx in VexContext:
+            assert isinstance(ctx.value, str)
+            assert ctx.value
+
+    def test_context_map_to_known_values(self) -> None:
+        assert VexContext.POINTS.value == "points"
+        assert VexContext.PRIMITIVES.value == "prims"
+        assert VexContext.VERTICES.value == "verts"
+        assert VexContext.DETAIL.value == "detail"
+
+
+# ---------------------------------------------------------------------------
+# WrangleType
+# ---------------------------------------------------------------------------
+
+
+class TestWrangleType:
+    def test_default_for_context_returns_correct_type(self) -> None:
+        assert WrangleType.default_for_context(VexContext.POINTS) == WrangleType.POINT_WRANGLE
+        assert WrangleType.default_for_context(VexContext.PRIMITIVES) == WrangleType.PRIMITIVE_WRANGLE
+        assert WrangleType.default_for_context(VexContext.VERTICES) == WrangleType.VERTEX_WRANGLE
+        assert WrangleType.default_for_context(VexContext.DETAIL) == WrangleType.DETAIL_WRANGLE
+
+    def test_default_for_context_falls_back_to_attribwrangle(self) -> None:
+        assert WrangleType.default_for_context(VexContext.GLOBAL_VERTICES) == WrangleType.ATTRIB_WRANGLE
+
+    def test_all_wrangle_types_have_nonempty_values(self) -> None:
+        for wt in WrangleType:
+            assert wt.value
+            assert "wrangle" in wt.value or "vop" in wt.value
+
+
+# ---------------------------------------------------------------------------
+# VexSyntaxError
+# ---------------------------------------------------------------------------
+
+
+class TestVexSyntaxError:
+    def test_basic_error_to_dict(self) -> None:
+        err = VexSyntaxError(message="syntax error", severity=VexSeverity.ERROR)
+        d = err.to_dict()
+        assert d["message"] == "syntax error"
+        assert d["severity"] == "error"
+        assert "line" not in d
+
+    def test_error_with_location_to_dict(self) -> None:
+        err = VexSyntaxError(
+            message="type mismatch",
+            severity=VexSeverity.ERROR,
+            line=5,
+            column=12,
+            snippet_context="float x = 'hello';",
+        )
+        d = err.to_dict()
+        assert d["line"] == 5
+        assert d["column"] == 12
+        assert d["snippet_context"] == "float x = 'hello';"
+
+
+# ---------------------------------------------------------------------------
+# VexSnippet
+# ---------------------------------------------------------------------------
+
+
+class TestVexSnippet:
+    def test_valid_snippet_construction(self) -> None:
+        snip = VexSnippet(code="@P += {1,0,0};", context=VexContext.POINTS)
+        assert snip.code == "@P += {1,0,0};"
+        assert snip.context == VexContext.POINTS
+        assert snip.bindings == {}
+        assert snip.parameter_values == {}
+
+    def test_empty_snippet_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            VexSnippet(code="", context=VexContext.POINTS)
+
+    def test_whitespace_only_snippet_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            VexSnippet(code="   \n  ", context=VexContext.POINTS)
+
+    def test_invalid_context_raises(self) -> None:
+        with pytest.raises(ValueError):
+            VexSnippet(code="@P += 1;", context="invalid")  # type: ignore
+
+    def test_line_count(self) -> None:
+        snip = VexSnippet(code="@P += 1;\n@Cd = {1,0,0};\n", context=VexContext.POINTS)
+        assert snip.line_count == 2
+
+    def test_line_count_excludes_empty_lines(self) -> None:
+        snip = VexSnippet(code="@P += 1;\n\n\n@Cd = {1,0,0};\n", context=VexContext.POINTS)
+        assert snip.line_count == 2
+
+    def test_with_bindings(self) -> None:
+        snip = VexSnippet(
+            code="@pos = @P;",
+            context=VexContext.POINTS,
+            bindings={"pos": "vector"},
+        )
+        assert snip.bindings == {"pos": "vector"}
+
+    def test_frozen_after_construction(self) -> None:
+        snip = VexSnippet(code="@P += 1;", context=VexContext.POINTS)
+        with pytest.raises(Exception):
+            snip.code = "@Cd += 1;"  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# WrangleNodeSpec
+# ---------------------------------------------------------------------------
+
+
+class TestWrangleNodeSpec:
+    def test_minimal_spec(self) -> None:
+        spec = WrangleNodeSpec(parent_path="/obj/geo1")
+        assert spec.parent_path == "/obj/geo1"
+        assert spec.node_name is None
+        assert spec.wrangle_type == WrangleType.ATTRIB_WRANGLE
+        assert spec.run_over == VexContext.POINTS
+        assert spec.snippet is None
+
+    def test_full_spec(self) -> None:
+        snip = VexSnippet(code="@P += 1;", context=VexContext.POINTS)
+        spec = WrangleNodeSpec(
+            parent_path="/obj/geo1",
+            node_name="myWrangle",
+            wrangle_type=WrangleType.POINT_WRANGLE,
+            run_over=VexContext.POINTS,
+            snippet=snip,
+            set_display=True,
+            set_render=False,
+        )
+        assert spec.node_name == "myWrangle"
+        assert spec.wrangle_type == WrangleType.POINT_WRANGLE
+        assert spec.snippet is snip
+        assert spec.set_display is True
+        assert spec.set_render is False
+
+    def test_empty_parent_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="parent_path"):
+            WrangleNodeSpec(parent_path="")
+
+    def test_invalid_wrangle_type_raises(self) -> None:
+        with pytest.raises(ValueError):
+            WrangleNodeSpec(parent_path="/obj/geo1", wrangle_type="bogus")  # type: ignore
+
+    def test_invalid_snippet_type_raises(self) -> None:
+        with pytest.raises(ValueError):
+            WrangleNodeSpec(parent_path="/obj/geo1", snippet="not a VexSnippet")  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# CookDiagnostic
+# ---------------------------------------------------------------------------
+
+
+class TestCookDiagnostic:
+    def test_successful_cook_to_dict(self) -> None:
+        diag = CookDiagnostic(
+            node_path="/obj/geo1/pointwrangle1",
+            cooked=True,
+            point_count=42,
+            primitive_count=10,
+            vertex_count=84,
+            attribute_names=["P", "Cd", "N"],
+            group_names=["group1"],
+            elapsed_secs=0.123,
+        )
+        d = diag.to_dict()
+        assert d["cooked"] is True
+        assert d["point_count"] == 42
+        assert d["vertex_count"] == 84
+        assert "Cd" in d["attribute_names"]
+
+    def test_failed_cook_to_dict(self) -> None:
+        diag = CookDiagnostic(
+            node_path="/obj/geo1/pointwrangle1",
+            cooked=False,
+            cook_error="syntax error on line 3",
+            errors=["syntax error on line 3"],
+            warnings=[],
+            elapsed_secs=0.001,
+        )
+        d = diag.to_dict()
+        assert d["cooked"] is False
+        assert d["cook_error"] == "syntax error on line 3"
+        assert d["errors"] == ["syntax error on line 3"]
+
+
+# ---------------------------------------------------------------------------
+# WrangleInfo
+# ---------------------------------------------------------------------------
+
+
+class TestWrangleInfo:
+    def test_info_to_dict(self) -> None:
+        info = WrangleInfo(
+            node_path="/obj/geo1/pointwrangle1",
+            node_name="pointwrangle1",
+            wrangle_type="pointwrangle",
+            run_over="points",
+            snippet_preview="@P += {1,0,0};",
+            has_snippet=True,
+            cook_state="cooked",
+            input_count=1,
+            output_count=1,
+        )
+        d = info.to_dict()
+        assert d["node_path"] == "/obj/geo1/pointwrangle1"
+        assert d["wrangle_type"] == "pointwrangle"
+        assert d["has_snippet"] is True
+        assert d["cook_state"] == "cooked"
+
+
+# ---------------------------------------------------------------------------
+# vex_context_to_attrib_class
+# ---------------------------------------------------------------------------
+
+
+class TestVexContextToAttribClass:
+    def test_points_maps_to_0(self) -> None:
+        from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
+
+        assert vex_context_to_attrib_class(VexContext.POINTS) == 0
+
+    def test_primitives_maps_to_1(self) -> None:
+        from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
+
+        assert vex_context_to_attrib_class(VexContext.PRIMITIVES) == 1
+
+    def test_vertices_maps_to_2(self) -> None:
+        from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
+
+        assert vex_context_to_attrib_class(VexContext.VERTICES) == 2
+
+    def test_detail_maps_to_3(self) -> None:
+        from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
+
+        assert vex_context_to_attrib_class(VexContext.DETAIL) == 3

--- a/tests/test_vex_validator.py
+++ b/tests/test_vex_validator.py
@@ -1,0 +1,229 @@
+"""Unit tests for VEX validator — no Houdini dependency."""
+
+from __future__ import annotations
+
+from dcc_mcp_houdini._vex_types import VexSeverity, WrangleType
+from dcc_mcp_houdini._vex_validator import (
+    validate_attribute_bindings,
+    validate_vex_snippet_client,
+    validate_wrangle_parameters,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_vex_snippet_client — allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVexSnippetClient:
+    def test_empty_snippet_rejected(self) -> None:
+        errors = validate_vex_snippet_client("")
+        assert len(errors) == 1
+        assert "empty" in errors[0].message.lower()
+
+    def test_whitespace_only_rejected(self) -> None:
+        errors = validate_vex_snippet_client("   \n  \t  ")
+        assert len(errors) == 1
+
+    def test_valid_simple_snippet(self) -> None:
+        errors = validate_vex_snippet_client("@P += {1, 0, 0};")
+        assert len(errors) == 0
+
+    def test_valid_multi_line_snippet(self) -> None:
+        snippet = """// Move points up
+vector offset = {0, 1, 0};
+@P += offset;
+@Cd = {1, 0, 0};
+"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+    def test_valid_with_if_statement(self) -> None:
+        snippet = """if (@P.y > 0) {
+    @Cd = {1, 0, 0};
+} else {
+    @Cd = {0, 0, 1};
+}"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+    def test_valid_with_for_loop(self) -> None:
+        snippet = """int i;
+for (i = 0; i < @numpt; i++) {
+    setpointattrib(0, "Cd", i, {1, 0, 0});
+}"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+    def test_valid_with_functions(self) -> None:
+        snippet = """vector n = normalize(@N);
+float d = dot(n, {0, 1, 0});
+@P.y += d * 0.5;"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+    def test_valid_with_noise(self) -> None:
+        snippet = """float n = noise(@P * 0.1);
+@P.y += n;
+@Cd = snoise(@P);"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+    def test_valid_volume_wrangle(self) -> None:
+        snippet = """@density = rand(@P);
+@temperature = fit(@density, 0, 1, 0, 100);"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+    def test_valid_with_comments(self) -> None:
+        snippet = """/* Block comment */
+// Line comment
+@P += 1;  // Inline comment
+"""
+        errors = validate_vex_snippet_client(snippet)
+        assert len(errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_vex_snippet_client — deny list
+# ---------------------------------------------------------------------------
+
+
+class TestValidateVexSnippetDenyList:
+    def test_python_blocked(self) -> None:
+        errors = validate_vex_snippet_client("python { @P += 1; }")
+        assert len(errors) >= 1
+        assert any("python" in e.message.lower() for e in errors)
+
+    def test_exec_blocked(self) -> None:
+        errors = validate_vex_snippet_client("exec('something')")
+        assert len(errors) >= 1
+        assert any("exec" in e.message.lower() for e in errors)
+
+    def test_eval_blocked(self) -> None:
+        errors = validate_vex_snippet_client("eval(@P)")
+        assert len(errors) >= 1
+        assert any("eval" in e.message.lower() for e in errors)
+
+    def test_import_blocked(self) -> None:
+        errors = validate_vex_snippet_client("import something")
+        assert len(errors) >= 1
+        assert any("import" in e.message.lower() for e in errors)
+
+    def test_subprocess_blocked(self) -> None:
+        errors = validate_vex_snippet_client("subprocess.call('ls')")
+        assert len(errors) >= 1
+
+    def test_os_access_blocked(self) -> None:
+        errors = validate_vex_snippet_client("os.system('ls')")
+        assert len(errors) >= 1
+
+    def test_sys_access_blocked(self) -> None:
+        errors = validate_vex_snippet_client("sys.exit(1)")
+        assert len(errors) >= 1
+
+    def test_hou_access_blocked(self) -> None:
+        errors = validate_vex_snippet_client("hou.node('/obj')")
+        assert len(errors) >= 1
+
+    def test_dunder_blocked(self) -> None:
+        errors = validate_vex_snippet_client("__import__('os')")
+        assert len(errors) >= 1
+
+    def test_unicode_escape_blocked(self) -> None:
+        errors = validate_vex_snippet_client("@P += \\x41;")
+        assert len(errors) >= 1
+
+    def test_system_call_blocked(self) -> None:
+        errors = validate_vex_snippet_client('run("calc.exe")')
+        assert len(errors) >= 1
+
+    def test_popen_blocked(self) -> None:
+        errors = validate_vex_snippet_client("popen('cmd')")
+        assert len(errors) >= 1
+
+    def test_non_ascii_blocked(self) -> None:
+        # Unicode homoglyph attack
+        errors = validate_vex_snippet_client("@P += 1; // 你好")
+        assert len(errors) >= 1
+
+
+# ---------------------------------------------------------------------------
+# validate_wrangle_parameters
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWrangleParameters:
+    def test_valid_known_parameters(self) -> None:
+        errors = validate_wrangle_parameters(
+            WrangleType.ATTRIB_WRANGLE,
+            {"snippet": "// code", "group": "group1"},
+        )
+        assert len(errors) == 0
+
+    def test_unknown_parameter_is_reported(self) -> None:
+        errors = validate_wrangle_parameters(
+            WrangleType.ATTRIB_WRANGLE,
+            {"bogus_parm": 42},
+        )
+        assert len(errors) >= 1
+        assert any("bogus_parm" in e for e in errors)
+
+    def test_wrong_type_is_reported(self) -> None:
+        errors = validate_wrangle_parameters(
+            WrangleType.ATTRIB_WRANGLE,
+            {"snippet": 123},  # Should be str
+        )
+        assert len(errors) >= 1
+
+    def test_empty_parameters_is_valid(self) -> None:
+        errors = validate_wrangle_parameters(WrangleType.ATTRIB_WRANGLE, {})
+        assert len(errors) == 0
+
+    def test_point_wrangle_accepts_snippet(self) -> None:
+        errors = validate_wrangle_parameters(
+            WrangleType.POINT_WRANGLE,
+            {"snippet": "@P += 1;"},
+        )
+        assert len(errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_attribute_bindings
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAttributeBindings:
+    def test_builtin_attributes_not_flagged(self) -> None:
+        errors = validate_attribute_bindings("@P += 1; @Cd = {1,0,0}; @N = {0,1,0};", [])
+        assert len(errors) == 0
+
+    def test_unknown_attribute_flagged_as_warning(self) -> None:
+        errors = validate_attribute_bindings("@myCustomAttr = 1.0;", [])
+        assert len(errors) >= 1
+        assert errors[0].severity == VexSeverity.WARNING
+        assert "myCustomAttr" in errors[0].message
+
+    def test_known_user_attribute_not_flagged(self) -> None:
+        errors = validate_attribute_bindings("@myAttr = 1.0;", ["myAttr"])
+        assert len(errors) == 0
+
+    def test_multiple_unknown_attributes(self) -> None:
+        errors = validate_attribute_bindings("@foo = 1; @bar = 2;", [])
+        assert len(errors) == 2
+
+    def test_ptnum_not_flagged(self) -> None:
+        errors = validate_attribute_bindings("@ptnum", [])
+        assert len(errors) == 0
+
+    def test_Time_not_flagged(self) -> None:
+        errors = validate_attribute_bindings("@Time", [])
+        assert len(errors) == 0
+
+    def test_line_extraction_in_errors(self) -> None:
+        snippet = "// header\n@unknownAttr = 1.0;\n@P += 1;"
+        errors = validate_attribute_bindings(snippet, [])
+        assert len(errors) >= 1
+        # Should have line context
+        assert errors[0].line is not None
+        assert "unknownAttr" in errors[0].message

--- a/tests/test_vex_validator.py
+++ b/tests/test_vex_validator.py
@@ -9,7 +9,6 @@ from dcc_mcp_houdini._vex_validator import (
     validate_wrangle_parameters,
 )
 
-
 # ---------------------------------------------------------------------------
 # validate_vex_snippet_client — allowlist
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a safe, typed VEX creation and diagnosis workflow for Houdini Wrangle nodes.  No arbitrary script execution — all VEX code flows through `hou.Parm.set()` with client-side validation.

## What's included

### Core modules (`_vex/`)
- **`_vex_types.py`** — Typed contracts: `VexContext`, `WrangleType`, `VexSeverity` enums; frozen `VexSnippet`, `WrangleNodeSpec`, `CookDiagnostic`, `WrangleInfo`, `VexSyntaxError` dataclasses. Pure Python, no `hou` imports.
- **`_vex_validator.py`** — Client-side VEX validation: allowlist of 200+ VEX builtins, deny-list for `python`/`exec`/`eval`/`os.*`/`hou.*`/unicode escapes. Attribute binding and parameter type checks.
- **`_vex_executor.py`** — Safe Wrangle CRUD, cook with geometry diagnostics (point/prim/vertex counts, attribute/group names, errors/warnings), and failure localization heuristics. All `hou` calls gated through main-thread dispatcher.

### Skill package (`houdini-vex`)
- **7 typed MCP tools** across 5 groups:
  - `vex-create`: `create_wrangle`
  - `vex-edit`: `update_vex_snippet`
  - `vex-validate`: `validate_vex_syntax`
  - `vex-cook`: `cook_wrangle`, `diagnose_wrangle`
  - `vex-query`: `get_vex_info`, `list_wrangles`
- `tools.yaml` with full JSON Schema inputs, `next-tools` hints, and security documentation
- Added to `SKILLS_INDEX.md` in the authoring stage

### Tests
- **103 regression tests** with full mock-`hou` coverage
- Tests for: types, validation (allowlist/deny-list/parameter/bindings), skill scripts (all 7 tools success + error paths), and end-to-end integration workflow

### Security model
- VEX snippets are set via `hou.Parm.set()`, never Python `exec`/`eval`
- Client-side validation: allowlist (VEX builtins only) + deny-list (Python/system/Houdini internals)
- Size limits: 64KB / 2000 lines per snippet
- All `hou` calls routed through the existing main-thread dispatcher
- Non-ASCII characters blocked (homoglyph attack prevention)