### PR TITLE
fix(render): guard headless OpenGL ROP crashes

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -27,6 +27,9 @@ use `affinity: main`; background job polling and cancellation use `affinity: any
 Viewport tools are **UI-aware**: in a headless `hython` session they return a
 structured `warnings` payload with `captured: false` instead of failing, so an
 agent can detect and skip cleanly when rendering is unavailable.
+OpenGL ROP rendering is likewise rejected in headless Houdini because the
+native viewport/Vulkan path may terminate the process; use interactive Houdini
+or Karma/Husk for batch rendering.
 
 ## Tool groups
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -48,7 +48,17 @@ def render_rop(
 
     try:
         rop = get_node(hou, rop_path)
-        is_solaris = rop.type().name().split("::", 1)[0] == "usdrender_rop"
+        rop_type = rop.type().name().split("::", 1)[0]
+        is_solaris = rop_type == "usdrender_rop"
+        if rop_type == "opengl" and not bool(hou.isUIAvailable()):
+            return skill_error(
+                "OpenGL ROP requires interactive Houdini",
+                "Headless OpenGL ROP rendering can crash in the native Vulkan compositor. "
+                "Run this ROP in the Houdini UI, use capture_viewport there, or use Karma/Husk "
+                "for headless rendering.",
+                node_path=rop.path(),
+                rop_type=rop_type,
+            )
         if (is_solaris and rop.parm("execute") is None) or (
             not is_solaris and not callable(getattr(rop, "render", None))
         ):

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -2564,6 +2564,41 @@ class TestRenderExecution:
         launch.assert_called_once_with(mock_hou, "/out/mantra1", [1, 720, 1], str(tmp_path / "beauty.$F4.exr"))
         rop.render.assert_not_called()
 
+    def test_render_rop_rejects_headless_opengl_before_background_launch(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        picture = _scalar_parm(str(tmp_path / "viewport.$F4.png"))
+        rop = _node("/out/opengl1", "opengl1", "opengl")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = False
+
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod, "launch_background_render") as launch:
+            result = mod.render_rop("/out/opengl1", frame_range=[1, 36, 1])
+
+        assert result["success"] is False
+        assert result["message"] == "OpenGL ROP requires interactive Houdini"
+        assert "Karma" in result["error"]
+        launch.assert_not_called()
+        rop.render.assert_not_called()
+
+    def test_render_rop_rejects_headless_opengl_foreground(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        picture = _scalar_parm(str(tmp_path / "viewport.png"))
+        rop = _node("/out/opengl1", "opengl1", "opengl")
+        rop.parmTuple.return_value = None
+        rop.parm.side_effect = lambda n: picture if n == "picture" else None
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = rop
+        mock_hou.isUIAvailable.return_value = False
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.render_rop("/out/opengl1", background=False)
+
+        assert result["success"] is False
+        rop.render.assert_not_called()
+
     def test_expand_outputs_accepts_single_value_parm_tuple(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
         out = tmp_path / "beauty.0001.exr"


### PR DESCRIPTION
## Summary
- reject OpenGL ROP execution before launching headless or isolated hython renders
- direct agents to interactive viewport capture or Karma/Husk batch rendering
- preserve interactive Houdini OpenGL rendering

## Reproduction
Houdini 22.0.368 headless OpenGL ROP rendering terminated in the native Vulkan compositor during pass composition. This failure is process-level and cannot be caught as a Python exception.

## Validation
- 903 passed, 1 skipped, 3 deselected
- Ruff format/check pass
- 34 skill packages pass metadata validation
- focused render_rop suite: 9 passed