### PR TITLE
Add selected-node layout control

### DIFF
--- a/src/dcc_mcp_houdini/_vex_validator.py
+++ b/src/dcc_mcp_houdini/_vex_validator.py
@@ -47,7 +47,7 @@ _ALLOWED_VEX_PATTERNS: List[re.Pattern] = [
         r"ident|illuminance|import|importdetail|importpoint|importprim|importvertex|"
         r"invert|irradiance|isfinite|isinf|isnan|"
         r"length|length2|lerp|lighter|lookat|"
-        r"match|max|min|minpos|mspace|nearpoint|nearpoints|neighbour|neighbourcount|"
+        r"match|max|min|minpos|mspace|nearpoint|nearpoints|neighbour|neighbourcount|nprimitives|"
         r"neighbours|noise|normalize|ntransform|"
         r"occlusion|onoise|outerproduct|ow_space|"
         r"pbrspecular|pcfilter|pgfind|pgnext|planepointdistance|planeside|"

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/layout_children.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/layout_children.py
@@ -6,8 +6,8 @@ from _node_common import get_node, hou_import_error
 from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
 
 
-def layout_children(parent_path: str = "/obj") -> dict:
-    """Layout children under *parent_path*."""
+def layout_children(parent_path: str = "/obj", selected_only: bool = False) -> dict:
+    """Layout all children or only the selected children under *parent_path*."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
@@ -16,11 +16,17 @@ def layout_children(parent_path: str = "/obj") -> dict:
     try:
         parent = get_node(hou, parent_path)
         children = list(parent.children())
-        parent.layoutChildren()
+        items = [node for node in hou.selectedNodes() if node.parent() == parent] if selected_only else children
+        if selected_only:
+            parent.layoutChildren(items=items)
+        else:
+            parent.layoutChildren()
         return skill_success(
             "Laid out Houdini node children",
             parent_path=parent.path(),
-            child_count=len(children),
+            child_count=len(items),
+            selected_only=selected_only,
+            node_paths=[node.path() for node in items],
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to layout Houdini node children")

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
@@ -276,7 +276,7 @@ tools:
     search_aliases: [cancel cook, stop background cook, terminate cook job]
 
   - name: layout_children
-    description: "Layout children under a Houdini network node. Mutates node positions only."
+    description: "Layout all children or only currently selected children under a Houdini network node, matching the Network Editor L action. Mutates node positions only."
     input_schema:
       type: object
       properties:
@@ -284,6 +284,10 @@ tools:
           type: string
           default: "/obj"
           description: "Network path whose children should be laid out."
+        selected_only:
+          type: boolean
+          default: false
+          description: "When true, arrange only selected nodes that are direct children of parent_path."
     read_only: false
     destructive: false
     idempotent: true
@@ -293,7 +297,7 @@ tools:
     source_file: scripts/layout_children.py
     tool_role: action
     risk: low
-    search_aliases: [layout nodes, arrange network, tidy graph, organize nodes]
+    search_aliases: [layout nodes, arrange selected nodes, network editor L, tidy graph, organize nodes]
     annotations:
       read_only_hint: false
       destructive_hint: false

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -501,6 +501,27 @@ class TestSceneNodeInspectionSkills:
 
 
 class TestNodeSkills:
+    def test_layout_children_can_match_network_editor_selected_layout(self) -> None:
+        mod = _load_script("houdini-nodes", "layout_children.py")
+        parent = MagicMock()
+        parent.path.return_value = "/obj/geo1"
+        selected = MagicMock()
+        selected.path.return_value = "/obj/geo1/box1"
+        selected.parent.return_value = parent
+        sibling = MagicMock()
+        sibling.parent.return_value = parent
+        parent.children.return_value = [selected, sibling]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+        mock_hou.selectedNodes.return_value = [selected]
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.layout_children("/obj/geo1", selected_only=True)
+
+        assert result["success"] is True
+        parent.layoutChildren.assert_called_once_with(items=[selected])
+        assert result["context"]["node_paths"] == ["/obj/geo1/box1"]
+
     def test_create_node_with_mock_hou(self) -> None:
         mod = _load_script("houdini-nodes", "create_node.py")
         child = MagicMock()

--- a/tests/test_vex_validator.py
+++ b/tests/test_vex_validator.py
@@ -87,6 +87,9 @@ float d = dot(n, {0, 1, 0});
         assert validate_vex_snippet_client(snippet)
         assert validate_vex_snippet_client(snippet, WrangleType.TOPOLOGY_WRANGLE) == []
 
+    def test_geometry_count_query_is_allowed(self) -> None:
+        assert validate_vex_snippet_client("int count = nprimitives(0);") == []
+
 
 # ---------------------------------------------------------------------------
 # validate_vex_snippet_client — deny list


### PR DESCRIPTION
Adds a typed selected-only mode to node layout, matching Houdini's Network Editor L action. Also permits the read-only nprimitives VEX query encountered during live topology authoring.\n\nValidation: 850 passed, 1 skipped; live Houdini selected-node layout verified.