### PR TITLE
feat: add fast selection inspection

### DIFF
--- a/.github/scripts/run_houdini_e2e.py
+++ b/.github/scripts/run_houdini_e2e.py
@@ -45,6 +45,23 @@ def _find_tool(names, suffix):
     raise AssertionError("Tool ending with {!r} not found in {}".format(suffix, names))
 
 
+def _tool_payload(payload):
+    result = payload.get("result") or {}
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        return structured
+    for item in result.get("content") or []:
+        if item.get("type") != "text":
+            continue
+        try:
+            decoded = json.loads(item.get("text") or "")
+        except (TypeError, ValueError):
+            continue
+        if isinstance(decoded, dict):
+            return decoded
+    raise AssertionError("Structured tool payload not found in {!r}".format(payload))
+
+
 def main() -> None:
     print("Houdini:", hou.applicationVersionString())
     server = dcc_mcp_houdini.start_server(port=0, register_builtins=True, wait_ready=True, readiness_timeout_secs=20)
@@ -66,6 +83,7 @@ def main() -> None:
         tools = _post(url, "tools/list")
         names = _tool_names(tools)
         get_session_info = _find_tool(names, "get_session_info")
+        inspect_selection = _find_tool(names, "inspect_selection")
         create_node = _find_tool(names, "create_node")
         set_node_parms = _find_tool(names, "set_node_parms")
         create_rig = _find_tool(names, "create_rig")
@@ -122,6 +140,31 @@ def main() -> None:
             },
         )
         assert "result" in mesh_configured, mesh_configured
+        mesh = hou.node(mesh_path)
+        pack = mesh.parent().createNode("pack", "ci_pack")
+        pack.setInput(0, mesh)
+        pack.setDisplayFlag(True)
+        pack.setCurrent(True, clear_all_selected=True)
+        pack.cook(force=True)
+        assert pack.geometry().countPrimType("PackedGeometry") == 1
+        inspect_started = time.monotonic()
+        inspected = _post(url, "tools/call", {"name": inspect_selection, "arguments": {}})
+        inspect_elapsed = time.monotonic() - inspect_started
+        inspect_payload = _tool_payload(inspected)
+        inspect_context = inspect_payload["context"]
+        assert inspect_context["selection"][0]["path"] == pack.path(), inspect_payload
+        assert inspect_context["display_node"]["path"] == pack.path(), inspect_payload
+        assert inspect_context["geometry"]["needs_cook"] is False, inspect_payload
+        assert inspect_context["geometry"]["point_count"] == pack.geometry().pointCount(), inspect_payload
+        assert inspect_context["geometry"]["packed_primitive_count"] == 1, inspect_payload
+        assert "P" in inspect_context["geometry"]["key_attributes"]["point"], inspect_payload
+        print(
+            "inspect_selection elapsed_seconds={:.3f} point_count={} packed_count={}".format(
+                inspect_elapsed,
+                inspect_context["geometry"]["point_count"],
+                inspect_context["geometry"]["packed_primitive_count"],
+            )
+        )
 
         rigged = _post(
             url,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ print(server.mcp_url)  # OS-assigned instance endpoint
 ```
 1. search_skills(query="scene") -> find a typed Houdini skill
 2. load_skill("houdini-nodes") / load_skill("houdini-hda") when authoring tools are needed
-3. call houdini_scene__get_scene_info / houdini_nodes__create_node / houdini_hda__execute_hda
+3. call houdini_scene__inspect_selection / houdini_nodes__create_node / houdini_hda__execute_hda
 4. use houdini_scripting__execute_python only when no typed skill fits
 ```
 
@@ -86,7 +86,7 @@ When adding or changing bundled skills, load the project skill:
 ### scene stage (partial default — `houdini-scene` only)
 | Skill | Tools | Load |
 |-------|-------|------|
-| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` | default |
+| `houdini-scene` | `inspect_selection`, `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` | default |
 | `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` | on demand |
 
 ### authoring stage (load on demand)
@@ -128,7 +128,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 31 skill packages, 199 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 32 skill packages, 216 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 ### scene (partial default — `houdini-scene` only)
 | Skill | Tools | Load |
 |-------|-------|------|
-| `houdini-scene` | `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` | default |
+| `houdini-scene` | `inspect_selection`, `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info` | default |
 | `houdini-scene-edit` | `new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box` | on demand |
 
 ### authoring (load on demand)

--- a/llms.txt
+++ b/llms.txt
@@ -41,7 +41,7 @@ server.list_skills()
 - `houdini_scripting__execute_python`, `get_session_info`
 
 ### scene (default)
-- `houdini_scene__get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info`
+- `houdini_scene__inspect_selection`, `get_scene_info`, `list_obj_nodes`, `list_child_nodes`, `get_node_info`
 - `houdini_scene_edit__new_scene`, `open_scene`, `save_scene`, `get_selection`, `set_selection`, `find_nodes`, `list_cameras`, `get_bounding_box`
 
 ### authoring (load on demand)

--- a/src/dcc_mcp_houdini/_capability_manifest.py
+++ b/src/dcc_mcp_houdini/_capability_manifest.py
@@ -44,6 +44,20 @@ _SKILL_STUB_PREFIX = "__skill__"
 _GROUP_STUB_PREFIX = "__group__"
 
 
+def _schema_has_arguments(schema: Any) -> bool:
+    """Return whether an input schema describes arguments worth fetching."""
+    if not isinstance(schema, dict):
+        return bool(schema)
+    if schema.get("type") != "object":
+        return bool(schema)
+    if schema.get("properties") or schema.get("required"):
+        return True
+    additional = schema.get("additionalProperties")
+    if additional is True or isinstance(additional, dict):
+        return True
+    return any(schema.get(key) for key in ("oneOf", "anyOf", "allOf", "patternProperties", "dependentSchemas"))
+
+
 # ---------------------------------------------------------------------------
 # Value object
 # ---------------------------------------------------------------------------
@@ -218,7 +232,7 @@ class HoudiniCapabilityManifestBuilder:
         affinity = _maybe_str(action.get("affinity"))
         timeout_hint = _maybe_int(action.get("timeout_hint_secs"))
 
-        has_schema = bool(action.get("input_schema") or action.get("inputSchema"))
+        has_schema = _schema_has_arguments(action.get("input_schema") or action.get("inputSchema"))
 
         slug = _slugify_tool_slug(self._dcc_name, name)
         return CapabilityRecord(
@@ -291,7 +305,7 @@ class HoudiniCapabilityManifestBuilder:
         tags = sorted({t for t in tags if t})
 
         schema = tool.get("input_schema") or tool.get("inputSchema")
-        has_schema = bool(schema) and not _is_stub(tool_name)
+        has_schema = _schema_has_arguments(schema) and not _is_stub(tool_name)
 
         return CapabilityRecord(
             tool_slug=_slugify_tool_slug(self._dcc_name, backend_tool),

--- a/src/dcc_mcp_houdini/_resources.py
+++ b/src/dcc_mcp_houdini/_resources.py
@@ -36,6 +36,8 @@ import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
 
+from dcc_mcp_core import register_docs_resource
+
 from dcc_mcp_houdini._env import ENV_RESOURCES, resolve_resources_enabled
 
 logger = logging.getLogger(__name__)
@@ -46,10 +48,30 @@ DEFAULT_SCENE_THROTTLE_SECS: float = 0.5
 #: Houdini-specific dynamic resource URI scheme for node-type help.
 SCHEME_HOUDINI_HELP = "houdini-help://"
 
+#: Short, optional agent workflow for common read-only inspection.
+URI_HOUDINI_AGENT_QUICKSTART = "docs://houdini/agent-quickstart"
+HOUDINI_AGENT_QUICKSTART = """# Houdini agent quickstart
+
+For a warm GUI instance, avoid loading the full workflow guide or repeating
+discovery before every read-only inspection.
+
+1. Call `houdini_scene__inspect_selection({})` for selection, display-SOP
+   point/primitive/packed counts, key attributes, and timeline.
+2. Call `houdini_geometry__get_geometry_info({"node_path": "..."})` only for
+   another SOP path. Follow a correlated search/load hint directly and skip
+   `describe` when a compact schema already supplies the arguments.
+3. Call `houdini_scripting__execute_python` only when no typed tool exposes the
+   required field.
+
+Do not enumerate points or unpack packed geometry merely to count it.
+"""
+
 __all__ = [
     "ENV_RESOURCES",
     "DEFAULT_SCENE_THROTTLE_SECS",
     "SCHEME_HOUDINI_HELP",
+    "URI_HOUDINI_AGENT_QUICKSTART",
+    "HOUDINI_AGENT_QUICKSTART",
     "HoudiniResourceBinder",
     "install_resources",
     "resolve_enabled",
@@ -433,6 +455,13 @@ def install_resources(
     )
     if not binder.bind(server):
         return None
+    register_docs_resource(
+        server,
+        uri=URI_HOUDINI_AGENT_QUICKSTART,
+        name="Houdini agent quickstart",
+        description="Three-step fast path for read-only Houdini scene inspection.",
+        content=HOUDINI_AGENT_QUICKSTART,
+    )
     if install_scene_events:
         binder.install_scene_events()
     return binder

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -15,6 +15,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Task | Chain |
 |------|-------|
 | Verify MCP session | `houdini_scripting__get_session_info` |
+| Inspect selection | `houdini_scene__inspect_selection` (always loaded; selection, display SOP, counts, attributes, timeline) |
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Scene lifecycle | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__open_scene` / `houdini_scene_edit__save_scene` |
 | Select & frame | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__find_nodes` → `houdini_scene_edit__set_selection` → `houdini_scene_edit__get_bounding_box` |

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_geometry_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_geometry_info.py
@@ -13,6 +13,16 @@ def _vec(value) -> list:
         return [float(value[i]) for i in range(len(value))]
 
 
+def _count(geometry, method_name):
+    method = getattr(geometry, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return int(method())
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def get_geometry_info(node_path: str) -> dict:
     """Summarise geometry counts and bounds for *node_path*."""
     try:
@@ -23,19 +33,11 @@ def get_geometry_info(node_path: str) -> dict:
     try:
         node = get_node(hou, node_path)
         geo = cooked_geometry(node)
-        point_count = len(geo.points()) if hasattr(geo, "points") else None
-        prim_count = len(geo.prims()) if hasattr(geo, "prims") else None
-        vertex_count = None
-        if hasattr(geo, "iterVertices"):
-            try:
-                vertex_count = sum(1 for _ in geo.iterVertices())
-            except Exception:  # noqa: BLE001
-                vertex_count = None
         context = {
             "node_path": node.path(),
-            "point_count": point_count,
-            "primitive_count": prim_count,
-            "vertex_count": vertex_count,
+            "point_count": _count(geo, "pointCount"),
+            "primitive_count": _count(geo, "primCount"),
+            "vertex_count": _count(geo, "vertexCount"),
         }
         try:
             bbox = geo.boundingBox()

--- a/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/SKILL.md
@@ -2,9 +2,9 @@
 name: houdini-scene
 description: >-
   Scene skill — read-only inspection of the active Houdini hip file and node
-  graphs. Use when you need frame range, hip path, object-level nodes, or node
-  details. Not for creating geometry, sims, or exports — use authoring or
-  interchange skills.
+  graphs. Use when you need the current selection, display-SOP geometry counts,
+  frame range, hip path, object-level nodes, or node details. Not for creating
+  geometry, sims, or exports — use authoring or interchange skills.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.19.70+"
 allowed-tools: Bash Read Write Edit
@@ -15,8 +15,8 @@ metadata:
     stage: scene
     version: "1.0.0"
     tags: [houdini, scene, hip, nodes, obj]
-    search-hint: "scene info, hip file, list nodes, node details, obj context, frame range"
-    search-aliases: [scene summary, what is in the scene, list nodes, find nodes, hip info, frame range, inspect node, node connections, obj tree]
+    search-hint: "inspect selection, display SOP, packed pieces, point count, scene info, hip file, list nodes, frame range"
+    search-aliases: [inspect selection, selected geometry, packed count, scene summary, what is in the scene, list nodes, find nodes, hip info, frame range, inspect node, node connections, obj tree]
     example-prompts:
       - "What's in the current Houdini scene?"
       - "List all geo nodes under /obj"
@@ -43,8 +43,10 @@ Read-only scene inventory for agents. All tools are `affinity: main` because the
 
 ## Suggested flow
 
-1. `get_scene_info` — hip path, playback range, /obj child count
-2. `list_obj_nodes` or `list_child_nodes` — filter by node type when needed
-3. `get_node_info` — inspect flags, child paths, and connections
+1. `inspect_selection` — selection, display SOP, constant-time geometry counts,
+   key attributes, and timeline in one call
+2. `get_scene_info` — hip path and /obj child count when needed
+3. `list_obj_nodes`, `list_child_nodes`, or `get_node_info` — expand only the
+   relevant graph branch
 
 On failure, load `houdini-scripting` and call `get_session_info`, or use gateway diagnostics when available.

--- a/src/dcc_mcp_houdini/skills/houdini-scene/scripts/inspect_selection.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/scripts/inspect_selection.py
@@ -1,0 +1,186 @@
+"""Inspect the selected Houdini node and its display SOP in one call."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_KEY_ATTRIBUTES = {
+    "point": ("P", "N", "v", "Cd", "id", "name", "orient", "pivot"),
+    "primitive": ("name", "path", "active", "shop_materialpath"),
+    "vertex": ("uv", "N"),
+    "detail": ("name", "path", "frame", "fps"),
+}
+_ATTRIBUTE_FINDERS = {
+    "point": "findPointAttrib",
+    "primitive": "findPrimAttrib",
+    "vertex": "findVertexAttrib",
+    "detail": "findGlobalAttrib",
+}
+_PACKED_TYPE_FALLBACKS = (
+    "PackedFragment",
+    "PackedGeometry",
+    "PackedPrim",
+    "PackedDisk",
+    "PackedDiskSequence",
+)
+
+
+def _call_or_none(obj: Any, method_name: str) -> Any:
+    method = getattr(obj, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return method()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _category_name(node: Any) -> Optional[str]:
+    node_type = _call_or_none(node, "type")
+    category = _call_or_none(node_type, "category")
+    name = _call_or_none(category, "name")
+    return str(name) if name is not None else None
+
+
+def _is_sop(node: Any) -> bool:
+    category = _category_name(node)
+    return bool(category and category.lower() == "sop")
+
+
+def _node_summary(node: Any) -> Optional[Dict[str, Any]]:
+    if node is None:
+        return None
+    node_type = _call_or_none(node, "type")
+    return {
+        "path": _call_or_none(node, "path"),
+        "name": _call_or_none(node, "name"),
+        "type": _call_or_none(node_type, "name"),
+        "category": _category_name(node),
+    }
+
+
+def _current_node(selected: List[Any]) -> Any:
+    for node in selected:
+        if _call_or_none(node, "isCurrent"):
+            return node
+    return selected[-1] if selected else None
+
+
+def _display_sop(selected: List[Any], current: Any) -> Any:
+    candidates = ([current] if current is not None else []) + [node for node in selected if node is not current]
+    for node in candidates:
+        owner = _call_or_none(node, "parent") if _is_sop(node) else node
+        display = _call_or_none(owner, "displayNode")
+        if display is not None and _is_sop(display):
+            return display
+    for node in candidates:
+        if _is_sop(node) and _call_or_none(node, "isDisplayFlagSet"):
+            return node
+    return current if _is_sop(current) else None
+
+
+def _count(geometry: Any, method_name: str) -> Optional[int]:
+    value = _call_or_none(geometry, method_name)
+    return int(value) if value is not None else None
+
+
+def _packed_primitive_counts(geometry: Any) -> Dict[str, int]:
+    count_prim_type = getattr(geometry, "countPrimType", None)
+    if not callable(count_prim_type):
+        return {}
+
+    type_names = _call_or_none(geometry, "primTypeNames")
+    if type_names is None:
+        type_names = _PACKED_TYPE_FALLBACKS
+
+    counts: Dict[str, int] = {}
+    for type_name in type_names:
+        name = str(type_name)
+        if "packed" not in name.lower():
+            continue
+        try:
+            count = int(count_prim_type(type_name))
+        except Exception:  # noqa: BLE001
+            continue
+        if count:
+            counts[name] = count
+    return counts
+
+
+def _key_attribute_names(geometry: Any) -> Dict[str, List[str]]:
+    found: Dict[str, List[str]] = {}
+    for owner, names in _KEY_ATTRIBUTES.items():
+        finder = getattr(geometry, _ATTRIBUTE_FINDERS[owner], None)
+        found[owner] = [name for name in names if callable(finder) and finder(name) is not None]
+    return found
+
+
+def _geometry_summary(node: Any) -> Optional[Dict[str, Any]]:
+    if node is None:
+        return None
+    if _call_or_none(node, "needsToCook") is True:
+        return {"needs_cook": True}
+    geometry_method = getattr(node, "geometry", None)
+    if not callable(geometry_method):
+        return None
+    geometry = geometry_method()
+    if geometry is None:
+        return None
+
+    packed_by_type = _packed_primitive_counts(geometry)
+    return {
+        "needs_cook": False,
+        "point_count": _count(geometry, "pointCount"),
+        "primitive_count": _count(geometry, "primCount"),
+        "vertex_count": _count(geometry, "vertexCount"),
+        "packed_primitive_count": sum(packed_by_type.values()),
+        "packed_primitive_counts": packed_by_type,
+        "key_attributes": _key_attribute_names(geometry),
+    }
+
+
+def _timeline(hou: Any) -> Dict[str, Any]:
+    start_frame, end_frame = hou.playbar.playbackRange()
+    return {
+        "frame": hou.frame(),
+        "start_frame": start_frame,
+        "end_frame": end_frame,
+        "fps": hou.fps(),
+    }
+
+
+def inspect_selection() -> dict:
+    """Return selection, display-SOP geometry counts, attributes, and timeline."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        selected = list(hou.selectedNodes())
+        current = _current_node(selected)
+        display = _display_sop(selected, current)
+        return skill_success(
+            "Inspected Houdini selection",
+            selection=[summary for summary in (_node_summary(node) for node in selected) if summary is not None],
+            current_node=_node_summary(current),
+            display_node=_node_summary(display),
+            geometry=_geometry_summary(display),
+            timeline=_timeline(hou),
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to inspect Houdini selection")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    """Entry point; delegates to :func:`inspect_selection`."""
+    return inspect_selection(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-scene/tools.yaml
@@ -1,4 +1,31 @@
 tools:
+  - name: inspect_selection
+    description: >-
+      Inspect the current selection and its display SOP in one read-only call.
+      Returns constant-time geometry counts, packed primitive counts, key
+      attribute names, and timeline state without enumerating geometry elements.
+    source_file: scripts/inspect_selection.py
+    execution: sync
+    affinity: main
+    group: scene-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    tool_role: read_only
+    risk: low
+    search_aliases: [inspect selection, selected geometry, display sop, packed pieces, point count, timeline]
+    produces: [scene_report]
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      properties: {}
+      additionalProperties: false
+    next-tools:
+      on-failure:
+        - houdini_scripting__get_session_info
   - name: get_scene_info
     description: >-
       Return hip file path, whether a file is saved, current frame, playback

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -14,6 +14,7 @@ from dcc_mcp_houdini._capability_manifest import (
     CapabilityRecord,
     HoudiniCapabilityManifestBuilder,
     _as_dict,
+    _schema_has_arguments,
     build_manifest_payload,
     register_capability_mcp_tool,
 )
@@ -92,7 +93,7 @@ def test_builder_projects_loaded_and_unloaded_actions():
             tags=["python"],
             execution="async",
             timeout_hint_secs=120,
-            input_schema={"type": "object"},
+            input_schema={"type": "object", "properties": {"code": {"type": "string"}}},
         ),
         _action("houdini_render__render", skill="houdini-render", summary="Render", tags=["render"]),
     ]
@@ -119,6 +120,15 @@ def test_builder_projects_loaded_and_unloaded_actions():
     assert rec.has_schema is True
     assert rec.tool_slug == "houdini.instance.houdini_scripting__execute_python"
     assert set(by_name["houdini_scene__get_scene_info"].tags) >= {"scene", "io"}
+
+
+def test_empty_object_schema_does_not_require_describe():
+    assert _schema_has_arguments({"type": "object"}) is False
+    assert _schema_has_arguments({"type": "object", "properties": {}}) is False
+    assert _schema_has_arguments({"type": "object", "additionalProperties": False}) is False
+    assert _schema_has_arguments({"type": "object", "additionalProperties": True}) is True
+    assert _schema_has_arguments({"type": "object", "additionalProperties": {}}) is True
+    assert _schema_has_arguments({"type": "object", "properties": {"node_path": {"type": "string"}}}) is True
 
 
 def test_builder_drops_skill_and_group_stubs():

--- a/tests/test_geometry_mesh_skills.py
+++ b/tests/test_geometry_mesh_skills.py
@@ -61,11 +61,30 @@ class TestGeometrySkills:
         bbox.minvec.return_value = (0.0, 0.0, 0.0)
         bbox.maxvec.return_value = (1.0, 2.0, 3.0)
         bbox.sizevec.return_value = (1.0, 2.0, 3.0)
-        geo = MagicMock()
-        geo.points.return_value = [1, 2, 3, 4]
-        geo.prims.return_value = [1, 2]
-        geo.iterVertices.return_value = iter([1, 2, 3, 4, 5, 6, 7, 8])
-        geo.boundingBox.return_value = bbox
+
+        class PoisonLargeGeometry:
+            def pointCount(self):
+                return 2_280_000
+
+            def primCount(self):
+                return 8_685
+
+            def vertexCount(self):
+                return 26_055
+
+            def boundingBox(self):
+                return bbox
+
+            def points(self):
+                raise AssertionError("get_geometry_info must not enumerate points")
+
+            def prims(self):
+                raise AssertionError("get_geometry_info must not enumerate primitives")
+
+            def iterVertices(self):
+                raise AssertionError("get_geometry_info must not iterate vertices")
+
+        geo = PoisonLargeGeometry()
         node = _node("/obj/geo1/box1", "box1", "box")
         node.geometry.return_value = geo
         mock_hou = MagicMock()
@@ -76,9 +95,9 @@ class TestGeometrySkills:
 
         assert result["success"] is True
         ctx = result["context"]
-        assert ctx["point_count"] == 4
-        assert ctx["primitive_count"] == 2
-        assert ctx["vertex_count"] == 8
+        assert ctx["point_count"] == 2_280_000
+        assert ctx["primitive_count"] == 8_685
+        assert ctx["vertex_count"] == 26_055
         assert ctx["bounds_max"] == [1.0, 2.0, 3.0]
 
     def test_list_attributes_groups_by_class(self) -> None:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -19,7 +19,9 @@ import dcc_mcp_houdini._resources as resources
 from dcc_mcp_houdini._resources import (
     DEFAULT_SCENE_THROTTLE_SECS,
     ENV_RESOURCES,
+    HOUDINI_AGENT_QUICKSTART,
     SCHEME_HOUDINI_HELP,
+    URI_HOUDINI_AGENT_QUICKSTART,
     HoudiniResourceBinder,
     _houdini_help_producer,
     _parse_path_uri,
@@ -81,6 +83,9 @@ class _FakeServer:
         inner = MagicMock()
         inner.resources.return_value = self.resource_handle
         self._server = inner
+
+    def resources(self) -> _RecordingResourceHandle:
+        return self.resource_handle
 
 
 class TestBinderBind:
@@ -216,6 +221,20 @@ class TestInstallResources:
         assert binder is not None
         assert binder.handle is server.resource_handle
         assert binder.scene_publish_count == 1
+
+    def test_registers_compact_agent_quickstart(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_RESOURCES, raising=False)
+        server = _FakeServer()
+        assert install_resources(server, install_scene_events=False) is not None
+
+        producer = server.resource_handle.producers[URI_HOUDINI_AGENT_QUICKSTART]
+        payload = producer(URI_HOUDINI_AGENT_QUICKSTART)
+        assert payload["mimeType"] == "text/markdown"
+        assert payload["text"] == HOUDINI_AGENT_QUICKSTART
+        assert len(payload["text"].encode("utf-8")) <= 2_048
+        assert payload["text"].count("\n1.") == 1
+        assert payload["text"].count("\n2.") == 1
+        assert payload["text"].count("\n3.") == 1
 
     def test_save_as_publishes_registry_scene_after_save(self, monkeypatch: pytest.MonkeyPatch) -> None:
         callbacks: List[Callable[..., None]] = []

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -92,6 +92,9 @@ def test_stage_loader_maps_bootstrap_and_scene() -> None:
     cfg = build_minimal_mode_for_stages(["scene"])
     assert "houdini-scene" in cfg.skills
     assert "houdini-scripting" in cfg.skills
+    scene_tools = yaml.safe_load((_SKILLS_ROOT / "houdini-scene" / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    inspect = next(tool for tool in scene_tools if tool["name"] == "inspect_selection")
+    assert inspect["input_schema"]["additionalProperties"] is False
 
 
 class TestGetSessionInfoSkill:
@@ -143,6 +146,132 @@ class TestGetSceneInfoSkill:
         assert result["success"] is True
         assert result["context"]["obj_node_count"] == 3
         assert result["context"]["end_frame"] == 240
+
+
+class TestInspectSelectionSkill:
+    def test_large_packed_geometry_uses_constant_time_queries(self) -> None:
+        mod = _load_script("houdini-scene", "inspect_selection.py")
+
+        class PoisonLargeGeometry:
+            def pointCount(self):
+                return 2_280_000
+
+            def primCount(self):
+                return 8_685
+
+            def vertexCount(self):
+                return 8_685
+
+            def primTypeNames(self):
+                return ("Poly", "PackedFragment")
+
+            def countPrimType(self, type_name):
+                return 8_685 if type_name == "PackedFragment" else 0
+
+            def findPointAttrib(self, name):
+                return object() if name == "P" else None
+
+            def findPrimAttrib(self, name):
+                return object() if name == "name" else None
+
+            def findVertexAttrib(self, _name):
+                return None
+
+            def findGlobalAttrib(self, _name):
+                return None
+
+            def points(self):
+                raise AssertionError("inspect_selection must not enumerate points")
+
+            def prims(self):
+                raise AssertionError("inspect_selection must not enumerate primitives")
+
+            def iterPoints(self):
+                raise AssertionError("inspect_selection must not iterate points")
+
+            def iterPrims(self):
+                raise AssertionError("inspect_selection must not iterate primitives")
+
+            def iterVertices(self):
+                raise AssertionError("inspect_selection must not iterate vertices")
+
+        parent = MagicMock(spec=["displayNode"])
+        current = _mock_inspection_node(
+            "Sop",
+            "/obj/geo1/material11",
+            "material",
+            "geometry",
+            "isCurrent",
+            "isDisplayFlagSet",
+        )
+        display = _mock_inspection_node(
+            "Sop",
+            "/obj/ue_export/OUT_vat_rbd",
+            "null",
+            "geometry",
+            "isCurrent",
+            "isDisplayFlagSet",
+            "needsToCook",
+        )
+        current.parent.return_value = parent
+        current.isCurrent.return_value = True
+        parent.displayNode.return_value = display
+        display.needsToCook.return_value = False
+        display.geometry.return_value = PoisonLargeGeometry()
+
+        mock_hou = MagicMock()
+        mock_hou.selectedNodes.return_value = (current,)
+        mock_hou.frame.return_value = 42
+        mock_hou.fps.return_value = 24.0
+        mock_hou.playbar.playbackRange.return_value = (1, 160)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.inspect_selection()
+
+        assert result["success"] is True
+        context = result["context"]
+        assert context["selection"][0]["path"] == "/obj/geo1/material11"
+        assert context["display_node"]["path"] == "/obj/ue_export/OUT_vat_rbd"
+        assert context["geometry"]["needs_cook"] is False
+        assert context["geometry"]["point_count"] == 2_280_000
+        assert context["geometry"]["packed_primitive_count"] == 8_685
+        assert context["geometry"]["key_attributes"]["point"] == ["P"]
+        assert context["geometry"]["key_attributes"]["primitive"] == ["name"]
+        assert context["timeline"] == {
+            "frame": 42,
+            "start_frame": 1,
+            "end_frame": 160,
+            "fps": 24.0,
+        }
+        current.geometry.assert_not_called()
+
+    def test_dirty_display_sop_is_not_cooked(self) -> None:
+        mod = _load_script("houdini-scene", "inspect_selection.py")
+        display = _mock_inspection_node(
+            "Sop",
+            "/obj/geo1/OUT_dirty",
+            "null",
+            "geometry",
+            "isCurrent",
+            "isDisplayFlagSet",
+            "needsToCook",
+        )
+        display.isCurrent.return_value = True
+        display.isDisplayFlagSet.return_value = True
+        display.needsToCook.return_value = True
+
+        mock_hou = MagicMock()
+        mock_hou.selectedNodes.return_value = (display,)
+        mock_hou.frame.return_value = 1
+        mock_hou.fps.return_value = 24.0
+        mock_hou.playbar.playbackRange.return_value = (1, 240)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.inspect_selection()
+
+        assert result["success"] is True
+        assert result["context"]["geometry"] == {"needs_cook": True}
+        display.geometry.assert_not_called()
 
 
 class TestListObjNodesSkill:


### PR DESCRIPTION
## Summary
- add a default-loaded read-only selection inspector with constant-time geometry counts
- avoid implicit cooks for dirty SOPs and element enumeration for large geometry
- add a compact quickstart resource and packed-geometry Houdini E2E coverage

## Validation
- `just test` (835 passed, 1 skipped)
- Ruff checks and task-file format checks
- skill metadata validator
- Python 3.7 syntax check

Part of #198.