### PR TITLE
fix: harden Houdini UI debug workflow

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-dev/scripts/ui_action.py
+++ b/src/dcc_mcp_houdini/skills/houdini-dev/scripts/ui_action.py
@@ -42,8 +42,28 @@ def ui_action(action: str, value: Optional[str] = None) -> dict:
             target = next((d for d in hou.ui.desktops() if d.name() == value), None)
             if target is None:
                 return skill_error("Desktop not found", "No desktop named {!r}".format(value))
+            # Switching layouts destroys and recreates pane widgets.  Doing so
+            # inside the adapter's event-loop dispatch callback can invalidate
+            # the callback stack and terminate Houdini.  Defer the mutation to
+            # the next UI event, after the MCP call has returned.
+            post_event_callback = getattr(hou.ui, "postEventCallback", None)
+            if callable(post_event_callback):
+                post_event_callback(target.setAsCurrent)
+                return skill_success(
+                    "Scheduled desktop switch",
+                    supported=True,
+                    action=action,
+                    desktop=value,
+                    deferred=True,
+                )
             target.setAsCurrent()
-            return skill_success("Switched desktop", supported=True, action=action, desktop=value)
+            return skill_success(
+                "Switched desktop",
+                supported=True,
+                action=action,
+                desktop=value,
+                deferred=False,
+            )
 
         if action == "display_message":
             hou.ui.displayMessage(value or "")

--- a/tests/test_dev_skills.py
+++ b/tests/test_dev_skills.py
@@ -173,3 +173,23 @@ class TestDevUi:
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.ui_action("delete_everything")
         assert result["success"] is False
+
+    def test_ui_action_defers_desktop_switch_until_next_event(self) -> None:
+        mod = _load_script("ui_action.py")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        target = MagicMock()
+        target.name.return_value = "TechnicalWide"
+        mock_hou.ui.desktops.return_value = [target]
+        callbacks = []
+        mock_hou.ui.postEventCallback.side_effect = callbacks.append
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.ui_action("set_desktop", value="TechnicalWide")
+
+        assert result["success"] is True
+        assert result["context"]["deferred"] is True
+        target.setAsCurrent.assert_not_called()
+        assert callbacks == [target.setAsCurrent]
+        callbacks[0]()
+        target.setAsCurrent.assert_called_once_with()

--- a/tools/houdini-dev-build-link-core-win.ps1
+++ b/tools/houdini-dev-build-link-core-win.ps1
@@ -49,10 +49,12 @@ if (-not (Test-Path $HoudiniBase)) {
 }
 
 # Find hython executable (Python version may vary)
-$HythonCandidates = @(
-    "$HoudiniBase\bin\hython.exe",
-    Get-ChildItem "$HoudiniBase\python*\python.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-)
+$HythonCandidates = @("$HoudiniBase\bin\hython.exe")
+$BundledPython = Get-ChildItem "$HoudiniBase\python*\python.exe" -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if ($BundledPython) {
+    $HythonCandidates += $BundledPython.FullName
+}
 
 $Hython = $null
 foreach ($candidate in $HythonCandidates) {


### PR DESCRIPTION
## Summary
- defer desktop layout changes until the next Houdini UI event
- cover deferred switching with a regression test
- fix Windows dev-link script parsing

## Validation
- 16 Houdini dev-skill tests passed
- Ruff passed
- PowerShell parser passed
- Houdini 22 survived repeated Build/TechnicalWide switching with MCP responsive