### PR TITLE
Fix Husk output artifact tracking

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/render_with_husk.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/render_with_husk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import time
 from typing import List, Optional
@@ -15,6 +16,42 @@ from _husk_common import (  # noqa: E402
     resolve_husk_renderer,
 )
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_FRAME_TOKEN = re.compile(r"\$F(\d*)")
+
+
+def _expand_frame_token(output_path: str, frame: float) -> str:
+    """Expand Houdini's $F/$F4-style token for artifact verification."""
+    if not float(frame).is_integer():
+        return output_path
+    frame_number = int(frame)
+
+    def replace(match: re.Match[str]) -> str:
+        width = int(match.group(1) or 0)
+        return str(frame_number).zfill(width) if width else str(frame_number)
+
+    return _FRAME_TOKEN.sub(replace, output_path)
+
+
+def _expected_output_paths(
+    output_path: str,
+    frame: Optional[int],
+    frame_range: Optional[List[float]],
+) -> list[str]:
+    if frame is not None:
+        return [_expand_frame_token(output_path, frame)]
+    if frame_range:
+        start, end = float(frame_range[0]), float(frame_range[1])
+        increment = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+        if increment <= 0:
+            return []
+        frame_values = []
+        current = start
+        while current <= end + 1.0e-9:
+            frame_values.append(current)
+            current += increment
+        return [_expand_frame_token(output_path, value) for value in frame_values]
+    return [output_path]
 
 
 def render_with_husk(
@@ -79,6 +116,10 @@ def render_with_husk(
         )
 
     try:
+        output_directory = os.path.dirname(os.path.abspath(output_path))
+        if output_directory:
+            os.makedirs(output_directory, exist_ok=True)
+
         resolved_renderer = resolve_husk_renderer(renderer)
         cmd = build_husk_command(
             usd_file=usd_file,
@@ -101,15 +142,13 @@ def render_with_husk(
         )
         elapsed = round(time.time() - start, 3)
 
-        written_files: list = []
-        if os.path.isfile(output_path):
-            written_files.append(output_path)
-        # Check for frame-padded files
-        if frame_range and not written_files:
+        written_files = [
+            path for path in _expected_output_paths(output_path, frame, frame_range) if os.path.isfile(path)
+        ]
+        if not written_files and _FRAME_TOKEN.search(output_path):
             import glob
 
-            base, ext = os.path.splitext(output_path)
-            written_files = sorted(glob.glob("{}.*{}".format(base, ext)))
+            written_files = sorted(glob.glob(_FRAME_TOKEN.sub("*", output_path)))
 
         context = {
             "usd_file": usd_file,

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -87,6 +87,54 @@ def test_render_with_husk_returns_failure_for_nonzero_exit(tmp_path: Path) -> No
     assert "delegate failed" in result["error"]
 
 
+def test_render_with_husk_creates_parent_and_reports_single_frame_pattern(tmp_path: Path) -> None:
+    render = _load_script("render_with_husk.py")
+    output_pattern = tmp_path / "new" / "review" / "beauty.$F4.exr"
+    expected_output = tmp_path / "new" / "review" / "beauty.0007.exr"
+    process = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def run_husk(*_args, **_kwargs):
+        assert output_pattern.parent.is_dir()
+        expected_output.write_bytes(b"render")
+        return process
+
+    with patch.object(render, "find_husk", return_value="husk"), patch.object(
+        render.subprocess, "run", side_effect=run_husk
+    ):
+        result = render.render_with_husk(
+            str(tmp_path / "scene.usda"),
+            str(output_pattern),
+            frame=7,
+        )
+
+    assert result["success"] is True
+    assert result["context"]["written_files"] == [str(expected_output)]
+
+
+def test_render_with_husk_reports_frame_range_pattern(tmp_path: Path) -> None:
+    render = _load_script("render_with_husk.py")
+    output_pattern = tmp_path / "sequence" / "beauty.$F4.exr"
+    expected_outputs = [output_pattern.parent / f"beauty.{frame:04d}.exr" for frame in (1, 3, 5)]
+    process = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def run_husk(*_args, **_kwargs):
+        for output in expected_outputs:
+            output.write_bytes(b"render")
+        return process
+
+    with patch.object(render, "find_husk", return_value="husk"), patch.object(
+        render.subprocess, "run", side_effect=run_husk
+    ):
+        result = render.render_with_husk(
+            str(tmp_path / "scene.usda"),
+            str(output_pattern),
+            frame_range=[1, 5, 2],
+        )
+
+    assert result["success"] is True
+    assert result["context"]["written_files"] == [str(output) for output in expected_outputs]
+
+
 class _SnapshotParm:
     def __init__(self, rop, name: str) -> None:
         self.rop = rop


### PR DESCRIPTION
## Summary
- create output directories before launching Husk
- resolve Houdini frame tokens for single-frame and range renders
- report rendered artifacts reliably

## Validation
- 17 focused tests passed
- live Houdini 22 Karma render passed with a new output directory and $F4 pattern