### PR TITLE
fix: unify ROP job identity and polling

### DIFF
--- a/src/dcc_mcp_houdini/_isolated_jobs.py
+++ b/src/dcc_mcp_houdini/_isolated_jobs.py
@@ -30,9 +30,20 @@ _SIGTERM = getattr(signal, "SIGTERM", 15)
 _SIGKILL = getattr(signal, "SIGKILL", 9)
 
 
+def _normalize_job_id(job_id: str) -> str:
+    if not isinstance(job_id, str):
+        raise ValueError("job_id must be a 32-character hex or canonical UUID identifier")
+    try:
+        parsed = uuid.UUID(job_id)
+    except ValueError as exc:
+        raise ValueError("job_id must be a 32-character hex or canonical UUID identifier") from exc
+    if job_id.lower() not in {parsed.hex, str(parsed)}:
+        raise ValueError("job_id must be a 32-character hex or canonical UUID identifier")
+    return parsed.hex
+
+
 def _status_path(job_id: str) -> Path:
-    if not job_id or any(char not in "0123456789abcdef" for char in job_id.lower()):
-        raise ValueError("job_id must be a hexadecimal identifier")
+    job_id = _normalize_job_id(job_id)
     return Path(tempfile.gettempdir()) / _JOB_ROOT_NAME / job_id / "status.json"
 
 
@@ -67,6 +78,7 @@ def launch_job(
     env: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, Any]:
     """Launch and retain ownership of one isolated worker process."""
+    job_id = _normalize_job_id(job_id)
     status_path = _status_path(job_id)
     status = _read_status(status_path)
     stdout_path = Path(status["stdout_path"])
@@ -185,6 +197,7 @@ def _terminate_process_tree(process: Any) -> None:
 
 
 def read_job(job_id: str) -> Dict[str, Any]:
+    job_id = _normalize_job_id(job_id)
     status_path = _status_path(job_id)
     with _PROCESS_LOCK:
         status = _read_status(status_path)
@@ -196,6 +209,7 @@ def read_job(job_id: str) -> Dict[str, Any]:
 
 def cancel_job(job_id: str, terminate: Any = None) -> Dict[str, Any]:
     """Cancel a live job only when this process owns its Popen handle."""
+    job_id = _normalize_job_id(job_id)
     status_path = _status_path(job_id)
     terminate = terminate or _terminate_process_tree
     with _PROCESS_LOCK:

--- a/src/dcc_mcp_houdini/_rop_jobs.py
+++ b/src/dcc_mcp_houdini/_rop_jobs.py
@@ -502,6 +502,7 @@ def finalize_render_outputs(job_id: str, validator_receipts: List[dict]) -> Dict
     """Publish externally validated staged EXRs without replacing final paths."""
     if not isinstance(validator_receipts, list) or not validator_receipts:
         raise ValueError("validator_receipts must be a non-empty array")
+    job_id = _isolated_jobs._normalize_job_id(job_id)
     _isolated_jobs.read_job(job_id)
     status_path = _isolated_jobs._status_path(job_id)
     finalized_frames = []

--- a/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/SKILL.md
@@ -37,10 +37,10 @@ Typed animation tools for agents. All tools are `affinity: main`.
 - **`validation`:** `validate_loop_contract` — bounded, read-only OBJ world-
   transform continuity checks with driver summaries. It never inspects or cooks
   geometry and restores the original frame in `finally`.
-- **`bake`** (async): `bake_channels` (per-frame sample → constant keys, hard
-  frame cap), `cache_simulation` (render a filecache/DOP/geometry ROP, report
-  a background job in interactive Houdini or `written_files` + `elapsed_secs`
-  in headless/explicit foreground mode).
+- **`bake`:** `bake_channels` (async per-frame sample → constant keys, hard
+  frame cap), `cache_simulation` (launch an isolated filecache/DOP/geometry ROP
+  job by default, or report `written_files` + `elapsed_secs` in explicit
+  foreground mode).
 
 ## Tracer-bullet flow
 
@@ -79,13 +79,13 @@ whose endpoints are both played. Supply `tolerances` to override the documented
 defaults; requests remain bounded to 64 unique `/obj` paths and six transform
 samples per resolved node.
 
-`cache_simulation` is `async` with a 1-hour timeout hint. Interactive Houdini
-defaults to isolated `hython`; poll its `job_id` with
+`cache_simulation` uses synchronous dispatch metadata so its adapter-owned job
+identity is returned directly. UI and headless Houdini default to isolated
+`hython`; poll its `job_id` with
 `houdini_render__get_render_job` and cancel it with
 `houdini_render__cancel_render_job`. Pass `background=false` for intentional
 foreground execution. Interactive background launch requires an explicitly
-saved, clean HIP and never auto-saves the GUI scene. Explicit headless
-background launch requires an existing HIP and captures its current state in a
-job-owned temporary snapshot without saving the source scene. Output-path parm
-names are probed defensively so File
-Cache, DOP I/O, and Geometry ROPs are all tolerated.
+saved, clean HIP and never auto-saves the GUI scene. Headless isolation
+requires an existing HIP and captures its current state in a job-owned
+temporary snapshot without saving the source scene. Output-path parm names are
+probed defensively so File Cache, DOP I/O, and Geometry ROPs are all tolerated.

--- a/src/dcc_mcp_houdini/skills/houdini-animation/scripts/cache_simulation.py
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/scripts/cache_simulation.py
@@ -76,7 +76,7 @@ def cache_simulation(
                 "Node has no render(); expected a ROP/file cache node",
                 node_path=rop.path(),
             )
-        use_background = bool(hou.isUIAvailable()) if background is None else background
+        use_background = True if background is None else background
         output_pattern = _eval_output(rop, preserve_string=use_background)
         if use_background:
             job = launch_background_render(

--- a/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-animation/tools.yaml
@@ -321,12 +321,12 @@ tools:
   - name: cache_simulation
     description: >-
       Bake a simulation/cache by rendering a ROP (filecache/dop/geometry) over a
-      frame range. Interactive Houdini defaults to an isolated job; headless
-      Houdini defaults to foreground execution.
+      frame range. UI and headless Houdini default to an isolated job and return
+      its adapter job_id directly; pass background=false only for intentional
+      foreground execution.
     source_file: scripts/cache_simulation.py
-    execution: async
+    execution: sync
     affinity: main
-    timeout_hint_secs: 3600
     group: bake
     read_only: false
     destructive: false
@@ -350,7 +350,6 @@ tools:
           type: boolean
           description: >-
             Explicitly select isolated hython (true) or foreground (false)
-            execution. When omitted, interactive Houdini uses an isolated job
-            and headless Houdini runs in the foreground. Explicit headless
-            isolation uses a job-owned temporary HIP snapshot without saving the
-            source scene.
+            execution. When omitted, UI and headless Houdini use an isolated
+            job. Headless isolation uses a job-owned temporary HIP snapshot
+            without saving the source scene.

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/SKILL.md
@@ -32,26 +32,27 @@ definition introspection, instantiation, validation, and graph-level cooking.
 - **`hda-query`** (read-only): `scan_hda_libraries`, `inspect_hda_definition`,
   `validate_hda`.
 - **`hda-edit`:** `instantiate_hda` (async — creates and cooks a node).
-- **`pdg-rop`** (async): `cook_top_network`, `execute_rop_chain`.
+- **`pdg-rop`:** async `cook_top_network` and self-managed
+  `execute_rop_chain`.
 
 ## Context limitations
 
 - **Headless / no license:** all tools degrade through structured
   `skill_error` envelopes when `hou` is unavailable; PDG/ROP cooking still
   requires a valid Houdini session.
-- **Long runs:** `instantiate_hda`, `validate_hda`, `cook_top_network`, and
-  `execute_rop_chain` are `execution: async` with `timeout_hint_secs` set.
-  Interactive `execute_rop_chain` returns an isolated job; poll it through
+- **Long runs:** `instantiate_hda`, `validate_hda`, and `cook_top_network` use
+  core async jobs. `execute_rop_chain` uses synchronous dispatch metadata so it
+  returns its adapter-owned isolated job identity directly; poll it through
   `houdini_render__get_render_job` instead of occupying the Houdini event loop.
 - **PDG stats:** `cook_top_network` reports `work_item_count` on a best-effort
   basis via `getPDGGraphContext()`; it may be `null` when the context is
   unavailable.
 - **ROP dependencies:** `execute_rop_chain` honours upstream ROP inputs by
   default in both foreground and isolated workers; pass `ignore_inputs=true`
-  to render only the named driver. Interactive Houdini defaults to isolated
-  `hython`, while headless Houdini defaults to foreground. Interactive isolated
-  launch requires a saved, clean HIP and never auto-saves the GUI scene.
-  Explicit headless isolated launch requires an existing HIP and captures its
+  to render only the named driver. UI and headless Houdini default to isolated
+  `hython`; pass `background=false` only for intentional foreground execution.
+  Interactive isolated launch requires a saved, clean HIP and never auto-saves
+  the GUI scene. Headless isolation requires an existing HIP and captures its
   current state in a job-owned temporary snapshot without saving the source
   scene. A chain can complete without a
   discoverable output path when it has no execution/cook errors;

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/scripts/execute_rop_chain.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/scripts/execute_rop_chain.py
@@ -57,7 +57,7 @@ def execute_rop_chain(
                 node=node_summary(node),
             )
 
-        use_background = bool(hou.isUIAvailable()) if background is None else background
+        use_background = True if background is None else background
         if use_background:
             job = launch_background_render(
                 hou,

--- a/src/dcc_mcp_houdini/skills/houdini-hda-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda-automation/tools.yaml
@@ -128,14 +128,14 @@ tools:
   - name: execute_rop_chain
     description: >-
       Render a ROP with its upstream output-driver dependencies (or just itself
-      when ignore_inputs is set). Interactive Houdini defaults to an isolated
-      job; headless Houdini defaults to foreground execution. Chain success is
-      based on execution/cook errors; output_verification reports whether file
-      output was verified, not observed, or unavailable.
+      when ignore_inputs is set). UI and headless Houdini default to an isolated
+      job and return its adapter job_id directly; pass background=false only for
+      intentional foreground execution. Chain success is based on execution/cook
+      errors; output_verification reports whether file output was verified, not
+      observed, or unavailable.
     source_file: scripts/execute_rop_chain.py
-    execution: async
+    execution: sync
     affinity: main
-    timeout_hint_secs: 600
     group: pdg-rop
     read_only: false
     destructive: false
@@ -162,7 +162,6 @@ tools:
           type: boolean
           description: >-
             Explicitly select isolated hython (true) or foreground (false)
-            execution. When omitted, interactive Houdini uses an isolated job
-            and headless Houdini runs in the foreground. Explicit headless
-            isolation uses a job-owned temporary HIP snapshot without saving the
-            source scene.
+            execution. When omitted, UI and headless Houdini use an isolated
+            job. Headless isolation uses a job-owned temporary HIP snapshot
+            without saving the source scene.

--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -87,6 +87,8 @@ Interactive Houdini defaults to an isolated process; poll
 started by the same adapter process. Pass `background=false` only when
 foreground execution is intentional. Both interactive and headless Houdini
 default to isolated background execution.
+Poll and cancel accept the returned 32-character hex job id or its canonical
+dashed UUID spelling; both resolve to the same job and process ownership.
 The default poll response is bounded: it reports `completed`, `total`,
 fractional `progress`, `elapsed_secs`, `eta_secs`, `written_file_count`, and up
 to ten `recent_written_files`. `output_verification.state` distinguishes

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -296,7 +296,8 @@ tools:
       ROP render/cache/chain job. Set include_details only when full internal
       output and warning lists plus traceback data are required. The bounded
       summary includes warning_count and at most ten individually truncated
-      recent_warnings.
+      recent_warnings. Accepts the returned 32-character hex job ID or its
+      canonical dashed UUID spelling.
     source_file: scripts/get_render_job.py
     execution: sync
     affinity: any
@@ -314,6 +315,7 @@ tools:
       properties:
         job_id:
           type: string
+          description: "Adapter job ID in 32-character hex or canonical dashed UUID form."
         include_details:
           type: boolean
           default: false
@@ -385,7 +387,10 @@ tools:
                     type: string
                     pattern: "^[0-9A-Fa-f]{64}$"
   - name: cancel_render_job
-    description: Cancel a background ROP render/cache/chain job owned by the current adapter process. Repeated calls are safe.
+    description: >-
+      Cancel a background ROP render/cache/chain job owned by the current
+      adapter process. Accepts 32-character hex or canonical dashed UUID form.
+      Repeated calls are safe.
     source_file: scripts/cancel_render_job.py
     execution: sync
     affinity: any
@@ -404,6 +409,7 @@ tools:
       properties:
         job_id:
           type: string
+          description: "Adapter job ID in 32-character hex or canonical dashed UUID form."
   - name: create_render_layer
     description: >-
       Create a Solaris Render Product, or clone a Mantra ifd ROP into a real

--- a/tests/test_animation_skills.py
+++ b/tests/test_animation_skills.py
@@ -327,24 +327,34 @@ class TestBake:
         )
         rop.render.assert_not_called()
 
-    def test_cache_simulation_defaults_to_foreground_without_ui(self, tmp_path: Path) -> None:
+    def test_cache_simulation_defaults_to_background_without_ui(self, tmp_path: Path) -> None:
         mod = _load_script("cache_simulation.py")
         output = tmp_path / "cache.bgeo.sc"
         file_parm = MagicMock()
         file_parm.eval.return_value = str(output)
+        file_parm.unexpandedString.return_value = str(output)
         rop = MagicMock()
         rop.path.return_value = "/out/filecache1"
         rop.parm.side_effect = lambda name: file_parm if name == "file" else None
-        rop.parmTuple.return_value = None
-        rop.render.side_effect = lambda verbose=False: output.write_bytes(b"cache")
         mock_hou = MagicMock()
         mock_hou.node.return_value = rop
         mock_hou.isUIAvailable.return_value = False
+        job = {"job_id": "c" * 32, "state": "queued", "pid": 2468}
 
-        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod, "launch_background_render") as launch:
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(
+            mod, "launch_background_render", return_value=job
+        ) as launch:
             result = mod.cache_simulation("/out/filecache1")
 
         assert result["success"] is True
-        assert result["context"]["background"] is False
-        launch.assert_not_called()
-        rop.render.assert_called_once_with(verbose=False)
+        assert result["context"]["background"] is True
+        assert result["context"]["job_id"] == "c" * 32
+        launch.assert_called_once_with(
+            mock_hou,
+            "/out/filecache1",
+            None,
+            str(output),
+            job_kind="cache",
+        )
+        mock_hou.isUIAvailable.assert_not_called()
+        rop.render.assert_not_called()

--- a/tests/test_hda_automation_skills.py
+++ b/tests/test_hda_automation_skills.py
@@ -238,23 +238,35 @@ class TestPdgRop:
 
         assert mod._output_pattern(node) == "/tmp/stage.$F4.usd"
 
-    def test_execute_rop_chain_defaults_to_foreground_without_ui(self) -> None:
+    def test_execute_rop_chain_defaults_to_background_without_ui(self) -> None:
         mod = _load_script("execute_rop_chain.py")
         node = _node("/out/mantra1", "mantra1", "ifd")
-        node.errors.return_value = []
+        picture = MagicMock()
+        picture.unexpandedString.return_value = "/tmp/beauty.$F4.exr"
+        node.parm.side_effect = lambda name: picture if name == "picture" else None
         mock_hou = MagicMock()
         mock_hou.node.return_value = node
         mock_hou.isUIAvailable.return_value = False
+        job = {"job_id": "d" * 32, "state": "queued", "pid": 1357}
 
-        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod, "launch_background_render") as launch:
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(
+            mod, "launch_background_render", return_value=job
+        ) as launch:
             result = mod.execute_rop_chain("/out/mantra1", frame_range=[1, 24, 2], ignore_inputs=True)
 
         assert result["success"] is True
-        assert result["context"]["background"] is False
-        launch.assert_not_called()
-        _, kwargs = node.render.call_args
-        assert kwargs["frame_range"] == (1.0, 24.0, 2.0)
-        assert kwargs["ignore_inputs"] is True
+        assert result["context"]["background"] is True
+        assert result["context"]["job_id"] == "d" * 32
+        launch.assert_called_once_with(
+            mock_hou,
+            "/out/mantra1",
+            [1, 24, 2],
+            "/tmp/beauty.$F4.exr",
+            ignore_inputs=True,
+            job_kind="rop_chain",
+        )
+        mock_hou.isUIAvailable.assert_not_called()
+        node.render.assert_not_called()
 
     def test_execute_rop_chain_fallback_never_drops_ignore_inputs(self) -> None:
         mod = _load_script("execute_rop_chain.py")

--- a/tests/test_isolated_jobs.py
+++ b/tests/test_isolated_jobs.py
@@ -1,0 +1,35 @@
+"""Durable isolated-job identity contracts."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dcc_mcp_houdini import _isolated_jobs, _rop_jobs
+
+
+def test_hex_and_dashed_uuid_resolve_the_same_job_and_process(tmp_path) -> None:
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        status, _ = _isolated_jobs.create_job({"job_kind": "render"})
+        compact_id = status["job_id"]
+        dashed_id = str(uuid.UUID(hex=compact_id))
+        process = MagicMock()
+        process.poll.return_value = None
+        _isolated_jobs._PROCESS_HANDLES[compact_id] = process
+        try:
+            compact = _rop_jobs.read_render_job(compact_id)
+            dashed = _rop_jobs.read_render_job(dashed_id)
+        finally:
+            _isolated_jobs._PROCESS_HANDLES.pop(compact_id, None)
+
+    assert _isolated_jobs._status_path(compact_id) == _isolated_jobs._status_path(dashed_id)
+    assert compact["job_id"] == dashed["job_id"] == compact_id
+    assert compact["owned_by_current_process"] is dashed["owned_by_current_process"] is True
+
+
+@pytest.mark.parametrize("job_id", ("../status", "{00000000-0000-0000-0000-000000000000}", 7))
+def test_job_id_normalization_rejects_noncanonical_identifiers(job_id) -> None:
+    with pytest.raises(ValueError, match="32-character hex or canonical UUID"):
+        _isolated_jobs._status_path(job_id)

--- a/tests/test_render_artifact_transactions.py
+++ b/tests/test_render_artifact_transactions.py
@@ -992,6 +992,14 @@ def test_finalize_binds_receipt_and_updates_aggregate(tmp_path: Path) -> None:
     assert Path(artifact["final_path"]).read_bytes() == b"validated frame 1"
 
 
+def test_finalize_accepts_dashed_job_id_with_compact_receipt(tmp_path: Path) -> None:
+    job_id, _, artifacts = _completed_job(tmp_path)
+    receipt = _receipt(job_id, artifacts[0])
+    with patch.object(_isolated_jobs.tempfile, "gettempdir", return_value=str(tmp_path)):
+        result = _rop_jobs.finalize_render_outputs("22222222-2222-2222-2222-222222222222", [receipt])
+    assert result["job_id"] == job_id
+
+
 def test_finalize_rejects_staged_drift_without_writing_final(tmp_path: Path) -> None:
     job_id, status_path, artifacts = _completed_job(tmp_path)
     receipt = _receipt(job_id, artifacts[0])

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -66,13 +66,24 @@ def test_tools_yaml_contract(skill_dir: str) -> None:
             assert tool.get("timeout_hint_secs"), f"{tool['name']} missing timeout_hint_secs"
 
 
-def test_render_rop_returns_its_render_job_identity_directly_by_default() -> None:
-    tools_path = _SKILLS_ROOT / "houdini-render" / "tools.yaml"
+@pytest.mark.parametrize(
+    ("skill_name", "tool_name"),
+    (
+        ("houdini-render", "render_rop"),
+        ("houdini-animation", "cache_simulation"),
+        ("houdini-hda-automation", "execute_rop_chain"),
+    ),
+)
+def test_self_managed_rop_tools_return_adapter_job_identity_directly(
+    skill_name: str,
+    tool_name: str,
+) -> None:
+    tools_path = _SKILLS_ROOT / skill_name / "tools.yaml"
     tools = yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]
-    render_rop = next(tool for tool in tools if tool["name"] == "render_rop")
+    tool = next(tool for tool in tools if tool["name"] == tool_name)
 
-    assert render_rop["execution"] == "sync"
-    assert "timeout_hint_secs" not in render_rop
+    assert tool["execution"] == "sync"
+    assert "timeout_hint_secs" not in tool
 
 
 def test_skills_index_exists() -> None:


### PR DESCRIPTION
## Summary
- return adapter-owned job IDs for cache and ROP-chain launches
- default UI and headless runs to isolated workers
- normalize compact and dashed UUIDs across polling, cancellation, and finalization

## Validation
- `just lint-all`
- `just test` (838 passed, 1 skipped)
- render artifact transactions (56 passed)

Part of #198.