### PR TITLE
fix: honor husk frame selection

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import shutil
 from typing import Any, Optional, Sequence
@@ -120,9 +121,29 @@ def build_husk_command(
         cmd.extend(["--res", str(int(resolution[0])), str(int(resolution[1]))])
 
     if frame_range and len(frame_range) >= 2:
-        cmd.extend(["--frame", str(float(frame_range[0])), str(float(frame_range[1]))])
+        start = float(frame_range[0])
+        end = float(frame_range[1])
+        increment = float(frame_range[2]) if len(frame_range) >= 3 else 1.0
+        if increment <= 0:
+            raise ValueError("frame range increment must be greater than zero")
+        if end < start:
+            raise ValueError("frame range end must not be less than start")
+        frame_count = int(math.floor((end - start) / increment)) + 1
+        cmd.extend(
+            [
+                "--frame",
+                str(start),
+                "--frame-count",
+                str(frame_count),
+                "--frame-inc",
+                str(increment),
+            ]
+        )
     elif frame is not None:
-        cmd.extend(["--frame", str(int(frame))])
+        # Husk derives frame count from USD stage metadata unless it is
+        # explicitly overridden.  A single-frame request must therefore
+        # clamp the count even when the stage advertises an animation range.
+        cmd.extend(["--frame", str(int(frame)), "--frame-count", "1"])
 
     if output_path:
         cmd.extend(["--output", output_path])

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -33,6 +33,34 @@ def test_build_husk_command_resolves_karma_alias() -> None:
     assert command[:3] == ["husk", "--renderer", "BRAY_HdKarma"]
 
 
+def test_build_husk_command_clamps_single_frame() -> None:
+    common = _load_script("_husk_common.py")
+
+    command = common.build_husk_command("scene.usda", "beauty.exr", frame=8)
+
+    assert command[command.index("--frame") : command.index("--frame") + 4] == [
+        "--frame",
+        "8",
+        "--frame-count",
+        "1",
+    ]
+
+
+def test_build_husk_command_converts_frame_range_to_husk_contract() -> None:
+    common = _load_script("_husk_common.py")
+
+    command = common.build_husk_command("scene.usda", "beauty.$F4.exr", frame_range=[1, 12, 2])
+
+    assert command[command.index("--frame") : command.index("--frame") + 6] == [
+        "--frame",
+        "1.0",
+        "--frame-count",
+        "6",
+        "--frame-inc",
+        "2.0",
+    ]
+
+
 def test_husk_environment_restores_houdini_default_paths() -> None:
     common = _load_script("_husk_common.py")
     base = {"HOUDINI_PATH": "custom", "HOUDINI_SCRIPT_PATH": ""}


### PR DESCRIPTION
## Summary
- clamp single-frame renders with an explicit frame count
- translate frame ranges to husk start/count/increment options
- add command-contract regression coverage

## Validation
- 8 focused tests passed
- Ruff passed
- verified against Houdini 22 husk with an animated USD stage