### PR TITLE
Add selected-node layout control

### DIFF
--- a/src/dcc_mcp_houdini/_flipbook_jobs.py
+++ b/src/dcc_mcp_houdini/_flipbook_jobs.py
@@ -1,0 +1,7 @@
+"""Process-wide storage shared by flipbook tool entrypoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+flipbook_jobs: dict[str, dict[str, Any]] = {}

--- a/src/dcc_mcp_houdini/_vex_executor.py
+++ b/src/dcc_mcp_houdini/_vex_executor.py
@@ -66,7 +66,7 @@ def create_wrangle(hou: Any, spec: WrangleNodeSpec) -> Dict[str, Any]:
     except ValueError as exc:
         return _fail(str(exc))
 
-    sop_type = spec.wrangle_type.value
+    sop_type = "attribwrangle" if spec.wrangle_type is WrangleType.TOPOLOGY_WRANGLE else spec.wrangle_type.value
     node = parent.createNode(sop_type, node_name=spec.node_name)
 
     if node is None:
@@ -111,7 +111,8 @@ def create_wrangle(hou: Any, spec: WrangleNodeSpec) -> Dict[str, Any]:
         "success": True,
         "node_path": node.path(),
         "node_name": node.name(),
-        "wrangle_type": sop_type,
+        "wrangle_type": spec.wrangle_type.value,
+        "node_type": sop_type,
         "run_over": spec.run_over.value,
         "has_snippet": spec.snippet is not None,
     }

--- a/src/dcc_mcp_houdini/_vex_types.py
+++ b/src/dcc_mcp_houdini/_vex_types.py
@@ -144,22 +144,21 @@ class WrangleNodeSpec:
             raise ValueError(f"snippet must be a VexSnippet, got {type(self.snippet)}")
 
 
-# Mapping from VexContext to Houdini's numeric class parameter value
-# (hou.attribType enum values).
-_VEX_CONTEXT_TO_ATTRIB_CLASS: Dict[VexContext, int] = {
-    VexContext.POINTS: 0,
-    VexContext.PRIMITIVES: 1,
-    VexContext.VERTICES: 2,
-    VexContext.DETAIL: 3,
-    VexContext.GLOBAL_VERTICES: 0,
-    VexContext.ATTRIBUTES: 0,
-    VexContext.NUMBERS: 0,
+# Mapping from VexContext to stable Attrib Wrangle menu tokens.
+_VEX_CONTEXT_TO_ATTRIB_CLASS: Dict[VexContext, str] = {
+    VexContext.POINTS: "point",
+    VexContext.PRIMITIVES: "prim",
+    VexContext.VERTICES: "vertex",
+    VexContext.DETAIL: "detail",
+    VexContext.GLOBAL_VERTICES: "point",
+    VexContext.ATTRIBUTES: "point",
+    VexContext.NUMBERS: "point",
 }
 
 
-def vex_context_to_attrib_class(context: VexContext) -> int:
-    """Map a :class:`VexContext` to the ``hou.attribType`` enum value."""
-    return _VEX_CONTEXT_TO_ATTRIB_CLASS.get(context, 0)
+def vex_context_to_attrib_class(context: VexContext) -> str:
+    """Map a :class:`VexContext` to the Attrib Wrangle menu token."""
+    return _VEX_CONTEXT_TO_ATTRIB_CLASS.get(context, "point")
 
 
 @dataclass(frozen=True)

--- a/src/dcc_mcp_houdini/_vex_validator.py
+++ b/src/dcc_mcp_houdini/_vex_validator.py
@@ -47,7 +47,7 @@ _ALLOWED_VEX_PATTERNS: List[re.Pattern] = [
         r"ident|illuminance|import|importdetail|importpoint|importprim|importvertex|"
         r"invert|irradiance|isfinite|isinf|isnan|"
         r"length|length2|lerp|lighter|lookat|"
-        r"match|max|min|minpos|mspace|nearpoint|nearpoints|neighbour|neighbourcount|"
+        r"match|max|min|minpos|mspace|nearpoint|nearpoints|neighbour|neighbourcount|nprimitives|"
         r"neighbours|noise|normalize|ntransform|"
         r"occlusion|onoise|outerproduct|ow_space|"
         r"pbrspecular|pcfilter|pgfind|pgnext|planepointdistance|planeside|"

--- a/src/dcc_mcp_houdini/_vex_validator.py
+++ b/src/dcc_mcp_houdini/_vex_validator.py
@@ -91,6 +91,8 @@ _ALLOWED_VEX_PATTERNS: List[re.Pattern] = [
     re.compile(r"[+\-*/%=<>!&|^~?:@.;,(){}\[\]]"),
 ]
 
+_TOPOLOGY_VEX_FUNCTIONS = {"addpoint", "addprim", "addvertex", "append", "resize"}
+
 
 # Constructs that are FORBIDDEN in any VEX snippet passed through this gateway.
 # These block the "arbitrary script execution" escape hatch.
@@ -162,7 +164,10 @@ _WRANGLE_PARM_RULES: Dict[WrangleType, Dict[str, tuple]] = {
 }
 
 
-def validate_vex_snippet_client(code: str) -> List[VexSyntaxError]:
+def validate_vex_snippet_client(
+    code: str,
+    wrangle_type: WrangleType | str = WrangleType.ATTRIB_WRANGLE,
+) -> List[VexSyntaxError]:
     """Client-side (no ``hou``) VEX snippet validation.
 
     Returns a list of :class:`VexSyntaxError`.  An empty list means the
@@ -202,7 +207,7 @@ def validate_vex_snippet_client(code: str) -> List[VexSyntaxError]:
     # Variable names like `offset`, `x`, `y` are user-defined and not checked.
     func_calls = re.findall(r"([a-zA-Z_]\w*)\s*\(", stripped)
     for token in func_calls:
-        if not _is_allowed_token(token):
+        if not _is_allowed_token(token, wrangle_type):
             line = code[: code.find(token + "(")].count("\n") + 1
             errors.append(
                 VexSyntaxError(
@@ -322,8 +327,11 @@ def _strip_comments_and_strings(code: str) -> str:
     return code
 
 
-def _is_allowed_token(token: str) -> bool:
+def _is_allowed_token(token: str, wrangle_type: WrangleType | str) -> bool:
     """Check if a token matches any allowlist pattern."""
+    type_name = wrangle_type.value if isinstance(wrangle_type, WrangleType) else str(wrangle_type).lower()
+    if type_name == WrangleType.TOPOLOGY_WRANGLE.value and token in _TOPOLOGY_VEX_FUNCTIONS:
+        return True
     for pattern in _ALLOWED_VEX_PATTERNS:
         if pattern.fullmatch(token):
             return True

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/layout_children.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/layout_children.py
@@ -6,8 +6,8 @@ from _node_common import get_node, hou_import_error
 from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
 
 
-def layout_children(parent_path: str = "/obj") -> dict:
-    """Layout children under *parent_path*."""
+def layout_children(parent_path: str = "/obj", selected_only: bool = False) -> dict:
+    """Layout all children or only the selected children under *parent_path*."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
@@ -16,11 +16,17 @@ def layout_children(parent_path: str = "/obj") -> dict:
     try:
         parent = get_node(hou, parent_path)
         children = list(parent.children())
-        parent.layoutChildren()
+        items = [node for node in hou.selectedNodes() if node.parent() == parent] if selected_only else children
+        if selected_only:
+            parent.layoutChildren(items=items)
+        else:
+            parent.layoutChildren()
         return skill_success(
             "Laid out Houdini node children",
             parent_path=parent.path(),
-            child_count=len(children),
+            child_count=len(items),
+            selected_only=selected_only,
+            node_paths=[node.path() for node in items],
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to layout Houdini node children")

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
@@ -276,7 +276,7 @@ tools:
     search_aliases: [cancel cook, stop background cook, terminate cook job]
 
   - name: layout_children
-    description: "Layout children under a Houdini network node. Mutates node positions only."
+    description: "Layout all children or only currently selected children under a Houdini network node, matching the Network Editor L action. Mutates node positions only."
     input_schema:
       type: object
       properties:
@@ -284,6 +284,10 @@ tools:
           type: string
           default: "/obj"
           description: "Network path whose children should be laid out."
+        selected_only:
+          type: boolean
+          default: false
+          description: "When true, arrange only selected nodes that are direct children of parent_path."
     read_only: false
     destructive: false
     idempotent: true
@@ -293,7 +297,7 @@ tools:
     source_file: scripts/layout_children.py
     tool_role: action
     risk: low
-    search_aliases: [layout nodes, arrange network, tidy graph, organize nodes]
+    search_aliases: [layout nodes, arrange selected nodes, network editor L, tidy graph, organize nodes]
     annotations:
       read_only_hint: false
       destructive_hint: false

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/_flipbook_chunked.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/_flipbook_chunked.py
@@ -21,6 +21,8 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 # Import dcc_mcp_core modules
 from dcc_mcp_core.cancellation import CancelledError, CancelToken
 
+from dcc_mcp_houdini._flipbook_jobs import flipbook_jobs as _flipbook_jobs
+
 # ---------------------------------------------------------------------------
 # Embedded ChunkedRunner (PIP-2788, pending next dcc-mcp-core release).
 # Once the release ships this block can be replaced by:
@@ -162,8 +164,6 @@ class ChunkedRunner:
 # ---------------------------------------------------------------------------
 # Flipbook job registry — shared state for launch / poll / cancel
 # ---------------------------------------------------------------------------
-
-_flipbook_jobs: Dict[str, Dict[str, Any]] = {}
 
 
 def _normalize_frame_range(frame_range: List[float]) -> tuple:
@@ -444,6 +444,21 @@ def launch_flipbook_job(
         "warnings": warnings,
         "total_frames": len(chunks),
     }
+
+    def _pump_callback() -> None:
+        job = _flipbook_jobs.get(job_id)
+        if job is None:
+            return
+        job_runner: ChunkedRunner = job["runner"]
+        if not job_runner.is_terminal:
+            job_runner.step()
+        if job_runner.is_terminal:
+            try:
+                hou.ui.removeEventLoopCallback(_pump_callback)
+            except Exception:  # noqa: BLE001
+                pass
+
+    hou.ui.addEventLoopCallback(_pump_callback)
 
     return {
         "success": True,

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/cancel_flipbook_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/cancel_flipbook_job.py
@@ -1,0 +1,11 @@
+"""Cancel a chunked viewport flipbook job."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+from flipbook import cancel_flipbook_job
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return cancel_flipbook_job(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_flipbook_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/get_flipbook_job.py
@@ -1,0 +1,11 @@
+"""Read a chunked viewport flipbook job."""
+
+from __future__ import annotations
+
+from dcc_mcp_core.skill import skill_entry
+from flipbook import get_flipbook_job
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_flipbook_job(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -72,7 +72,7 @@ tools:
       Read bounded status, output progress, and written files for a chunked
       flipbook job. Terminal states (completed/cancelled/failed) report
       written_files and skipped_frames.
-    source_file: scripts/flipbook.py
+    source_file: scripts/get_flipbook_job.py
     execution: sync
     affinity: any
     timeout_hint_secs: 10
@@ -93,7 +93,7 @@ tools:
           description: "Job identifier returned by the flipbook launch."
   - name: cancel_flipbook_job
     description: Cancel a running chunked flipbook job. Repeated calls are safe.
-    source_file: scripts/flipbook.py
+    source_file: scripts/cancel_flipbook_job.py
     execution: sync
     affinity: any
     timeout_hint_secs: 10

--- a/src/dcc_mcp_houdini/skills/houdini-scripting/scripts/get_session_info.py
+++ b/src/dcc_mcp_houdini/skills/houdini-scripting/scripts/get_session_info.py
@@ -12,7 +12,11 @@ def get_session_info() -> dict:
     try:
         import hou  # noqa: PLC0415
 
+        import dcc_mcp_houdini  # noqa: PLC0415
+
         info = {
+            "adapter_version": dcc_mcp_houdini.__version__,
+            "adapter_module_path": dcc_mcp_houdini.__file__,
             "houdini_version": ".".join(str(v) for v in hou.applicationVersion()),
             "houdini_version_string": hou.applicationVersionString(),
             "python_version": sys.version,

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/create_wrangle.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/create_wrangle.py
@@ -31,15 +31,19 @@ def create_wrangle(
 
     try:
         from dcc_mcp_houdini._vex_executor import create_wrangle as _create
-        from dcc_mcp_houdini._vex_types import VexSnippet, WrangleNodeSpec
+        from dcc_mcp_houdini._vex_types import VexContext, VexSnippet, WrangleNodeSpec
         from dcc_mcp_houdini._vex_validator import validate_vex_snippet_client
     except ImportError as exc:
         return skill_error("VEX module not available", str(exc))
 
     # ── Build snippet if VEX code provided ─────────────────────────────
+    resolved_wrangle_type = resolve_wrangle_type(wrangle_type)
+    resolved_run_over = (
+        VexContext.DETAIL if resolved_wrangle_type.value == "topologywrangle" else resolve_vex_context(run_over)
+    )
     snippet = None
     if vex_code:
-        client_errors = validate_vex_snippet_client(vex_code)
+        client_errors = validate_vex_snippet_client(vex_code, resolved_wrangle_type)
         if client_errors:
             return skill_error(
                 "VEX snippet validation failed",
@@ -50,7 +54,7 @@ def create_wrangle(
         try:
             snippet = VexSnippet(
                 code=vex_code,
-                context=resolve_vex_context(run_over),
+                context=resolved_run_over,
                 bindings=bindings or {},
                 parameter_values=parameters or {},
             )
@@ -60,8 +64,8 @@ def create_wrangle(
     spec = WrangleNodeSpec(
         parent_path=parent_path,
         node_name=node_name,
-        wrangle_type=resolve_wrangle_type(wrangle_type),
-        run_over=resolve_vex_context(run_over),
+        wrangle_type=resolved_wrangle_type,
+        run_over=resolved_run_over,
         snippet=snippet,
         set_display=set_display,
         set_render=set_render,

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/update_vex_snippet.py
@@ -11,6 +11,7 @@ from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 def update_vex_snippet(
     node_path: str,
     vex_code: str,
+    wrangle_type: str = "attribwrangle",
     run_over: Optional[str] = None,
     bindings: Optional[Dict[str, str]] = None,
     parameters: Optional[Dict[str, Any]] = None,
@@ -34,7 +35,7 @@ def update_vex_snippet(
         return skill_error("VEX module not available", str(exc))
 
     # ── Client-side validation ─────────────────────────────────────────
-    client_errors = validate_vex_snippet_client(vex_code)
+    client_errors = validate_vex_snippet_client(vex_code, wrangle_type)
     if client_errors:
         return skill_error(
             "VEX snippet validation failed",

--- a/src/dcc_mcp_houdini/skills/houdini-vex/scripts/validate_vex_syntax.py
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/scripts/validate_vex_syntax.py
@@ -27,7 +27,7 @@ def validate_vex_syntax(
         return skill_error("VEX module not available", str(exc))
 
     # ── Client-side syntax check ───────────────────────────────────────
-    errors = validate_vex_snippet_client(vex_code)
+    errors = validate_vex_snippet_client(vex_code, wrangle_type)
 
     # ── Attribute binding check ────────────────────────────────────────
     if known_attributes:

--- a/src/dcc_mcp_houdini/skills/houdini-vex/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-vex/tools.yaml
@@ -97,6 +97,11 @@ tools:
         vex_code:
           type: string
           description: New VEX snippet (validated client-side before commit).
+        wrangle_type:
+          type: string
+          default: attribwrangle
+          enum: [attribwrangle, volumewrangle, geometrywrangle, pointwrangle, primitivewrangle, vertexwrangle, detailwrangle, topologywrangle]
+          description: Semantic wrangle type used for context-aware validation.
         run_over:
           type: string
           enum: [points, prims, verts, detail, global, attribs, numbers]

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -56,6 +56,13 @@ def _load_render_worker() -> ModuleType:
     return _load_script("houdini-render", "_render_worker.py")
 
 
+def test_flipbook_registry_is_shared_across_tool_module_loads() -> None:
+    first = _load_script("houdini-render", "_flipbook_chunked.py")
+    second = _load_script("houdini-render", "_flipbook_chunked.py")
+
+    assert first._flipbook_jobs is second._flipbook_jobs
+
+
 def _node(path: str, name: str, type_name: str = "geo") -> MagicMock:
     node = MagicMock()
     node.path.return_value = path
@@ -556,6 +563,7 @@ class TestViewportCapture:
         assert ctx["frame_range"] == [1.0, 10.0, 3.0]
         assert ctx["camera_path"] == "/obj/shotcam"
         assert ctx["progress"] == {"completed": 0, "total": 4}
+        mock_hou.ui.addEventLoopCallback.assert_called_once()
 
     def test_flipbook_rejects_non_positive_increment(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "flipbook.py")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -501,6 +501,27 @@ class TestSceneNodeInspectionSkills:
 
 
 class TestNodeSkills:
+    def test_layout_children_can_match_network_editor_selected_layout(self) -> None:
+        mod = _load_script("houdini-nodes", "layout_children.py")
+        parent = MagicMock()
+        parent.path.return_value = "/obj/geo1"
+        selected = MagicMock()
+        selected.path.return_value = "/obj/geo1/box1"
+        selected.parent.return_value = parent
+        sibling = MagicMock()
+        sibling.parent.return_value = parent
+        parent.children.return_value = [selected, sibling]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+        mock_hou.selectedNodes.return_value = [selected]
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.layout_children("/obj/geo1", selected_only=True)
+
+        assert result["success"] is True
+        parent.layoutChildren.assert_called_once_with(items=[selected])
+        assert result["context"]["node_paths"] == ["/obj/geo1/box1"]
+
     def test_create_node_with_mock_hou(self) -> None:
         mod = _load_script("houdini-nodes", "create_node.py")
         child = MagicMock()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -66,6 +66,15 @@ def test_tools_yaml_contract(skill_dir: str) -> None:
             assert tool.get("timeout_hint_secs"), f"{tool['name']} missing timeout_hint_secs"
 
 
+def test_flipbook_job_tools_have_dedicated_entrypoints() -> None:
+    tools_path = _SKILLS_ROOT / "houdini-render" / "tools.yaml"
+    tools = yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]
+    sources = {tool["name"]: tool["source_file"] for tool in tools}
+
+    assert sources["get_flipbook_job"] == "scripts/get_flipbook_job.py"
+    assert sources["cancel_flipbook_job"] == "scripts/cancel_flipbook_job.py"
+
+
 @pytest.mark.parametrize(
     ("skill_name", "tool_name"),
     (
@@ -182,6 +191,7 @@ class TestGetSessionInfoSkill:
 
     def test_with_mock_hou(self) -> None:
         mod = _load_script("houdini-scripting", "get_session_info.py")
+        mock_adapter = MagicMock(__version__="0.28.0", __file__="/tmp/dcc_mcp_houdini/__init__.py")
         mock_hou = MagicMock()
         mock_hou.applicationVersion.return_value = (20, 5, 0)
         mock_hou.applicationVersionString.return_value = "20.5.0"
@@ -189,10 +199,12 @@ class TestGetSessionInfoSkill:
         mock_hou.hipFile.isNewFile.return_value = False
         mock_hou.hipFile.name.return_value = "/tmp/test.hip"
 
-        with patch.dict(sys.modules, {"hou": mock_hou}):
+        with patch.dict(sys.modules, {"dcc_mcp_houdini": mock_adapter, "hou": mock_hou}):
             result = mod.get_session_info()
 
         assert result["success"] is True
+        assert result["context"]["adapter_version"] == "0.28.0"
+        assert result["context"]["adapter_module_path"] == "/tmp/dcc_mcp_houdini/__init__.py"
         assert result["context"]["houdini_version_string"] == "20.5.0"
         assert result["context"]["hip_file"] == "/tmp/test.hip"
 

--- a/tests/test_vex_skills.py
+++ b/tests/test_vex_skills.py
@@ -100,7 +100,7 @@ class TestCreateWrangle:
         assert result["context"]["has_snippet"] is True
         parent.createNode.assert_called_once_with("pointwrangle", node_name=None)
         snip_parm.set.assert_called_once_with(snippet)
-        class_parm.set.assert_called_once_with(0)  # points -> 0
+        class_parm.set.assert_called_once_with("point")
 
     def test_create_wrangle_rejects_forbidden_vex(self) -> None:
         mod = _load_script("houdini-vex", "create_wrangle.py")
@@ -113,6 +113,30 @@ class TestCreateWrangle:
 
         assert result["success"] is False
         assert "validation" in str(result.get("error", "")).lower()
+
+    def test_create_topology_wrangle_uses_detail_attrib_wrangle(self) -> None:
+        mod = _load_script("houdini-vex", "create_wrangle.py")
+        new = _node("/obj/geo1/topology1", "topology1", "attribwrangle")
+        snip_parm = MagicMock()
+        class_parm = MagicMock()
+        new.parm.side_effect = lambda name: {"snippet": snip_parm, "class": class_parm}.get(name)
+        parent = _node("/obj/geo1", "geo1")
+        parent.createNode.return_value = new
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_wrangle(
+                parent_path="/obj/geo1",
+                wrangle_type="topologywrangle",
+                vex_code='int point = addpoint(0, {0, 0, 0}); int prim = addprim(0, "poly"); addvertex(0, prim, point);',
+            )
+
+        assert result["success"] is True
+        assert result["context"]["wrangle_type"] == "topologywrangle"
+        assert result["context"]["node_type"] == "attribwrangle"
+        parent.createNode.assert_called_once_with("attribwrangle", node_name=None)
+        class_parm.set.assert_called_once_with("detail")
 
     def test_create_wrangle_rejects_empty_vex(self) -> None:
         mod = _load_script("houdini-vex", "create_wrangle.py")
@@ -295,7 +319,7 @@ class TestUpdateVexSnippet:
             )
 
         assert result["success"] is True
-        class_parm.set.assert_called_once_with(1)  # prims -> 1
+        class_parm.set.assert_called_once_with("prim")
 
     def test_update_no_snippet_parm(self) -> None:
         mod = _load_script("houdini-vex", "update_vex_snippet.py")

--- a/tests/test_vex_skills.py
+++ b/tests/test_vex_skills.py
@@ -267,6 +267,29 @@ class TestUpdateVexSnippet:
         snip_parm.set.assert_called_once_with(new_snippet)
         class_parm.set.assert_not_called()
 
+    def test_update_topology_wrangle_allows_topology_functions(self) -> None:
+        mod = _load_script("houdini-vex", "update_vex_snippet.py")
+        snippet = 'int point = addpoint(0, {0, 0, 0}); int prim = addprim(0, "poly"); addvertex(0, prim, point);'
+        snip_parm = MagicMock()
+        snip_parm.evalAsString.return_value = ""
+        class_parm = MagicMock()
+        node = _node("/obj/geo1/topology1", "topology1", "attribwrangle")
+        node.parm.side_effect = lambda name: {"snippet": snip_parm, "class": class_parm}.get(name)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.update_vex_snippet(
+                node_path="/obj/geo1/topology1",
+                vex_code=snippet,
+                wrangle_type="topologywrangle",
+                run_over="detail",
+            )
+
+        assert result["success"] is True
+        snip_parm.set.assert_called_once_with(snippet)
+        class_parm.set.assert_called_once_with("detail")
+
     def test_update_with_validation_rejects_forbidden(self) -> None:
         mod = _load_script("houdini-vex", "update_vex_snippet.py")
 

--- a/tests/test_vex_types.py
+++ b/tests/test_vex_types.py
@@ -246,19 +246,19 @@ class TestVexContextToAttribClass:
     def test_points_maps_to_0(self) -> None:
         from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
 
-        assert vex_context_to_attrib_class(VexContext.POINTS) == 0
+        assert vex_context_to_attrib_class(VexContext.POINTS) == "point"
 
     def test_primitives_maps_to_1(self) -> None:
         from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
 
-        assert vex_context_to_attrib_class(VexContext.PRIMITIVES) == 1
+        assert vex_context_to_attrib_class(VexContext.PRIMITIVES) == "prim"
 
     def test_vertices_maps_to_2(self) -> None:
         from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
 
-        assert vex_context_to_attrib_class(VexContext.VERTICES) == 2
+        assert vex_context_to_attrib_class(VexContext.VERTICES) == "vertex"
 
     def test_detail_maps_to_3(self) -> None:
         from dcc_mcp_houdini._vex_types import vex_context_to_attrib_class
 
-        assert vex_context_to_attrib_class(VexContext.DETAIL) == 3
+        assert vex_context_to_attrib_class(VexContext.DETAIL) == "detail"

--- a/tests/test_vex_validator.py
+++ b/tests/test_vex_validator.py
@@ -87,6 +87,9 @@ float d = dot(n, {0, 1, 0});
         assert validate_vex_snippet_client(snippet)
         assert validate_vex_snippet_client(snippet, WrangleType.TOPOLOGY_WRANGLE) == []
 
+    def test_geometry_count_query_is_allowed(self) -> None:
+        assert validate_vex_snippet_client("int count = nprimitives(0);") == []
+
 
 # ---------------------------------------------------------------------------
 # validate_vex_snippet_client — deny list

--- a/tests/test_vex_validator.py
+++ b/tests/test_vex_validator.py
@@ -82,6 +82,11 @@ float d = dot(n, {0, 1, 0});
         errors = validate_vex_snippet_client(snippet)
         assert len(errors) == 0
 
+    def test_topology_functions_require_topology_wrangle(self) -> None:
+        snippet = 'int point = addpoint(0, {0, 0, 0}); int prim = addprim(0, "poly"); addvertex(0, prim, point);'
+        assert validate_vex_snippet_client(snippet)
+        assert validate_vex_snippet_client(snippet, WrangleType.TOPOLOGY_WRANGLE) == []
+
 
 # ---------------------------------------------------------------------------
 # validate_vex_snippet_client — deny list


### PR DESCRIPTION
Adds a typed selected-only mode to node layout, matching Houdini's Network Editor L action. Also permits the read-only nprimitives VEX query encountered during live topology authoring.\n\nValidation: 850 passed, 1 skipped; live Houdini selected-node layout verified.