### PR TITLE
fix: preserve VEX context on snippet updates

### DIFF
--- a/src/dcc_mcp_houdini/_vex_executor.py
+++ b/src/dcc_mcp_houdini/_vex_executor.py
@@ -35,13 +35,6 @@ from dcc_mcp_houdini._vex_types import (
 _MAX_VEX_LINES = 2000
 _MAX_VEX_CHARS = 64 * 1024  # 64KB
 
-# Default cook timeout for in-process cooks (no isolated job).
-_DEFAULT_COOK_TIMEOUT_SECS = 60.0
-
-# Threshold beyond which a cook is launched as an isolated hython job.
-_ISOLATED_COOK_THRESHOLD_SECS = 10.0
-
-
 # ---------------------------------------------------------------------------
 # Core operations (each expects ``hou`` as an explicit parameter)
 # ---------------------------------------------------------------------------
@@ -128,6 +121,7 @@ def update_vex_snippet(
     hou: Any,
     node_path: str,
     snippet: VexSnippet,
+    run_over: Optional[VexContext] = None,
 ) -> Dict[str, Any]:
     """Update the VEX snippet on an existing Wrangle node.
 
@@ -138,6 +132,8 @@ def update_vex_snippet(
         hou: The ``hou`` module.
         node_path: Path to an existing Wrangle node.
         snippet: The validated VEX snippet to set.
+        run_over: Optional new run-over context.  ``None`` preserves the
+            node's current context.
 
     Returns:
         Dict with ``success``, ``node_path``, and ``previous_snippet_preview``.
@@ -165,8 +161,8 @@ def update_vex_snippet(
 
     snip_parm.set(snippet.code)
 
-    # Update run-over if context changed.
-    _set_run_over(node, snippet.context)
+    if run_over is not None:
+        _set_run_over(node, run_over)
 
     # Apply bindings.
     if snippet.bindings:
@@ -199,19 +195,23 @@ def cook_and_diagnose(
 ) -> CookDiagnostic:
     """Cook a Wrangle node and collect geometry diagnostics.
 
-    For cooks that may exceed the timeout threshold, use
-    :func:`launch_durable_cook` instead.
+    Houdini's in-process ``node.cook`` call is monolithic.  A hard deadline
+    requires an isolated Houdini process; this helper rejects timeout values
+    rather than silently pretending it can interrupt the host call.
 
     Args:
         hou: The ``hou`` module.
         node_path: Path to the Wrangle node.
         force: Force a recook even if already cooked.
-        timeout_secs: Soft timeout (best-effort; Houdini cooks cannot be
-            interrupted mid-cook from Python).
+        timeout_secs: Unsupported for in-process cooks.  Passing a value
+            raises :class:`ValueError`.
 
     Returns:
         A :class:`CookDiagnostic` with cook status and geometry stats.
     """
+    if timeout_secs is not None:
+        raise ValueError("in-process Houdini cooks cannot enforce timeout_secs")
+
     t0 = time.monotonic()
 
     try:

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
@@ -55,7 +55,12 @@ def update_vex_snippet(
     except ValueError as exc:
         return skill_error("Invalid VEX snippet", str(exc))
 
-    result = _update(hou, node_path, snippet)
+    result = _update(
+        hou,
+        node_path,
+        snippet,
+        run_over=context if run_over is not None else None,
+    )
     if result.get("success"):
         return skill_success("Updated VEX snippet", **result)
     return skill_error("Failed to update VEX snippet", **result)

--- a/tests/test_vex_skills.py
+++ b/tests/test_vex_skills.py
@@ -241,6 +241,7 @@ class TestUpdateVexSnippet:
         assert result["success"] is True
         assert result["context"]["previous_snippet_preview"] == old_snippet
         snip_parm.set.assert_called_once_with(new_snippet)
+        class_parm.set.assert_not_called()
 
     def test_update_with_validation_rejects_forbidden(self) -> None:
         mod = _load_script("houdini-vex", "update_vex_snippet.py")
@@ -374,6 +375,16 @@ class TestValidateVexSyntax:
 
 
 class TestCookWrangle:
+    def test_in_process_cook_rejects_unenforceable_timeout(self) -> None:
+        from dcc_mcp_houdini._vex_executor import cook_and_diagnose
+
+        try:
+            cook_and_diagnose(MagicMock(), "/obj/geo1/pointwrangle1", timeout_secs=1)
+        except ValueError as exc:
+            assert "cannot enforce" in str(exc)
+        else:
+            raise AssertionError("timeout_secs must not be silently ignored")
+
     def test_cook_successful_wrangle(self) -> None:
         mod = _load_script("houdini-vex", "cook_wrangle.py")
         node = _node("/obj/geo1/pointwrangle1", "pointwrangle1", "pointwrangle")


### PR DESCRIPTION
## Summary
- preserve an existing Wrangle run-over context when `run_over` is omitted
- apply a new run-over context only when the caller explicitly supplies it
- reject unenforceable in-process cook timeout values instead of silently ignoring them

## Validation
- `vx uv run --extra dev python -m ruff check src tests tools packaging`
- `vx uv run --extra dev python -m ruff format --check src tests tools packaging`
- `vx uv run --extra dev python tools/lint_skills.py --require-cli --warnings-as-errors` (32 skills, 0 errors, 0 warnings)
- `vx uv run --extra dev python tools/check_py37_syntax.py src tests tools packaging`
- VEX tests: 104 passed
- full tests: 826 passed, 1 skipped, 3 deselected
- wheel and sdist build plus `twine check`

Live Houdini is not available locally; the regression covers the skill entry point and mocked HOM parameter writes. Existing skill metadata already documents `run_over` as optional, so no guidance update is required.