### PR TITLE
feat(groom): add GSplat KineFX deformation and short fur

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-parameters` | `list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression` |
 | `houdini-node-graph` | `get_connections`, `connect_input`, `disconnect_input` |
 | `houdini-geometry` | `create_primitive`, `create_curve_guides`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
+| `houdini-groom` | `build_short_fur_groom` |
 | `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material`, `build_materialx_pbr`, `validate_materialx_pbr` |
@@ -105,7 +106,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
 | `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
-| `houdini-kinefx` | `create_rig`, `set_rig_pose`, `capture_joints`, `apply_mocap` |
+| `houdini-kinefx` | `create_rig`, `set_rig_pose`, `capture_joints`, `deform_gsplat_with_rig`, `apply_mocap` |
 | `houdini-light-rig` | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
 | `houdini-material-library` | `save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management` |
 | `houdini-texture-bake` | `list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps` |
@@ -128,7 +129,7 @@ When adding or changing bundled skills, load the project skill:
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
 
-**Total: 32 skill packages, 219 tools** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative index and ready-made task→skill chains.
+**Total: 34 skill packages** — See `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md` for the authoritative package and tool index.
 
 ## Key Env Vars
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-parameters` | `list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression` |
 | `houdini-node-graph` | `get_connections`, `connect_input`, `disconnect_input` |
 | `houdini-geometry` | `create_primitive`, `create_curve_guides`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
+| `houdini-groom` | `build_short_fur_groom` |
 | `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material`, `build_materialx_pbr`, `validate_materialx_pbr` |
@@ -288,7 +289,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-chops` | `create_chop_network`, `create_motionclip`, `create_audio_driven`, `apply_filter`, `export_to_keyframes`, `get_channel_info` |
 | `houdini-constraints` | `create_parent_constraint`, `create_blend_constraint`, `create_position_constraint`, `create_orient_constraint`, `list_constraints`, `delete_constraint` |
 | `houdini-export-preset` | `list_export_presets`, `save_export_preset`, `load_export_preset`, `delete_export_preset` |
-| `houdini-kinefx` | `create_rig`, `set_rig_pose`, `capture_joints`, `apply_mocap` |
+| `houdini-kinefx` | `create_rig`, `set_rig_pose`, `capture_joints`, `deform_gsplat_with_rig`, `apply_mocap` |
 | `houdini-light-rig` | `create_three_point_light_rig`, `create_area_softbox`, `create_hdri_world`, `list_light_rigs`, `set_light_rig_intensity`, `aim_light_at_object`, `group_lights`, `set_render_view_transform`, `get_lighting_summary` |
 | `houdini-material-library` | `save_material_preset`, `list_material_presets`, `load_material_preset`, `delete_material_preset`, `get_shader_assignment`, `get_material_connections`, `set_material_attribute`, `assign_texture`, `list_images`, `reload_image`, `list_color_spaces`, `set_color_management` |
 | `houdini-texture-bake` | `list_bake_targets`, `bake_textures`, `bake_ambient_occlusion`, `bake_lighting`, `transfer_maps` |

--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -28,6 +28,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
         "houdini-parameters",
         "houdini-node-graph",
         "houdini-geometry",
+        "houdini-groom",
         "houdini-mesh-ops",
         "houdini-camera-light",
         "houdini-materials",

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -56,7 +56,8 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Motion FX & CHOPs | `load_skill("houdini-chops")` → `houdini_chops__create_chop_network` → `houdini_chops__create_motionclip` → `houdini_chops__apply_filter` → `houdini_chops__get_channel_info` → `houdini_chops__export_to_keyframes` |
 | Audio-driven animation | `load_skill("houdini-chops")` → `houdini_chops__create_chop_network` → `houdini_chops__create_audio_driven` |
 | Constrain transforms | `load_skill("houdini-constraints")` → `houdini_constraints__create_parent_constraint` / `create_blend_constraint` / `create_position_constraint` / `create_orient_constraint` → `houdini_constraints__list_constraints` → `houdini_constraints__delete_constraint` |
-| KineFX character rig | `load_skill("houdini-kinefx")` → `houdini_kinefx__create_rig` → `houdini_kinefx__set_rig_pose` → `houdini_kinefx__capture_joints` → `houdini_kinefx__apply_mocap` |
+| KineFX character rig | `load_skill("houdini-kinefx")` → `houdini_kinefx__create_rig` → `houdini_kinefx__set_rig_pose` → `houdini_kinefx__capture_joints` → optional `houdini_kinefx__deform_gsplat_with_rig` → `houdini_kinefx__apply_mocap` |
+| Short fur / insect groom | `load_skill("houdini-groom")` → `houdini_groom__build_short_fur_groom` → inspect Hair Generate / Guide Deform output |
 | Escape hatch | `load_skill("houdini-scripting")` → `houdini_scripting__execute_python` (last resort) |
 | Karma render setup | `load_skill("houdini-karma")` → `houdini_karma__configure_karma` → `houdini_karma__set_material_override` → `houdini_karma__configure_light_mixer` → `houdini_karma__set_image_output` |
 | Husk CLI render | `load_skill("houdini-husk")` → `houdini_husk__create_snapshot` → `houdini_husk__render_with_husk` → poll `houdini_husk__get_husk_job` → optional `houdini_husk__cancel_husk_job` |

--- a/src/dcc_mcp_houdini/skills/houdini-groom/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-groom/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: houdini-groom
+description: >-
+  Authoring skill - build Houdini 22 short-fur groom networks from rest skin,
+  optional guides, and animated skin. Use for insect fuzz, creature fur, and
+  deformation-ready hair generation. Not for interactive brush sculpting.
+license: MIT
+compatibility: "dcc-mcp-houdini 0.1+, Houdini 22.0+, dcc-mcp-core 0.19.70+"
+allowed-tools: Bash Read Write Edit
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: authoring
+    version: "1.0.0"
+    tags: [houdini, groom, fur, hair, guides, insect, creature, deformation]
+    search-hint: "insect fuzz bee fur hair generate guide deform animated skin groom"
+    tools: tools.yaml
+---
+
+# Houdini groom
+
+Build bounded native SOP networks for renderable short fur. All tools use main
+thread affinity because they create and wire Houdini nodes.
+
+## Workflow
+
+1. Prepare a polygon rest skin and optional root-to-tip guides.
+2. Call `build_short_fur_groom` with an optional animated skin.
+3. Inspect the returned Hair Generate and Guide Deform nodes before rendering.
+
+For insect fuzz, start with short lengths and Surface Deform. Use explicit
+guides for directional thorax and abdomen hair.

--- a/src/dcc_mcp_houdini/skills/houdini-groom/scripts/build_short_fur_groom.py
+++ b/src/dcc_mcp_houdini/skills/houdini-groom/scripts/build_short_fur_groom.py
@@ -1,0 +1,149 @@
+"""Build a native Houdini 22 short-fur groom network."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _node(hou, path: str):
+    node = hou.node(path)
+    if node is None:
+        raise ValueError("Houdini node does not exist: {}".format(path))
+    return node
+
+
+def _find_type(parent, candidates: Sequence[str]) -> str:
+    available = parent.childTypeCategory().nodeTypes()
+    for candidate in candidates:
+        if candidate in available:
+            return candidate
+    raise ValueError("Required Houdini node type is unavailable: {}".format(", ".join(candidates)))
+
+
+def _set_first(node, names: Sequence[str], value) -> Optional[str]:
+    for name in names:
+        parm = node.parm(name)
+        if parm is not None:
+            parm.set(value)
+            return name
+    return None
+
+
+def build_short_fur_groom(
+    geo_path: str,
+    rest_skin: str,
+    animated_skin: Optional[str] = None,
+    guides: Optional[str] = None,
+    skin_group: str = "",
+    density: float = 120000.0,
+    length: float = 0.025,
+    segments: int = 5,
+    clump_strength: float = 0.15,
+    deform_method: str = "surface",
+    name_prefix: str = "insect_fur",
+) -> dict:
+    """Create Hair Generate, optional Hair Clump, and Guide Deform SOPs."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = []
+    try:
+        if not 0.001 <= float(density) <= 10000000:
+            raise ValueError("density must be between 0.001 and 10000000")
+        if not 0 < float(length) <= 10:
+            raise ValueError("length must be greater than 0 and at most 10")
+        if isinstance(segments, bool) or not 2 <= int(segments) <= 64:
+            raise ValueError("segments must be between 2 and 64")
+        if not 0 <= float(clump_strength) <= 1:
+            raise ValueError("clump_strength must be between 0 and 1")
+        if deform_method not in {"surface", "guide_shape", "point"}:
+            raise ValueError("deform_method must be surface, guide_shape, or point")
+
+        geo = _node(hou, geo_path)
+        rest = _node(hou, "{}/{}".format(geo.path(), rest_skin))
+        animated = _node(hou, "{}/{}".format(geo.path(), animated_skin)) if animated_skin else None
+        guide_node = _node(hou, "{}/{}".format(geo.path(), guides)) if guides else None
+
+        hair_type = _find_type(geo, ("hairgen::2.0", "hairgen"))
+        hair = geo.createNode(hair_type, node_name="{}_generate".format(name_prefix))
+        created.append(hair)
+        hair.setInput(0, rest, 0)
+        if guide_node is not None:
+            hair.setInput(1, guide_node, 0)
+        configured = {
+            "density": _set_first(hair, ("density", "hairdensity"), float(density)),
+            "length": _set_first(hair, ("unguidedlength", "length", "hairlength"), float(length)),
+            "segments": _set_first(hair, ("unguidedsegments", "segments", "hairsegments"), int(segments)),
+            "group": _set_first(hair, ("group",), str(skin_group)),
+        }
+
+        current = hair
+        clump_path = None
+        if clump_strength > 0:
+            clump_type = _find_type(geo, ("hairclump::2.0", "hairclump"))
+            clump = geo.createNode(clump_type, node_name="{}_clump".format(name_prefix))
+            created.append(clump)
+            clump.setFirstInput(current)
+            clump.setInput(1, rest, 0)
+            configured["clump_strength"] = _set_first(
+                clump, ("blend", "strength", "clumpstrength"), float(clump_strength)
+            )
+            current = clump
+            clump_path = clump.path()
+
+        deform_path = None
+        if animated is not None:
+            deform_type = _find_type(geo, ("guidedeform::2.0", "guidedeform"))
+            deform = geo.createNode(deform_type, node_name="{}_deform".format(name_prefix))
+            created.append(deform)
+            deform.setInput(0, current, 0)
+            deform.setInput(1, rest, 0)
+            deform.setInput(2, animated, 0)
+            method_values = {
+                "guide_shape": "guideshapeinterpolation",
+                "surface": "surfacedeform",
+                "point": "pointdeform",
+            }
+            configured["deform_method"] = _set_first(deform, ("method", "deformmethod"), method_values[deform_method])
+            current = deform
+            deform_path = deform.path()
+
+        for node in created:
+            node.moveToGoodPosition()
+        current.setDisplayFlag(True)
+        current.setRenderFlag(True)
+
+        return skill_success(
+            "Built short-fur groom",
+            output_node_path=current.path(),
+            hair_generate_path=hair.path(),
+            hair_clump_path=clump_path,
+            guide_deform_path=deform_path,
+            rest_skin=rest.path(),
+            animated_skin=animated.path() if animated is not None else None,
+            guides=guide_node.path() if guide_node is not None else None,
+            deform_method=deform_method if animated is not None else None,
+            configured_parameters=configured,
+        )
+    except Exception as exc:
+        for node in reversed(created):
+            try:
+                node.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to build short-fur groom; created nodes were rolled back")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return build_short_fur_groom(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-groom/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-groom/tools.yaml
@@ -1,0 +1,41 @@
+tools:
+  - name: build_short_fur_groom
+    description: >-
+      Build a Houdini 22 Hair Generate 2.0 network for short fur and optionally
+      append Guide Deform so roots follow animated skin. Returns all node paths
+      and the parameter names available in the installed Houdini build.
+    source_file: scripts/build_short_fur_groom.py
+    execution: sync
+    affinity: main
+    group: fur-authoring
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [geo_path, rest_skin]
+      properties:
+        geo_path: {type: string, description: Geometry SOP container path.}
+        rest_skin: {type: string, description: Rest skin SOP name in geo_path.}
+        animated_skin: {type: string, description: Optional animated skin SOP name.}
+        guides: {type: string, description: Optional guide curve SOP name.}
+        skin_group: {type: string, default: "", description: Primitive group that grows fur.}
+        density: {type: number, minimum: 0.001, maximum: 10000000, default: 120000, description: Hair density.}
+        length: {type: number, exclusiveMinimum: 0, maximum: 10, default: 0.025, description: Fur length in scene units.}
+        segments: {type: integer, minimum: 2, maximum: 64, default: 5, description: Segments per unguided hair.}
+        clump_strength: {type: number, minimum: 0, maximum: 1, default: 0.15, description: Optional Hair Clump strength.}
+        deform_method:
+          type: string
+          enum: [surface, guide_shape, point]
+          default: surface
+          description: Guide Deform method; surface is recommended for short insect fur.
+        name_prefix: {type: string, default: insect_fur, description: Prefix for created SOP names.}
+    next-tools:
+      on-success:
+        - houdini_geometry__get_cook_status
+      on-failure:
+        - houdini_scene__get_node_info

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/SKILL.md
@@ -31,8 +31,9 @@ attributes, rigs are SOP networks, and mocap data is applied via SOP nodes.
   and optional rig pose/attachments.
 - **`pose`:** `set_rig_pose` — set the transform of a specific joint or the
   entire rig pose.
-- **`capture`:** `capture_joints` — capture skinning weights from joints to
-  a target mesh using proximity or bone-capture SOP nodes.
+- **`capture`:** `capture_joints` captures skinning weights; then
+  `deform_gsplat_with_rig` deforms GSplat centers and quaternion orientation
+  while preserving anisotropic scale.
 - **`mocap`:** `apply_mocap` — apply motion capture data (FBX, BVH, or
   KineFX clip) onto a rig skeleton.
 - **`retarget/mixer`:** `build_retarget_motion_mixer` — build the Houdini 22

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/deform_gsplat_with_rig.py
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/scripts/deform_gsplat_with_rig.py
@@ -1,0 +1,103 @@
+"""Deform Gaussian Splat points with a KineFX skeleton."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from _kinefx_common import get_node  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _set_first(node, names, value) -> Optional[str]:
+    for name in names:
+        parm = node.parm(name)
+        if parm is not None:
+            parm.set(value)
+            return name
+    return None
+
+
+def deform_gsplat_with_rig(
+    geo_path: str,
+    captured_splats: str,
+    rest_rig: str,
+    animated_rig: str,
+    output_name: str = "deformed_gsplats",
+    skinning_method: str = "dual_quaternion",
+    deform_normals: bool = True,
+    preserve_capture_attributes: bool = True,
+) -> dict:
+    """Create a Joint Deform SOP that preserves GSplat orientation and scale.
+
+    ``captured_splats`` must already contain ``boneCapture`` plus the GSplat
+    ``P``, ``orient``, and ``scale`` or ``pscale`` point attributes. Joint
+    Deform updates ``P`` and quaternion ``orient``; scale remains unchanged.
+    """
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if skinning_method not in {"linear", "dual_quaternion", "blend"}:
+            raise ValueError("skinning_method must be linear, dual_quaternion, or blend")
+
+        geo = get_node(hou, geo_path)
+        splats = get_node(hou, "{}/{}".format(geo.path(), captured_splats))
+        rest = get_node(hou, "{}/{}".format(geo.path(), rest_rig))
+        animated = get_node(hou, "{}/{}".format(geo.path(), animated_rig))
+
+        geometry = splats.geometry()
+        names = {attrib.name() for attrib in geometry.pointAttribs()}
+        required = {"P", "boneCapture", "orient"}
+        missing = sorted(required - names)
+        if not ({"scale", "pscale"} & names):
+            missing.append("scale_or_pscale")
+        if missing:
+            raise ValueError("captured_splats is missing: {}".format(", ".join(missing)))
+
+        deform = geo.createNode("kinefx::jointdeform", node_name=output_name)
+        deform.setInput(0, splats, 0)
+        deform.setInput(1, rest, 0)
+        deform.setInput(2, animated, 0)
+
+        method_values = {"linear": "linear", "dual_quaternion": "dualquat", "blend": "blenddualquat"}
+        method_parm = _set_first(deform, ("skinningmethod", "method"), method_values[skinning_method])
+        attrs_parm = _set_first(deform, ("otherattribs", "otherattributes"), "orient")
+        normals_parm = _set_first(deform, ("donormal", "deformnormals"), bool(deform_normals))
+        delete_parm = _set_first(
+            deform,
+            ("deletecaptureattrib", "deletecaptureattribs", "deletecaptureattributes"),
+            not bool(preserve_capture_attributes),
+        )
+        deform.moveToGoodPosition()
+
+        return skill_success(
+            "Created KineFX GSplat deformation",
+            node_path=deform.path(),
+            captured_splats=splats.path(),
+            rest_rig=rest.path(),
+            animated_rig=animated.path(),
+            skinning_method=skinning_method,
+            deformed_attributes=["P", "orient"] + (["N"] if deform_normals and "N" in names else []),
+            preserved_attributes=sorted({"scale", "pscale"} & names),
+            configured_parameters={
+                "skinning_method": method_parm,
+                "other_attributes": attrs_parm,
+                "deform_normals": normals_parm,
+                "delete_capture_attributes": delete_parm,
+            },
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to create KineFX GSplat deformation")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return deform_gsplat_with_rig(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-kinefx/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-kinefx/tools.yaml
@@ -142,6 +142,41 @@ tools:
         output_name:
           type: string
           description: Name for the capture SOP node (auto-generated if omitted).
+  - name: deform_gsplat_with_rig
+    description: >-
+      Deform captured Gaussian Splat points with rest and animated KineFX
+      skeletons while rotating quaternion orient and preserving anisotropic
+      scale. Validates GSplat and boneCapture attributes first.
+    source_file: scripts/deform_gsplat_with_rig.py
+    execution: sync
+    affinity: main
+    group: capture
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      required: [geo_path, captured_splats, rest_rig, animated_rig]
+      properties:
+        geo_path: {type: string, description: Path to the Geometry SOP container.}
+        captured_splats: {type: string, description: Captured GSplat SOP name with boneCapture.}
+        rest_rig: {type: string, description: Rest-pose KineFX skeleton SOP name.}
+        animated_rig: {type: string, description: Animated KineFX skeleton SOP name.}
+        output_name: {type: string, default: deformed_gsplats, description: Joint Deform SOP name.}
+        skinning_method:
+          type: string
+          enum: [linear, dual_quaternion, blend]
+          default: dual_quaternion
+          description: Joint Deform skinning method.
+        deform_normals: {type: boolean, default: true, description: Deform N when present.}
+        preserve_capture_attributes:
+          type: boolean
+          default: true
+          description: Keep boneCapture for inspection and downstream validation.
   - name: apply_mocap
     description: >-
       Apply motion capture data (FBX, BVH, or KineFX .bclip/.clip) onto a

--- a/tests/test_groom_skills.py
+++ b/tests/test_groom_skills.py
@@ -1,0 +1,84 @@
+"""Mock-HOM tests for the Houdini groom skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _load_script():
+    path = (
+        Path(__file__).parents[1]
+        / "src"
+        / "dcc_mcp_houdini"
+        / "skills"
+        / "houdini-groom"
+        / "scripts"
+        / "build_short_fur_groom.py"
+    )
+    spec = importlib.util.spec_from_file_location("build_short_fur_groom_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_short_fur_groom_with_animated_skin() -> None:
+    mod = _load_script()
+    geo = MagicMock()
+    geo.path.return_value = "/obj/bee"
+    geo.childTypeCategory.return_value.nodeTypes.return_value = {
+        "hairgen::2.0": MagicMock(),
+        "hairclump::2.0": MagicMock(),
+        "guidedeform::2.0": MagicMock(),
+    }
+    rest, animated, guides = MagicMock(), MagicMock(), MagicMock()
+    rest.path.return_value = "/obj/bee/rest_skin"
+    animated.path.return_value = "/obj/bee/animated_skin"
+    guides.path.return_value = "/obj/bee/guides"
+    hair, clump, deform = MagicMock(), MagicMock(), MagicMock()
+    hair.path.return_value = "/obj/bee/bee_fur_generate"
+    clump.path.return_value = "/obj/bee/bee_fur_clump"
+    deform.path.return_value = "/obj/bee/bee_fur_deform"
+    geo.createNode.side_effect = [hair, clump, deform]
+    for node in (hair, clump, deform):
+        node.parm.side_effect = lambda _name: MagicMock()
+
+    mock_hou = MagicMock()
+    mock_hou.node.side_effect = {
+        "/obj/bee": geo,
+        "/obj/bee/rest_skin": rest,
+        "/obj/bee/animated_skin": animated,
+        "/obj/bee/guides": guides,
+    }.get
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.build_short_fur_groom(
+            "/obj/bee", "rest_skin", animated_skin="animated_skin", guides="guides", name_prefix="bee_fur"
+        )
+
+    assert result["success"] is True
+    hair.setInput.assert_any_call(0, rest, 0)
+    hair.setInput.assert_any_call(1, guides, 0)
+    clump.setFirstInput.assert_called_once_with(hair)
+    clump.setInput.assert_called_once_with(1, rest, 0)
+    deform.setInput.assert_any_call(0, clump, 0)
+    deform.setInput.assert_any_call(1, rest, 0)
+    deform.setInput.assert_any_call(2, animated, 0)
+    deform.setDisplayFlag.assert_called_once_with(True)
+    deform.setRenderFlag.assert_called_once_with(True)
+
+
+def test_build_short_fur_groom_rolls_back_on_missing_node_type() -> None:
+    mod = _load_script()
+    geo = MagicMock()
+    geo.path.return_value = "/obj/bee"
+    geo.childTypeCategory.return_value.nodeTypes.return_value = {}
+    mock_hou = MagicMock()
+    mock_hou.node.side_effect = {"/obj/bee": geo, "/obj/bee/rest_skin": MagicMock()}.get
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.build_short_fur_groom("/obj/bee", "rest_skin")
+
+    assert result["success"] is False
+    geo.createNode.assert_not_called()

--- a/tests/test_kinefx_skills.py
+++ b/tests/test_kinefx_skills.py
@@ -350,6 +350,76 @@ class TestCaptureJoints:
         geo.createNode.assert_called_once_with("bonecapture", node_name="capture_rig1")
 
 
+class TestDeformGsplatWithRig:
+    @staticmethod
+    def _attrib(name: str) -> MagicMock:
+        attrib = MagicMock()
+        attrib.name.return_value = name
+        return attrib
+
+    def test_creates_joint_deform_and_preserves_scale(self) -> None:
+        mod = _load_script("deform_gsplat_with_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/bee"
+        splats = MagicMock()
+        splats.path.return_value = "/obj/bee/captured"
+        splats.geometry.return_value.pointAttribs.return_value = [
+            self._attrib(name) for name in ("P", "boneCapture", "orient", "scale", "N")
+        ]
+        rest = MagicMock()
+        rest.path.return_value = "/obj/bee/rest_rig"
+        animated = MagicMock()
+        animated.path.return_value = "/obj/bee/animated_rig"
+        deform = MagicMock()
+        deform.path.return_value = "/obj/bee/deformed_gsplats"
+        parms = {name: MagicMock() for name in ("method", "otherattribs", "donormal", "deletecaptureattrib")}
+        deform.parm.side_effect = parms.get
+        geo.createNode.return_value = deform
+
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = {
+            "/obj/bee": geo,
+            "/obj/bee/captured": splats,
+            "/obj/bee/rest_rig": rest,
+            "/obj/bee/animated_rig": animated,
+        }.get
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.deform_gsplat_with_rig("/obj/bee", "captured", "rest_rig", "animated_rig")
+
+        assert result["success"] is True
+        geo.createNode.assert_called_once_with("kinefx::jointdeform", node_name="deformed_gsplats")
+        deform.setInput.assert_any_call(0, splats, 0)
+        deform.setInput.assert_any_call(1, rest, 0)
+        deform.setInput.assert_any_call(2, animated, 0)
+        parms["method"].set.assert_called_once_with("dualquat")
+        parms["otherattribs"].set.assert_called_once_with("orient")
+        assert result["context"]["preserved_attributes"] == ["scale"]
+
+    def test_rejects_missing_orient(self) -> None:
+        mod = _load_script("deform_gsplat_with_rig.py")
+        geo = MagicMock()
+        geo.path.return_value = "/obj/bee"
+        splats = MagicMock()
+        splats.geometry.return_value.pointAttribs.return_value = [
+            self._attrib(name) for name in ("P", "boneCapture", "scale")
+        ]
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = {
+            "/obj/bee": geo,
+            "/obj/bee/captured": splats,
+            "/obj/bee/rest_rig": MagicMock(),
+            "/obj/bee/animated_rig": MagicMock(),
+        }.get
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.deform_gsplat_with_rig("/obj/bee", "captured", "rest_rig", "animated_rig")
+
+        assert result["success"] is False
+        assert "orient" in result["message"] or "orient" in str(result)
+        geo.createNode.assert_not_called()
+
+
 class TestApplyMocap:
     def test_apply_mocap_bclip(self) -> None:
         mod = _load_script("apply_mocap.py")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -195,6 +195,7 @@ def test_stage_loader_maps_bootstrap_and_scene() -> None:
     assert "houdini-scripting" in skills_for_stage("bootstrap")
     assert "houdini-scene" in skills_for_stage("scene")
     assert "houdini-materials" in skills_for_stage("authoring")
+    assert "houdini-groom" in skills_for_stage("authoring")
     cfg = build_minimal_mode_for_stages(["scene"])
     assert "houdini-scene" in cfg.skills
     assert "houdini-scripting" in cfg.skills


### PR DESCRIPTION
## Summary
- add typed KineFX deformation for captured GSplat centers and quaternion orientation while preserving anisotropic scale
- add a Houdini 22 short-fur groom skill using Hair Generate 2.0, Hair Clump, and Guide Deform
- register the authoring skill and update discovery documentation

## Validation
- 901 passed, 1 skipped, 3 deselected
- Ruff check and format pass
- 34 bundled skills pass metadata validation
- live Houdini 22.0 host probe produced 58,970 points / 11,794 hair curves with zero cook errors or warnings

## Acceptance boundary
- Groom network is live-host validated.
- GSplat deformation is typed and unit-tested; end-to-end validation remains gated on a licensed captured or scan-derived honeybee GSplat input.