### PR TITLE
fix: require abi3 core wheels in quickinstall

### DIFF
--- a/packaging/assemble_houdini_package.py
+++ b/packaging/assemble_houdini_package.py
@@ -79,9 +79,28 @@ def assert_versions_aligned() -> None:
 def resolve_core_version(min_version: str = MIN_CORE_VERSION) -> str:
     data = _fetch_json(PYPI_URL.format(package=CORE_PACKAGE))
     available = [Version(v) for v in data["releases"].keys() if not Version(v).is_prerelease]
-    compatible = [v for v in available if v >= Version(min_version) and v < Version("1.0.0")]
+    compatible = [
+        v
+        for v in available
+        if v >= Version(min_version)
+        and v < Version("1.0.0")
+        and all(
+            any(
+                "abi3" in str(item.get("filename", ""))
+                and _wheel_matches_platform(str(item.get("filename", "")), platform)
+                for item in data["releases"][str(v)]
+            )
+            for platform in PLATFORMS
+        )
+    ]
     if not compatible:
-        raise RuntimeError("No compatible {} release found >= {}".format(CORE_PACKAGE, min_version))
+        raise RuntimeError(
+            "No compatible {} release found >= {} with abi3 wheels for {}".format(
+                CORE_PACKAGE,
+                min_version,
+                ", ".join(PLATFORMS),
+            )
+        )
     return str(sorted(compatible)[-1])
 
 
@@ -544,7 +563,10 @@ def _readme(version: str, core_version: str, platform: str, explicit_core_versio
     if explicit_core_version:
         core_policy = "explicit validated dcc-mcp-core {}.".format(core_version)
     else:
-        core_policy = "latest non-prerelease dcc-mcp-core >= {},<1.0.0 at assembly time.".format(MIN_CORE_VERSION)
+        core_policy = (
+            "latest non-prerelease dcc-mcp-core >= {},<1.0.0 with abi3 wheels "
+            "for every release platform at assembly time."
+        ).format(MIN_CORE_VERSION)
     return """dcc-mcp-houdini quick install package
 ======================================
 
@@ -634,6 +656,13 @@ def verify_quickinstall_zip(
     wrong_platform = [name for name in core_wheels if not _wheel_matches_platform(name, platform)]
     if wrong_platform:
         raise RuntimeError("Core wheels do not match platform {}: {}".format(platform, ", ".join(wrong_platform)))
+    if not any("abi3" in name for name in core_wheels):
+        raise RuntimeError(
+            "Core wheels for {} require an abi3 build for supported Houdini Python versions: {}".format(
+                platform,
+                ", ".join(core_wheels),
+            )
+        )
 
     return {
         "platform": platform,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -195,6 +195,20 @@ def test_verify_quickinstall_zip_rejects_bundled_core_drift(tmp_path: Path) -> N
         pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.70")
 
 
+def test_verify_quickinstall_zip_rejects_python_specific_core_only(tmp_path: Path) -> None:
+    pkg = _load_packaging_script()
+
+    zip_path = tmp_path / "dcc_mcp_houdini_quickinstall_win64_v0.10.1.zip"
+    _write_quickinstall_zip(
+        zip_path,
+        "dcc_mcp_houdini-{}-py3-none-any.whl".format(pkg.get_package_version()),
+        "dcc_mcp_core-0.19.92-cp37-cp37m-win_amd64.whl",
+    )
+
+    with pytest.raises(RuntimeError, match="require an abi3 build"):
+        pkg.verify_quickinstall_zip(zip_path, "win64", expected_core_version="0.19.92")
+
+
 def test_verify_quickinstall_zip_requires_scene_load_hook(tmp_path: Path) -> None:
     pkg = _load_packaging_script()
 
@@ -455,3 +469,24 @@ def test_pick_core_wheels_includes_py37_and_abi3_for_platform() -> None:
         "dcc_mcp_core-0.18.2-cp311-cp311-win_amd64.whl",
         "dcc_mcp_core-0.18.2-cp37-cp37m-win_amd64.whl",
     ]
+
+
+def test_resolve_core_version_skips_release_without_cross_platform_abi3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pkg = _load_packaging_script()
+    releases = {
+        "0.19.91": [
+            {"filename": "dcc_mcp_core-0.19.91-cp38-abi3-win_amd64.whl"},
+            {"filename": "dcc_mcp_core-0.19.91-cp38-abi3-manylinux_2_17_x86_64.whl"},
+            {"filename": "dcc_mcp_core-0.19.91-cp38-abi3-macosx_11_0_universal2.whl"},
+        ],
+        "0.19.92": [
+            {"filename": "dcc_mcp_core-0.19.92-cp37-cp37m-win_amd64.whl"},
+            {"filename": "dcc_mcp_core-0.19.92-cp38-abi3-manylinux_2_17_x86_64.whl"},
+            {"filename": "dcc_mcp_core-0.19.92-cp38-abi3-macosx_11_0_universal2.whl"},
+        ],
+    }
+    monkeypatch.setattr(pkg, "_fetch_json", lambda _url: {"releases": releases})
+
+    assert pkg.resolve_core_version() == "0.19.91"


### PR DESCRIPTION
Prevents quickinstall releases from selecting a Core version that only provides a Python-specific wheel on one platform. Resolution now requires abi3 wheels across all release platforms, and ZIP verification rejects packages without an abi3 Core wheel.\n\nRegression: the previous Windows package fell back to dispatch-only mode in Houdini 22; the rebuilt package loads native Core, passes all readiness bits, exposes the complete 29-field LookDev schema, and completes validation.\n\nValidation: 16 focused tests passed; Ruff passed.