### PR TITLE
fix(kinefx): preserve rest pose and affine transforms

### DIFF
--- a/.github/scripts/run_houdini_e2e.py
+++ b/.github/scripts/run_houdini_e2e.py
@@ -62,10 +62,14 @@ def main() -> None:
         assert init["result"]["serverInfo"]["name"] == "dcc-mcp-houdini", init
 
         server.load_skill("houdini-nodes")
+        server.load_skill("houdini-kinefx")
         tools = _post(url, "tools/list")
         names = _tool_names(tools)
         get_session_info = _find_tool(names, "get_session_info")
         create_node = _find_tool(names, "create_node")
+        set_node_parms = _find_tool(names, "set_node_parms")
+        create_rig = _find_tool(names, "create_rig")
+        set_rig_pose = _find_tool(names, "set_rig_pose")
         delete_node = _find_tool(names, "delete_node")
 
         session = _post(url, "tools/call", {"name": get_session_info, "arguments": {}})
@@ -89,6 +93,99 @@ def main() -> None:
         )
         assert "result" in created, created
         assert hou.node("/obj/" + node_name) is not None
+
+        mesh_name = "ci_mesh"
+        mesh_created = _post(
+            url,
+            "tools/call",
+            {
+                "name": create_node,
+                "arguments": {
+                    "parent_path": "/obj/" + node_name,
+                    "node_type": "sphere",
+                    "node_name": mesh_name,
+                },
+            },
+        )
+        assert "result" in mesh_created, mesh_created
+        mesh_path = "/obj/{}/{}".format(node_name, mesh_name)
+        assert hou.node(mesh_path) is not None
+        mesh_configured = _post(
+            url,
+            "tools/call",
+            {
+                "name": set_node_parms,
+                "arguments": {
+                    "node_path": mesh_path,
+                    "parameters": {"type": 1},
+                },
+            },
+        )
+        assert "result" in mesh_configured, mesh_configured
+
+        rigged = _post(
+            url,
+            "tools/call",
+            {
+                "name": create_rig,
+                "arguments": {
+                    "geo_path": "/obj/" + node_name,
+                    "rig_name": "ci_rig",
+                    "joint_chain": [
+                        {"name": "root", "parent_index": -1, "translate": [0, -1, 0]},
+                        {"name": "spine", "parent_index": 0, "translate": [0, 1, 0]},
+                        {"name": "neck", "parent_index": 0, "translate": [1, 0, 0]},
+                    ],
+                    "auto_capture": True,
+                    "capture_mesh": mesh_name,
+                },
+            },
+        )
+        assert "result" in rigged, rigged
+        rig = hou.node("/obj/{}/ci_rig".format(node_name))
+        assert rig is not None
+        assert len(rig.geometry().points()) == 3
+        assert len(rig.geometry().prims()) == 2
+        assert [point.attribValue("name") for point in rig.geometry().points()] == ["root", "spine", "neck"]
+        assert sorted(tuple(point.number() for point in prim.points()) for prim in rig.geometry().prims()) == [
+            (0, 1),
+            (0, 2),
+        ]
+        capture = hou.node("/obj/{}/capture_ci_rig".format(node_name))
+        joint_deform = hou.node("/obj/{}/jointdeform_ci_rig".format(node_name))
+        assert capture is not None and capture.geometry().findPointAttrib("boneCapture") is not None
+        assert joint_deform is not None and not joint_deform.errors()
+        rest_positions = [tuple(point.position()) for point in joint_deform.geometry().points()]
+
+        posed = _post(
+            url,
+            "tools/call",
+            {
+                "name": set_rig_pose,
+                "arguments": {
+                    "rig_node": rig.path(),
+                    "joint_name": "spine",
+                    "translate": [0.25, 1.0, 0.0],
+                    "rotate": [90.0, 0.0, 0.0],
+                    "scale": [1.0, 2.0, 1.0],
+                },
+            },
+        )
+        assert "result" in posed, posed
+        spine = rig.geometry().points()[1]
+        assert abs(spine.position()[0] - 0.25) < 1e-6
+        expected_transform = hou.Matrix3(
+            hou.hmath.buildTransform({"rotate": (90.0, 0.0, 0.0), "scale": (1.0, 2.0, 1.0)})
+        ).asTuple()
+        assert (
+            max(abs(actual - expected) for actual, expected in zip(spine.attribValue("transform"), expected_transform))
+            < 1e-6
+        )
+        joint_deform.cook(force=True)
+        assert not joint_deform.errors()
+        assert len(joint_deform.geometry().points()) > 0
+        posed_positions = [tuple(point.position()) for point in joint_deform.geometry().points()]
+        assert any(before != after for before, after in zip(rest_positions, posed_positions))
 
         deleted = _post(url, "tools/call", {"name": delete_node, "arguments": {"node_path": "/obj/" + node_name}})
         assert "result" in deleted, deleted

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/_kinefx_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/_kinefx_common.py
@@ -41,6 +41,40 @@ def get_or_create_rig(
     If *joint_chain* is provided, creates a skeleton from joint definitions.
     Each joint is ``[name, parent_index, translate]``.
     """
+    if not isinstance(geo_path, str) or not geo_path.strip():
+        raise ValueError("geo_path must be a non-empty string")
+    if not isinstance(rig_name, str) or not rig_name.strip():
+        raise ValueError("rig_name must be a non-empty string")
+
+    points_positions = []
+    joint_names = []
+    parent_indices = []
+    for index, joint in enumerate(joint_chain or []):
+        if isinstance(joint, dict):
+            name = joint.get("name", "joint")
+            pos = joint.get("translate", [0, 0, 0])
+            parent_index = joint.get("parent_index", index - 1)
+        elif isinstance(joint, (list, tuple)):
+            name = str(joint[0]) if len(joint) > 0 else "joint"
+            parent_index = joint[1] if len(joint) > 1 else index - 1
+            pos = list(joint[2]) if len(joint) > 2 else [0, 0, 0]
+        else:
+            name = str(joint)
+            parent_index = index - 1
+            pos = [0, 0, 0]
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Joint name must be a non-empty string")
+        parent_index = int(parent_index)
+        if parent_index < -1 or parent_index >= index:
+            raise ValueError("Joint {!r} parent_index must reference an earlier joint or -1".format(name))
+        if len(pos) != 3:
+            raise ValueError("Joint {!r} translate must contain exactly 3 values".format(name))
+        if name in joint_names:
+            raise ValueError("Joint names must be unique: {!r}".format(name))
+        joint_names.append(name)
+        parent_indices.append(parent_index)
+        points_positions.append([float(value) for value in pos])
+
     geo = get_geo_container(hou, geo_path)
 
     # Check if rig already exists.
@@ -48,37 +82,37 @@ def get_or_create_rig(
     if existing is not None:
         return existing
 
-    # Create a KineFX skeleton by building a line of points with joint attrs.
-    # We use a 'bonedeform' as the main rig anchor and create joints via
-    # SOP chain.
-    rig_sop = geo.createNode("null", node_name=rig_name)
+    rig_sop = geo.createNode("kinefx::skeleton", node_name=rig_name)
 
-    if joint_chain:
-        # Build skeleton using a chain of points.
-        points_positions = []
-        joint_names = []
-        for joint in joint_chain:
-            if isinstance(joint, dict):
-                name = joint.get("name", "joint")
-                pos = joint.get("translate", [0, 0, 0])
-            elif isinstance(joint, (list, tuple)):
-                name = str(joint[0]) if len(joint) > 0 else "joint"
-                pos = list(joint[2]) if len(joint) > 2 else [0, 0, 0]
-            else:
-                name = str(joint)
-                pos = [0, 0, 0]
-            joint_names.append(name)
-            points_positions.append(list(pos))
+    if points_positions:
+        rig_geo = hou.Geometry()
+        pts = rig_geo.createPoints(points_positions)
+        name_attr = rig_geo.addAttrib(hou.attribType.Point, "name", "")
+        transform_attr = rig_geo.addAttrib(
+            hou.attribType.Point,
+            "transform",
+            (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        )
+        for i, pt in enumerate(pts):
+            pt.setPosition(points_positions[i])
+            pt.setAttribValue(name_attr, joint_names[i])
+            pt.setAttribValue(
+                transform_attr,
+                (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+            )
+        for child_index, parent_index in enumerate(parent_indices):
+            if parent_index < 0:
+                continue
+            bone = rig_geo.createPolygon()
+            bone.setIsClosed(False)
+            bone.addVertex(pts[parent_index])
+            bone.addVertex(pts[child_index])
 
-        if points_positions:
-            # Create geometry with skeleton attributes.
-            rig_geo = rig_sop.geometry()
-            rig_geo.clear()
-            pts = rig_geo.createPoints(len(points_positions))
-            name_attr = rig_geo.addAttrib(hou.attribType.Point, "name", "")
-            for i, pt in enumerate(pts):
-                pt.setPosition(points_positions[i])
-                pt.setAttribValue(name_attr, joint_names[i])
+        stash = rig_sop.parm("stash")
+        if stash is None:
+            raise RuntimeError("KineFX Skeleton node has no stash parameter")
+        stash.set(rig_geo)
+        rig_sop.cook(force=True)
 
     rig_sop.moveToGoodPosition()
     return rig_sop

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/create_rig.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/create_rig.py
@@ -29,14 +29,14 @@ def create_rig(
         ]
 
     When *auto_capture* is ``True`` and *capture_mesh* names an existing SOP
-    node in the same geo container, a ``bonedeform`` node is wired after the
-    rig for immediate skinning.
+    node in the same geo container, KineFX Joint Capture Proximity and Joint
+    Deform SOPs are wired for immediate skinning.
 
     Args:
         geo_path: Path to the Geometry SOP container (e.g. ``/obj/geo1``).
-        rig_name: Name for the rig null/container node.
+        rig_name: Name for the KineFX Skeleton SOP.
         joint_chain: List of joint definitions (name + translate).
-        auto_capture: If True, wire a bonedeform for immediate skinning.
+        auto_capture: If True, capture and deform the mesh with KineFX SOPs.
         capture_mesh: Name of the mesh SOP node to capture (for auto_capture).
     """
     try:
@@ -45,6 +45,19 @@ def create_rig(
         return skill_error("Houdini not available", "hou could not be imported")
 
     try:
+        mesh_node = None
+        if auto_capture:
+            if not joint_chain:
+                return skill_error("Joint chain required", "joint_chain is required when auto_capture is true")
+            if not capture_mesh:
+                return skill_error("Capture mesh required", "capture_mesh is required when auto_capture is true")
+            geo = hou.node(geo_path)
+            if geo is None:
+                return skill_error("Geometry container not found", geo_path=geo_path)
+            mesh_node = hou.node("{}/{}".format(geo.path(), capture_mesh))
+            if mesh_node is None:
+                return skill_error("Capture mesh not found", capture_mesh=capture_mesh, geo_path=geo_path)
+
         rig_node = get_or_create_rig(
             hou,
             geo_path=geo_path,
@@ -54,16 +67,30 @@ def create_rig(
 
         created_nodes = [rig_node.path()]
 
-        # Optional: auto-capture with a bonedeform node.
-        if auto_capture and capture_mesh:
+        if auto_capture:
             geo = get_node(hou, geo_path)
-            mesh_node = hou.node("{}/{}".format(geo.path(), capture_mesh))
-            if mesh_node is not None:
-                bone_deform = geo.createNode("bonedeform", node_name="bonedeform_{}".format(rig_name))
-                bone_deform.setFirstInput(mesh_node)
-                bone_deform.setInput(1, rig_node)
-                bone_deform.moveToGoodPosition()
-                created_nodes.append(bone_deform.path())
+            rest_rig = geo.createNode("stash", node_name="rest_{}".format(rig_name))
+            rest_stash = rest_rig.parm("stash")
+            if rest_stash is None:
+                raise RuntimeError("Rest Stash node has no stash parameter")
+            rest_stash.set(hou.Geometry(rig_node.geometry()))
+            rest_rig.cook(force=True)
+
+            capture = geo.createNode("kinefx::jointcaptureproximity", node_name="capture_{}".format(rig_name))
+            capture.setInput(0, mesh_node)
+            capture.setInput(1, rest_rig)
+            capture.setInput(2, rig_node)
+
+            joint_deform = geo.createNode("kinefx::jointdeform", node_name="jointdeform_{}".format(rig_name))
+            joint_deform.setInput(0, capture)
+            joint_deform.setInput(1, rest_rig)
+            joint_deform.setInput(2, rig_node)
+            joint_deform.cook(force=True)
+
+            rest_rig.moveToGoodPosition()
+            capture.moveToGoodPosition()
+            joint_deform.moveToGoodPosition()
+            created_nodes.extend([rest_rig.path(), capture.path(), joint_deform.path()])
 
         return skill_success(
             "Created KineFX rig",

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/set_rig_pose.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/set_rig_pose.py
@@ -8,6 +8,14 @@ from _kinefx_common import get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _vector3(values: Optional[List[float]], label: str) -> Optional[tuple]:
+    if values is None:
+        return None
+    if len(values) != 3:
+        raise ValueError("{} must contain exactly 3 values".format(label))
+    return tuple(float(value) for value in values)
+
+
 def set_rig_pose(
     rig_node: str,
     joint_index: Optional[int] = None,
@@ -22,8 +30,8 @@ def set_rig_pose(
     omitted, sets a uniform pose on the entire rig geometry (if applicable).
 
     The transform is applied to the point position/attributes on the rig SOP
-    geometry.  For KineFX skeleton points, ``P`` (position), ``rot``, and
-    ``scale`` point attributes are the standard pose controls.
+    geometry. For KineFX skeleton points, world transforms are stored in
+    ``P`` (position) and the ``transform`` matrix3 point attribute.
 
     Args:
         rig_node: Path to the rig SOP node (e.g. ``/obj/geo1/rig1``).
@@ -39,10 +47,22 @@ def set_rig_pose(
         return skill_error("Houdini not available", "hou could not be imported")
 
     try:
+        if joint_index is not None and joint_index < 0:
+            return skill_error("Joint index out of range", joint_index=joint_index)
+        translate_values = _vector3(translate, "translate")
+        rotate_values = _vector3(rotate, "rotate")
+        scale_values = _vector3(scale, "scale")
+        if translate_values is None and rotate_values is None and scale_values is None:
+            return skill_error("No pose supplied", "Provide translate, rotate, and/or scale")
+
         node = get_node(hou, rig_node)
-        geo = node.geometry()
-        if geo is None:
+        cooked_geo = node.geometry()
+        if cooked_geo is None:
             return skill_error("No geometry", "Rig node has no editable geometry")
+        geo = hou.Geometry(cooked_geo)
+        transform_attr = geo.findPointAttrib("transform")
+        if (rotate_values is not None or scale_values is not None) and transform_attr is None:
+            return skill_error("No transform attribute", "Rig geometry has no 'transform' matrix3 point attribute")
 
         # Find the target point(s).
         target_pts = []
@@ -53,7 +73,7 @@ def set_rig_pose(
                 return skill_error(
                     "Joint index out of range",
                     joint_index=joint_index,
-                    point_count=geo.floatListAttribValue("P") or 0,
+                    point_count=len(geo.points()),
                 )
         elif joint_name is not None:
             name_attr = geo.findPointAttrib("name")
@@ -70,25 +90,28 @@ def set_rig_pose(
 
         applied = {}
         for pt in target_pts:
-            if translate is not None and len(translate) >= 3:
-                pt.setPosition(hou.Vector3(float(translate[0]), float(translate[1]), float(translate[2])))
-                applied["translate"] = translate
-            if rotate is not None and len(rotate) >= 3:
-                rot_attr = geo.findPointAttrib("rot")
-                if rot_attr:
-                    pt.setAttribValue(rot_attr, hou.Vector3(float(rotate[0]), float(rotate[1]), float(rotate[2])))
-                else:
-                    rot_attr = geo.addAttrib(hou.attribType.Point, "rot", hou.Vector3())
-                    pt.setAttribValue(rot_attr, hou.Vector3(float(rotate[0]), float(rotate[1]), float(rotate[2])))
-                applied["rotate"] = rotate
-            if scale is not None and len(scale) >= 3:
-                scale_attr = geo.findPointAttrib("scale")
-                if scale_attr:
-                    pt.setAttribValue(scale_attr, hou.Vector3(float(scale[0]), float(scale[1]), float(scale[2])))
-                else:
-                    scale_attr = geo.addAttrib(hou.attribType.Point, "scale", hou.Vector3())
-                    pt.setAttribValue(scale_attr, hou.Vector3(float(scale[0]), float(scale[1]), float(scale[2])))
-                applied["scale"] = scale
+            if translate_values is not None:
+                pt.setPosition(hou.Vector3(*translate_values))
+                applied["translate"] = list(translate_values)
+            if rotate_values is not None or scale_values is not None:
+                current = hou.Matrix4(hou.Matrix3(pt.attribValue(transform_attr)))
+                transform = hou.hmath.buildTransform(
+                    {
+                        "rotate": rotate_values if rotate_values is not None else current.extractRotates(),
+                        "scale": scale_values if scale_values is not None else current.extractScales(),
+                    }
+                )
+                pt.setAttribValue(transform_attr, hou.Matrix3(transform).asTuple())
+                if rotate_values is not None:
+                    applied["rotate"] = list(rotate_values)
+                if scale_values is not None:
+                    applied["scale"] = list(scale_values)
+
+        stash = node.parm("stash")
+        if stash is None:
+            return skill_error("Unsupported rig node", "Rig node has no stash parameter")
+        stash.set(geo)
+        node.cook(force=True)
 
         return skill_success(
             "Set rig pose",

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/tools.yaml
@@ -23,7 +23,7 @@ tools:
           description: Path to the Geometry SOP container (e.g. /obj/geo1).
         rig_name:
           type: string
-          description: Name for the rig null/container node.
+          description: Name for the KineFX Skeleton SOP.
           default: "rig1"
         joint_chain:
           type: array
@@ -33,14 +33,20 @@ tools:
               name:
                 type: string
                 description: Joint name.
+              parent_index:
+                type: integer
+                minimum: -1
+                description: Earlier parent joint index, or -1 for a root. Defaults to the previous joint.
               translate:
                 type: array
                 items: {type: number}
+                minItems: 3
+                maxItems: 3
                 description: Joint position [x, y, z].
           description: List of joint definitions.
         auto_capture:
           type: boolean
-          description: If true, wire a bonedeform for immediate skinning.
+          description: If true, capture and deform capture_mesh with KineFX SOPs.
           default: false
         capture_mesh:
           type: string
@@ -69,6 +75,7 @@ tools:
           description: Path to the rig SOP node.
         joint_index:
           type: integer
+          minimum: 0
           description: Zero-based joint point index.
         joint_name:
           type: string
@@ -76,16 +83,19 @@ tools:
         translate:
           type: array
           items: {type: number}
+          minItems: 3
           maxItems: 3
           description: Translation [x, y, z] to set.
         rotate:
           type: array
           items: {type: number}
+          minItems: 3
           maxItems: 3
           description: Rotation [rx, ry, rz] in degrees.
         scale:
           type: array
           items: {type: number}
+          minItems: 3
           maxItems: 3
           description: Scale [sx, sy, sz] factors.
   - name: capture_joints

--- a/tests/test_kinefx_skills.py
+++ b/tests/test_kinefx_skills.py
@@ -30,15 +30,16 @@ class TestCreateRig:
         geo = MagicMock()
         geo.path.return_value = "/obj/geo1"
 
-        # rig_sop = geo.createNode("null", node_name=rig_name)
         rig_sop = MagicMock()
         rig_sop.path.return_value = "/obj/geo1/rig1"
         rig_geo = MagicMock()
-        rig_sop.geometry.return_value = rig_geo
+        stash = MagicMock()
+        rig_sop.parm.return_value = stash
 
         geo.createNode.return_value = rig_sop
 
         mock_hou = MagicMock()
+        mock_hou.Geometry.return_value = rig_geo
         # Use side_effect to differentiate: rig doesn't exist yet, return None
         mock_hou.node.side_effect = lambda p: None if "rig1" in p else geo
 
@@ -61,6 +62,9 @@ class TestCreateRig:
         assert result["success"] is True
         assert result["context"]["rig_path"] == "/obj/geo1/rig1"
         assert result["context"]["joint_count"] == 3
+        geo.createNode.assert_called_once_with("kinefx::skeleton", node_name="rig1")
+        rig_sop.geometry.assert_not_called()
+        stash.set.assert_called_once_with(rig_geo)
 
     def test_create_rig_with_auto_capture(self) -> None:
         mod = _load_script("create_rig.py")
@@ -70,17 +74,25 @@ class TestCreateRig:
         rig_sop = MagicMock()
         rig_sop.path.return_value = "/obj/geo1/rig1"
         rig_geo = MagicMock()
-        rig_sop.geometry.return_value = rig_geo
+        rig_sop.parm.return_value = MagicMock()
 
-        bone_deform = MagicMock()
-        bone_deform.path.return_value = "/obj/geo1/bonedeform_rig1"
+        rest_rig = MagicMock()
+        rest_rig.path.return_value = "/obj/geo1/rest_rig1"
+        rest_stash = MagicMock()
+        rest_rig.parm.return_value = rest_stash
+        rest_geo = MagicMock()
+        capture = MagicMock()
+        capture.path.return_value = "/obj/geo1/capture_rig1"
+        joint_deform = MagicMock()
+        joint_deform.path.return_value = "/obj/geo1/jointdeform_rig1"
 
         mesh_node = MagicMock()
         mesh_node.path.return_value = "/obj/geo1/body"
 
-        geo.createNode.side_effect = [rig_sop, bone_deform]
+        geo.createNode.side_effect = [rig_sop, rest_rig, capture, joint_deform]
 
         mock_hou = MagicMock()
+        mock_hou.Geometry.side_effect = [rig_geo, rest_geo]
         mock_hou.node.side_effect = lambda p: {
             "/obj/geo1": geo,
             "/obj/geo1/body": mesh_node,
@@ -102,22 +114,87 @@ class TestCreateRig:
 
         assert result["success"] is True
         assert result["context"]["auto_capture"] is True
-        assert len(result["context"]["created_nodes"]) == 2
-        bone_deform.setFirstInput.assert_called_once_with(mesh_node)
-        bone_deform.setInput.assert_called_with(1, rig_sop)
+        assert len(result["context"]["created_nodes"]) == 4
+        rest_stash.set.assert_called_once_with(rest_geo)
+        capture.setInput.assert_any_call(0, mesh_node)
+        capture.setInput.assert_any_call(1, rest_rig)
+        capture.setInput.assert_any_call(2, rig_sop)
+        joint_deform.setInput.assert_any_call(0, capture)
+        joint_deform.setInput.assert_any_call(1, rest_rig)
+        joint_deform.setInput.assert_any_call(2, rig_sop)
+        joint_deform.cook.assert_called_once_with(force=True)
+
+    def test_create_rig_validates_joint_chain_before_creating_nodes(self) -> None:
+        mod = _load_script("create_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: geo if path == "/obj/geo1" else None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_rig(
+                "/obj/geo1",
+                rig_name="rig1",
+                joint_chain=[
+                    {"name": "duplicate", "translate": [0, 0, 0]},
+                    {"name": "duplicate", "translate": [0, 1, 0]},
+                ],
+            )
+
+        assert result["success"] is False
+        geo.createNode.assert_not_called()
+
+    def test_create_rig_validates_joint_name_before_creating_nodes(self) -> None:
+        mod = _load_script("create_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: geo if path == "/obj/geo1" else None
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_rig(
+                "/obj/geo1",
+                rig_name="rig1",
+                joint_chain=[{"name": None, "translate": [0, 0, 0]}],
+            )
+
+        assert result["success"] is False
+        geo.createNode.assert_not_called()
+
+    def test_create_rig_auto_capture_requires_joint_chain_before_creating_nodes(self) -> None:
+        mod = _load_script("create_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/geo1"
+        mesh = MagicMock()
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {
+            "/obj/geo1": geo,
+            "/obj/geo1/body": mesh,
+        }.get(path)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_rig("/obj/geo1", auto_capture=True, capture_mesh="body")
+
+        assert result["success"] is False
+        geo.createNode.assert_not_called()
 
 
 class TestSetRigPose:
     def test_set_rig_pose_by_index(self) -> None:
         mod = _load_script("set_rig_pose.py")
         pt = MagicMock()
-        geo = MagicMock()
-        geo.iterPoints.return_value = [pt]
+        cooked_geo = MagicMock()
+        editable_geo = MagicMock()
+        editable_geo.iterPoints.return_value = [pt]
+        editable_geo.points.return_value = [pt]
         node = MagicMock()
         node.path.return_value = "/obj/geo1/rig1"
-        node.geometry.return_value = geo
+        node.geometry.return_value = cooked_geo
+        stash = MagicMock()
+        node.parm.return_value = stash
         mock_hou = MagicMock()
         mock_hou.node.return_value = node
+        mock_hou.Geometry.return_value = editable_geo
         mock_hou.Vector3 = lambda *args: list(args) if args else [0.0, 0.0, 0.0]
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
@@ -130,22 +207,34 @@ class TestSetRigPose:
         assert result["success"] is True
         assert result["context"]["applied"]["translate"] == [0.0, 1.0, 0.0]
         pt.setPosition.assert_called_once()
+        mock_hou.Geometry.assert_called_once_with(cooked_geo)
+        stash.set.assert_called_once_with(editable_geo)
 
     def test_set_rig_pose_with_rotation(self) -> None:
         mod = _load_script("set_rig_pose.py")
         pt = MagicMock()
-        geo = MagicMock()
-        geo.iterPoints.return_value = [pt]
-        geo.points.return_value = [pt]
-        geo.findPointAttrib.return_value = None  # rot attr doesn't exist yet
-        geo.addAttrib.return_value = "rot"
+        cooked_geo = MagicMock()
+        editable_geo = MagicMock()
+        editable_geo.iterPoints.return_value = [pt]
+        editable_geo.points.return_value = [pt]
+        editable_geo.findPointAttrib.return_value = "transform"
+        pt.attribValue.return_value = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
         node = MagicMock()
         node.path.return_value = "/obj/geo1/rig1"
-        node.geometry.return_value = geo
+        node.geometry.return_value = cooked_geo
+        node.parm.return_value = MagicMock()
         mock_hou = MagicMock()
         mock_hou.node.return_value = node
-        mock_hou.Vector3 = lambda *args: list(args) if args else [0.0, 0.0, 0.0]
-        mock_hou.attribType.Point = "point"
+        mock_hou.Geometry.return_value = editable_geo
+        current_matrix = MagicMock()
+        current_matrix.extractRotates.return_value = (0.0, 0.0, 0.0)
+        current_matrix.extractScales.return_value = (1.0, 1.0, 1.0)
+        mock_hou.Matrix4.return_value = current_matrix
+        built_matrix = MagicMock()
+        result_matrix = MagicMock()
+        result_matrix.asTuple.return_value = (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0)
+        mock_hou.hmath.buildTransform.return_value = built_matrix
+        mock_hou.Matrix3.side_effect = [MagicMock(), result_matrix]
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.set_rig_pose(
@@ -155,7 +244,11 @@ class TestSetRigPose:
 
         assert result["success"] is True
         assert result["context"]["applied"]["rotate"] == [90.0, 0.0, 0.0]
-        geo.addAttrib.assert_called_once()
+        pt.setAttribValue.assert_called_once_with(
+            "transform",
+            (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0),
+        )
+        editable_geo.addAttrib.assert_not_called()
 
     def test_set_rig_pose_no_geometry_returns_error(self) -> None:
         mod = _load_script("set_rig_pose.py")
@@ -169,6 +262,26 @@ class TestSetRigPose:
             result = mod.set_rig_pose("/obj/geo1/rig1")
 
         assert result["success"] is False
+
+    def test_set_rig_pose_rejects_short_vectors(self) -> None:
+        mod = _load_script("set_rig_pose.py")
+        mock_hou = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_rig_pose("/obj/geo1/rig1", rotate=[90.0, 0.0])
+
+        assert result["success"] is False
+        mock_hou.node.assert_not_called()
+
+    def test_set_rig_pose_rejects_negative_joint_index(self) -> None:
+        mod = _load_script("set_rig_pose.py")
+        mock_hou = MagicMock()
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.set_rig_pose("/obj/geo1/rig1", joint_index=-1, translate=[0.0, 1.0, 0.0])
+
+        assert result["success"] is False
+        mock_hou.node.assert_not_called()
 
 
 class TestCaptureJoints:


### PR DESCRIPTION
## Summary
- preserve full affine joint transforms when reading and writing KineFX poses
- keep a dedicated rest skeleton and use Joint Capture Proximity + Joint Deform for auto-captured skin
- validate joint indices, names, parents, and vector sizes before creating nodes
- extend schema, unit coverage, and Houdini E2E coverage for branching rigs and real deformation

## Validation
- `pytest`: 831 passed, 1 skipped, 3 deselected
- KineFX focused tests: 13 passed
- Ruff check/format, Python 3.7 grammar, and Skill lint passed
- Houdini 21.0.631 live: branching edges `(0,1)/(0,2)`, matrix3 max error `0.0`, `boneCapture` present, Joint Deform cooked without errors, 20 points moved
- invalid input leaves no residual nodes