### PR TITLE
Keep Husk renders off the Houdini UI thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,14 +121,14 @@ When adding or changing bundled skills, load the project skill:
 |-------|-----------|
 | `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `finalize_render_outputs`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
-| `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
+| `houdini-husk` | `render_with_husk`, `get_husk_job`, `cancel_husk_job`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
 | `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 32 skill packages, 216 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 32 skill packages, 218 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 |-------|-------|
 | `houdini-render` | `capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `finalize_render_outputs`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats` |
 | `houdini-karma` | `configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output` |
-| `houdini-husk` | `render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
+| `houdini-husk` | `render_with_husk`, `get_husk_job`, `cancel_husk_job`, `create_checkpoint`, `create_snapshot`, `set_husk_options` |
 | `houdini-animation` | `get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation` |
 | `houdini-hda-automation` | `scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain` |
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |

--- a/llms.txt
+++ b/llms.txt
@@ -70,7 +70,7 @@ server.list_skills()
 ### pipeline (load on demand)
 - `houdini_render__capture_viewport`, `flipbook`, `get_render_settings`, `set_render_settings`, `validate_karma_stage`, `render_rop`, `get_render_job`, `finalize_render_outputs`, `cancel_render_job`, `create_render_layer`, `configure_aovs`, `manage_takes`, `get_render_stats`
 - `houdini_karma__configure_karma`, `set_material_override`, `configure_light_mixer`, `set_image_output`
-- `houdini_husk__render_with_husk`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
+- `houdini_husk__render_with_husk`, `get_husk_job`, `cancel_husk_job`, `create_checkpoint`, `create_snapshot`, `set_husk_options`
 - `houdini_animation__get_timeline`, `set_timeline`, `set_keyframe`, `get_keyframes`, `delete_keyframes`, `list_animated_parms`, `validate_loop_contract`, `get_channel_info`, `export_channels`, `import_channels`, `bake_channels`, `cache_simulation`
 - `houdini_hda_automation__scan_hda_libraries`, `inspect_hda_definition`, `instantiate_hda`, `validate_hda`, `cook_top_network`, `execute_rop_chain`
 - `houdini_pipeline__set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package`

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -59,6 +59,6 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | KineFX character rig | `load_skill("houdini-kinefx")` → `houdini_kinefx__create_rig` → `houdini_kinefx__set_rig_pose` → `houdini_kinefx__capture_joints` → `houdini_kinefx__apply_mocap` |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |
 | Karma render setup | `load_skill("houdini-karma")` → `houdini_karma__configure_karma` → `houdini_karma__set_material_override` → `houdini_karma__configure_light_mixer` → `houdini_karma__set_image_output` |
-| Husk CLI render | `load_skill("houdini-husk")` → `houdini_husk__create_snapshot` → `houdini_husk__create_checkpoint` → `houdini_husk__set_husk_options` → `houdini_husk__render_with_husk` |
+| Husk CLI render | `load_skill("houdini-husk")` → `houdini_husk__create_snapshot` → `houdini_husk__render_with_husk` → poll `houdini_husk__get_husk_job` → optional `houdini_husk__cancel_husk_job` |
 | Render layers & AOVs | `load_skill("houdini-render")` → `houdini_render__create_render_layer` → `houdini_render__configure_aovs` → `houdini_render__get_render_stats` |
 | Takes management | `load_skill("houdini-render")` → `houdini_render__manage_takes(action="create")` → `houdini_render__manage_takes(action="switch")` → `houdini_render__manage_takes(action="list")` |

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -20,15 +20,16 @@ metadata:
 
 # houdini-husk
 
-Typed husk command-line rendering tools for USD/Hydra workflows. All tools
-are `affinity: main`. `render_with_husk` is `async` with a 1-hour timeout
-and falls back to hython in-process rendering when the husk binary is
-unavailable.
+Typed husk command-line rendering tools for USD/Hydra workflows. Scene export
+and option authoring stay `affinity: main`; native Husk launch, polling, and
+cancellation are `affinity: any`. The render process runs below an isolated
+hython worker so Karma cannot occupy Houdini's UI thread.
 
 ## Tool groups
 
-- **`render`:** `render_with_husk` — CLI USD rendering via husk with frame
-  range, resolution, custom args, and hython fallback.
+- **`render`:** `render_with_husk` launches and returns a durable `job_id`;
+  `get_husk_job` polls bounded output evidence and `cancel_husk_job` terminates
+  only an adapter-owned worker tree.
 - **`checkpoint`:** `create_checkpoint` (save intermediate USD state),
   `create_snapshot` (export stage as USD for offline rendering).
 - **`options`:** `set_husk_options` — configure or browse husk CLI options
@@ -40,7 +41,9 @@ unavailable.
 2. `create_snapshot(source_path="/stage", snapshot_path="/tmp/scene_snapshot.usd", flatten=true)`
 3. `set_husk_options(node_path="/stage/karmarenderproduct1", options={"threads": 8, "verbose": true})`
 4. `create_checkpoint(usd_file="/tmp/scene_snapshot.usd", checkpoint_path="/tmp/checkpoint_001.usd")`
-5. `render_with_husk(usd_file="/tmp/scene_snapshot.usd", output_path="/tmp/render/beauty.$F4.exr", renderer="karma", resolution=[1920, 1080], frame_range=[1, 120])` → `written_files`, `elapsed_secs`
+5. `render_with_husk(usd_file="/tmp/scene_snapshot.usd", output_path="/tmp/render/beauty.$F4.exr", renderer="karma", resolution=[1920, 1080], frame_range=[1, 120])` → `job_id`
+6. `get_husk_job(job_id="...")` until `state` is terminal → `written_files`, `elapsed_secs`
 
-When husk binary is not on PATH, use `use_hython_fallback=true` for in-process
-rendering via Houdini's Python session.
+`use_hython_fallback=true` is rejected because in-process rendering can freeze
+the Houdini event loop. Export a USD snapshot and use the isolated native Husk
+path instead.

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_jobs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_jobs.py
@@ -1,0 +1,85 @@
+"""Durable isolated jobs for command-line Husk renders."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence
+
+from _husk_common import find_hython  # noqa: E402
+
+from dcc_mcp_houdini import _isolated_jobs
+
+_LOG_TAIL_BYTES = 64 * 1024
+
+
+def launch_husk_job(
+    command: Sequence[str],
+    output_path: str,
+    expected_outputs: List[str],
+    output_glob: str,
+    environment: Mapping[str, str],
+    timeout_secs: int = 3600,
+) -> Dict[str, object]:
+    """Launch Husk below an isolated hython worker and return immediately."""
+    hython = find_hython()
+    if not hython:
+        raise FileNotFoundError("hython executable was not found beside Houdini")
+    initial, status_path = _isolated_jobs.create_job(
+        {
+            "job_kind": "husk_render",
+            "command": list(command),
+            "output_path": output_path,
+            "expected_outputs": list(expected_outputs),
+            "output_glob": output_glob,
+            "timeout_secs": int(timeout_secs),
+        }
+    )
+    worker_path = Path(__file__).resolve().parent / "_husk_worker.py"
+    worker_command = [
+        str(hython),
+        str(worker_path),
+        str(status_path),
+        json.dumps(list(command)),
+    ]
+    return _isolated_jobs.launch_job(initial["job_id"], worker_command, environment)
+
+
+def _tail(path_value: object) -> str:
+    if not path_value:
+        return ""
+    path = Path(str(path_value))
+    try:
+        with path.open("rb") as stream:
+            stream.seek(0, os.SEEK_END)
+            size = stream.tell()
+            stream.seek(max(0, size - _LOG_TAIL_BYTES))
+            payload = stream.read(_LOG_TAIL_BYTES)
+    except OSError:
+        return ""
+    return payload.decode("utf-8", errors="replace")[-2000:]
+
+
+def read_husk_job(job_id: str) -> Dict[str, object]:
+    """Read one Husk job without touching Houdini's main thread."""
+    result = _isolated_jobs.read_job(job_id)
+    if result.get("job_kind") != "husk_render":
+        raise ValueError("job_id does not identify a Husk render")
+    started_at = result.get("started_at")
+    if result.get("state") not in _isolated_jobs._TERMINAL_STATES and isinstance(started_at, (int, float)):
+        result["elapsed_secs"] = round(max(0.0, time.time() - float(started_at)), 3)
+    if result.get("state") in _isolated_jobs._TERMINAL_STATES:
+        result["stdout"] = _tail(result.get("stdout_path"))
+        result["stderr"] = _tail(result.get("stderr_path"))
+    return result
+
+
+def cancel_husk_job(job_id: str) -> Dict[str, object]:
+    """Cancel an owned Husk worker tree without signalling Houdini."""
+    result = read_husk_job(job_id)
+    if result.get("state") in _isolated_jobs._TERMINAL_STATES:
+        result["cancel_requested"] = False
+        return result
+    return _isolated_jobs.cancel_job(job_id)

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
@@ -1,0 +1,77 @@
+"""Isolated hython worker that owns one blocking Husk process."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from dcc_mcp_houdini._status_io import read_status, write_status
+
+
+def _written_files(status: dict) -> list:
+    written = [path for path in status.get("expected_outputs", []) if os.path.isfile(path)]
+    if not written and status.get("output_glob"):
+        written = sorted(path for path in glob.glob(str(status["output_glob"])) if os.path.isfile(path))
+    return written
+
+
+def main() -> None:
+    status_path = Path(sys.argv[1])
+    command = json.loads(sys.argv[2])
+    status = read_status(status_path)
+    started = time.time()
+    status.update({"state": "running", "started_at": started, "worker_pid": os.getpid()})
+    write_status(status_path, status)
+    try:
+        process = subprocess.run(  # noqa: S603
+            command,
+            stdin=subprocess.DEVNULL,
+            timeout=int(status.get("timeout_secs") or 3600),
+            check=False,
+        )
+        written_files = _written_files(status)
+        status.update(
+            {
+                "state": "completed" if process.returncode == 0 else "failed",
+                "returncode": process.returncode,
+                "written_files": written_files,
+                "output_verification": {
+                    "state": "verified" if written_files else "not_observed",
+                    "expected_output_count": len(status.get("expected_outputs", [])),
+                    "written_file_count": len(written_files),
+                },
+            }
+        )
+        if process.returncode != 0:
+            status["error"] = "husk exited with code {}".format(process.returncode)
+    except subprocess.TimeoutExpired:
+        status.update(
+            {
+                "state": "failed",
+                "error": "Husk render exceeded the configured timeout",
+                "written_files": _written_files(status),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        status.update(
+            {
+                "state": "failed",
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+                "written_files": _written_files(status),
+            }
+        )
+    finally:
+        status["finished_at"] = time.time()
+        status["elapsed_secs"] = round(status["finished_at"] - started, 3)
+        write_status(status_path, status)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/cancel_husk_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/cancel_husk_job.py
@@ -1,0 +1,18 @@
+"""Cancel one adapter-owned isolated Husk render job."""
+
+from __future__ import annotations
+
+from _husk_jobs import cancel_husk_job as _cancel_husk_job  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+
+def cancel_husk_job(job_id: str) -> dict:
+    try:
+        return skill_success("Husk render cancellation status", **_cancel_husk_job(job_id))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to cancel Husk render job")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return cancel_husk_job(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/get_husk_job.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/get_husk_job.py
@@ -1,0 +1,18 @@
+"""Read one isolated Husk render job."""
+
+from __future__ import annotations
+
+from _husk_jobs import read_husk_job  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+
+def get_husk_job(job_id: str) -> dict:
+    try:
+        return skill_success("Husk render job status", **read_husk_job(job_id))
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read Husk render job")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return get_husk_job(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/render_with_husk.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/render_with_husk.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
-import time
 from typing import List, Optional
 
 from _husk_common import (  # noqa: E402
     build_husk_command,
     find_husk,
-    find_hython,
     husk_subprocess_environment,
     resolve_husk_renderer,
 )
+from _husk_jobs import launch_husk_job  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 _FRAME_TOKEN = re.compile(r"\$F(\d*)")
@@ -54,6 +52,15 @@ def _expected_output_paths(
     return [output_path]
 
 
+def _output_glob(output_path: str, frame: Optional[int], frame_range: Optional[List[float]]) -> str:
+    if _FRAME_TOKEN.search(output_path):
+        return _FRAME_TOKEN.sub("*", output_path)
+    if frame is not None or frame_range:
+        base, extension = os.path.splitext(output_path)
+        return "{}.*{}".format(base, extension)
+    return output_path
+
+
 def render_with_husk(
     usd_file: str,
     output_path: str,
@@ -64,55 +71,21 @@ def render_with_husk(
     husk_args: Optional[List[str]] = None,
     use_hython_fallback: bool = False,
 ) -> dict:
-    """Render a USD file using husk (or hython fallback for inline rendering)."""
-    start = time.time()
+    """Launch an isolated Husk render and return a durable job identifier."""
 
     if use_hython_fallback:
-        # In-process rendering via hython + husk module
-        hython = find_hython()
-        if not hython:
-            return skill_error(
-                "hython not found",
-                "Neither husk nor hython found. Set HFS or ensure Houdini is installed.",
-            )
-        try:
-            import hou  # noqa: PLC0415
-        except ImportError:
-            return skill_error("Houdini not available", "hou could not be imported")
-
-        try:
-            import hou
-
-            usd_path = usd_file
-            if not os.path.isabs(usd_path):
-                usd_path = os.path.abspath(usd_path)
-
-            # Open the USD stage and render
-            stage = hou.node("/stage")
-            if not stage:
-                stage = hou.node("/obj").createNode("geo", node_name="husk_render")
-                lop = stage.createNode("usdimport")
-                lop.parm("file").set(usd_path)
-
-            elapsed = round(time.time() - start, 3)
-            return skill_success(
-                "Husk render via hython fallback",
-                usd_file=usd_file,
-                output_path=output_path,
-                renderer=renderer,
-                elapsed_secs=elapsed,
-                hint="In-process rendering — use native husk for full CLI control",
-            )
-        except Exception as exc:
-            return skill_exception(exc, message="Hython fallback render failed")
+        return skill_error(
+            "Blocking hython fallback is disabled",
+            "use_hython_fallback cannot preserve Houdini UI responsiveness. Export a USD snapshot, then launch native Husk.",
+            prompt="Call create_snapshot first, then call render_with_husk with use_hython_fallback=false.",
+        )
 
     # Native husk CLI path
     husk_path = find_husk()
     if not husk_path:
         return skill_error(
             "husk not found",
-            "husk executable not found. Set HFS or ensure Houdini is installed. "
-            "Try use_hython_fallback=true for in-process rendering.",
+            "husk executable not found. Set HFS or ensure Houdini is installed.",
         )
 
     try:
@@ -133,58 +106,34 @@ def render_with_husk(
         # Replace 'husk' with actual path
         cmd[0] = husk_path
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=3600,  # 1 hour timeout
-            env=husk_subprocess_environment(),
+        expected_outputs = _expected_output_paths(output_path, frame, frame_range)
+        job = launch_husk_job(
+            command=cmd,
+            output_path=output_path,
+            expected_outputs=expected_outputs,
+            output_glob=_output_glob(output_path, frame, frame_range),
+            environment=husk_subprocess_environment(),
+            timeout_secs=3600,
         )
-        elapsed = round(time.time() - start, 3)
-
-        written_files = [
-            path for path in _expected_output_paths(output_path, frame, frame_range) if os.path.isfile(path)
-        ]
-        if not written_files and _FRAME_TOKEN.search(output_path):
-            import glob
-
-            written_files = sorted(glob.glob(_FRAME_TOKEN.sub("*", output_path)))
-
-        context = {
-            "usd_file": usd_file,
-            "output_path": output_path,
-            "renderer": resolved_renderer,
-            "requested_renderer": renderer,
-            "elapsed_secs": elapsed,
-            "returncode": result.returncode,
-            "written_files": written_files,
-            "stdout": result.stdout[-2000:] if result.stdout else "",
-            "stderr": result.stderr[-2000:] if result.stderr else "",
-            "command": " ".join(cmd),
-        }
-        if result.returncode != 0:
-            details = context["stderr"] or context["stdout"] or f"husk exited with code {result.returncode}"
-            return skill_error(
-                "Husk render failed",
-                details,
-                prompt="Inspect the renderer delegate and Houdini search-path diagnostics.",
-                **context,
-            )
-
+        context = dict(job)
+        context.update(
+            {
+                "background": True,
+                "usd_file": usd_file,
+                "output_path": output_path,
+                "expected_outputs": expected_outputs,
+                "renderer": resolved_renderer,
+                "requested_renderer": renderer,
+                "command": " ".join(cmd),
+            }
+        )
         return skill_success(
-            "Husk render completed",
+            "Started isolated Husk render",
+            prompt="Poll get_husk_job with this job_id; call cancel_husk_job to stop the owned worker tree.",
             **context,
         )
-    except subprocess.TimeoutExpired:
-        elapsed = round(time.time() - start, 3)
-        return skill_error(
-            "Husk render timed out",
-            "Render exceeded 1-hour timeout",
-            elapsed_secs=elapsed,
-            usd_file=usd_file,
-        )
     except Exception as exc:
-        return skill_exception(exc, message="Failed to render with husk")
+        return skill_exception(exc, message="Failed to launch isolated Husk render")
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
@@ -1,13 +1,13 @@
 tools:
   - name: render_with_husk
     description: >-
-      Render a USD file using the husk command-line renderer (Karma or other
-      Hydra delegate). Supports frame range, resolution, and custom CLI args.
-      Falls back to hython in-process rendering when husk binary is unavailable.
+      Launch a USD render in an isolated Husk worker and return a durable
+      job_id immediately. Supports frame range, resolution, and custom CLI
+      args without occupying Houdini's UI thread.
     source_file: scripts/render_with_husk.py
-    execution: async
-    affinity: main
-    timeout_hint_secs: 3600
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 30
     group: render
     read_only: false
     destructive: false
@@ -45,6 +45,53 @@ tools:
         use_hython_fallback:
           type: boolean
           default: false
+          description: >-
+            Deprecated safety flag. True is rejected because in-process
+            rendering can block Houdini's UI thread.
+  - name: get_husk_job
+    description: >-
+      Poll a durable isolated Husk render. Returns state, elapsed time,
+      verified output files, bounded stdout/stderr tails, and worker ownership.
+    source_file: scripts/get_husk_job.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 10
+    group: render
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: true
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
+  - name: cancel_husk_job
+    description: >-
+      Cancel an adapter-owned Husk worker process tree. Repeated calls are
+      safe; jobs no longer owned by this adapter are never signalled.
+    source_file: scripts/cancel_husk_job.py
+    execution: sync
+    affinity: any
+    timeout_hint_secs: 10
+    group: render
+    read_only: false
+    destructive: true
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: true
+      idempotent_hint: true
+    input_schema:
+      type: object
+      required: [job_id]
+      properties:
+        job_id:
+          type: string
   - name: create_checkpoint
     description: >-
       Create a render checkpoint for husk — save intermediate USD state for

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import importlib.util
 import os
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import yaml
 from skill_loader import skill_script_import_context
+
+from dcc_mcp_houdini._status_io import read_status, write_status
 
 SCRIPTS = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills" / "houdini-husk" / "scripts"
 
@@ -72,67 +76,148 @@ def test_husk_environment_restores_houdini_default_paths() -> None:
     assert base == {"HOUDINI_PATH": "custom", "HOUDINI_SCRIPT_PATH": ""}
 
 
-def test_render_with_husk_returns_failure_for_nonzero_exit(tmp_path: Path) -> None:
+def test_render_with_husk_launches_isolated_job_without_waiting(tmp_path: Path) -> None:
     render = _load_script("render_with_husk.py")
-    process = SimpleNamespace(returncode=1, stdout="", stderr="delegate failed")
+    launched = {"job_id": "abc123", "state": "queued", "pid": 4321}
 
     with patch.object(render, "find_husk", return_value="husk"), patch.object(
-        render.subprocess, "run", return_value=process
-    ):
+        render, "launch_husk_job", return_value=launched
+    ) as launch:
         result = render.render_with_husk(str(tmp_path / "scene.usda"), str(tmp_path / "beauty.exr"))
 
-    assert result["success"] is False
-    assert result["context"]["returncode"] == 1
-    assert result["context"]["written_files"] == []
-    assert "delegate failed" in result["error"]
+    assert result["success"] is True
+    assert result["context"]["background"] is True
+    assert result["context"]["job_id"] == "abc123"
+    assert result["context"]["state"] == "queued"
+    launch.assert_called_once()
 
 
-def test_render_with_husk_creates_parent_and_reports_single_frame_pattern(tmp_path: Path) -> None:
+def test_expected_output_paths_reports_single_frame_pattern(tmp_path: Path) -> None:
     render = _load_script("render_with_husk.py")
     output_pattern = tmp_path / "new" / "review" / "beauty.$F4.exr"
     expected_output = tmp_path / "new" / "review" / "beauty.0007.exr"
-    process = SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    def run_husk(*_args, **_kwargs):
-        assert output_pattern.parent.is_dir()
-        expected_output.write_bytes(b"render")
-        return process
-
-    with patch.object(render, "find_husk", return_value="husk"), patch.object(
-        render.subprocess, "run", side_effect=run_husk
-    ):
-        result = render.render_with_husk(
-            str(tmp_path / "scene.usda"),
-            str(output_pattern),
-            frame=7,
-        )
-
-    assert result["success"] is True
-    assert result["context"]["written_files"] == [str(expected_output)]
+    assert render._expected_output_paths(str(output_pattern), 7, None) == [str(expected_output)]
 
 
-def test_render_with_husk_reports_frame_range_pattern(tmp_path: Path) -> None:
+def test_expected_output_paths_reports_frame_range_pattern(tmp_path: Path) -> None:
     render = _load_script("render_with_husk.py")
     output_pattern = tmp_path / "sequence" / "beauty.$F4.exr"
     expected_outputs = [output_pattern.parent / f"beauty.{frame:04d}.exr" for frame in (1, 3, 5)]
-    process = SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    def run_husk(*_args, **_kwargs):
-        for output in expected_outputs:
-            output.write_bytes(b"render")
-        return process
+    assert render._expected_output_paths(str(output_pattern), None, [1, 5, 2]) == [
+        str(output) for output in expected_outputs
+    ]
 
-    with patch.object(render, "find_husk", return_value="husk"), patch.object(
-        render.subprocess, "run", side_effect=run_husk
+
+def test_husk_tools_use_nonblocking_any_affinity_contract() -> None:
+    tools_path = SCRIPTS.parent / "tools.yaml"
+    tools = yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]
+    by_name = {tool["name"]: tool for tool in tools}
+
+    assert by_name["render_with_husk"]["execution"] == "sync"
+    assert by_name["render_with_husk"]["affinity"] == "any"
+    assert by_name["get_husk_job"]["affinity"] == "any"
+    assert by_name["cancel_husk_job"]["affinity"] == "any"
+
+
+def test_husk_worker_records_nonzero_exit_without_touching_host(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    write_status(
+        status_path,
+        {
+            "job_id": "abc123",
+            "job_kind": "husk_render",
+            "expected_outputs": [],
+            "output_glob": "",
+            "timeout_secs": 30,
+        },
+    )
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        return_value=SimpleNamespace(returncode=7),
     ):
-        result = render.render_with_husk(
-            str(tmp_path / "scene.usda"),
-            str(output_pattern),
-            frame_range=[1, 5, 2],
-        )
+        worker.main()
 
-    assert result["success"] is True
-    assert result["context"]["written_files"] == [str(output) for output in expected_outputs]
+    status = read_status(status_path)
+    assert status["state"] == "failed"
+    assert status["returncode"] == 7
+    assert status["error"] == "husk exited with code 7"
+
+
+def test_husk_worker_verifies_written_output(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    output = tmp_path / "beauty.0001.exr"
+    write_status(
+        status_path,
+        {
+            "job_id": "def456",
+            "job_kind": "husk_render",
+            "expected_outputs": [str(output)],
+            "output_glob": str(tmp_path / "beauty.*.exr"),
+            "timeout_secs": 30,
+        },
+    )
+
+    def render(*_args, **_kwargs):
+        output.write_bytes(b"render")
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=render,
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "completed"
+    assert status["written_files"] == [str(output)]
+    assert status["output_verification"]["state"] == "verified"
+
+
+def test_husk_job_launch_is_nonblocking_and_pollable(tmp_path: Path) -> None:
+    jobs = _load_script("_husk_jobs.py")
+    output = tmp_path / "beauty.exr"
+    source_root = SCRIPTS.parents[3]
+    environment = dict(os.environ)
+    existing_pythonpath = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [str(source_root)] + ([existing_pythonpath] if existing_pythonpath else [])
+    )
+    command = [
+        sys.executable,
+        "-c",
+        "import time; from pathlib import Path; time.sleep(1.2); Path({!r}).write_bytes(b'render')".format(str(output)),
+    ]
+
+    started = time.monotonic()
+    with patch.object(jobs, "find_hython", return_value=sys.executable):
+        launched = jobs.launch_husk_job(
+            command=command,
+            output_path=str(output),
+            expected_outputs=[str(output)],
+            output_glob=str(output),
+            environment=environment,
+            timeout_secs=30,
+        )
+    launch_elapsed = time.monotonic() - started
+
+    assert launch_elapsed < 1.0
+    assert launched["state"] == "queued"
+    deadline = time.monotonic() + 10.0
+    status = jobs.read_husk_job(launched["job_id"])
+    while status["state"] not in {"completed", "failed", "cancelled", "interrupted"}:
+        assert time.monotonic() < deadline
+        time.sleep(0.1)
+        status = jobs.read_husk_job(launched["job_id"])
+
+    assert status["state"] == "completed"
+    assert status["written_files"] == [str(output)]
 
 
 class _SnapshotParm:


### PR DESCRIPTION
## Summary
- launch native Husk renders in an isolated worker and return a durable job ID immediately
- add typed polling and cancellation tools with bounded logs and output evidence
- reject the blocking in-process fallback and update skill guidance

## Validation
- 884 passed, 1 skipped, 3 deselected
- Ruff check and format clean
- real subprocess launch/poll regression passes