### PR TITLE
Fix standard 3DGS PLY normalization

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
@@ -25,9 +25,13 @@ metadata:
 Use the typed tools in this package for the cross-context handoff:
 
 1. Inspect the SOP output and confirm point attributes and provenance before
-   changing it. A public reconstruction showcase requires splats trained from
-   at least three views of the same subject with solved camera poses.
-2. Prepare it with Labs `Normals from GSplats` and/or `Delight GSplats`.
+   changing it. The preflight recognizes Houdini-native GSplats and standard
+   3DGS PLY exports (`f_dc*`, `rot*`, `scale*`, `opacity`, and `f_rest*`). A
+   public reconstruction showcase requires splats trained from at least three
+   views of the same subject with solved camera poses.
+2. Prepare it with Houdini `Bake GSplats` when normalization is required, then
+   Labs `Normals from GSplats` and/or `Delight GSplats`. Keep spherical
+   harmonics enabled when the source provides `f_rest*` coefficients.
 3. In Solaris, use `Relight GSplats` with USD lights, a render camera, shadows,
    shadow bias, and optional dome/HDRI lighting. Use `houdini-parameters` for
    version-specific Labs parameters that are not exposed by the setup tool.

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -48,8 +48,7 @@ def _names(attributes: Iterable[dict]) -> set:
 def _has_expanded_attribute(names: set, base: str, count: int) -> bool:
     """Accept the expanded PLY spellings emitted by common 3DGS exporters."""
     return any(
-        all("{}{}{}".format(base, separator, index) in names for index in range(count))
-        for separator in ("", "_")
+        all("{}{}{}".format(base, separator, index) in names for index in range(count)) for separator in ("", "_")
     )
 
 
@@ -73,9 +72,7 @@ def _gsplat_schema(names: set) -> dict:
         "spherical_harmonics": "f_rest" in names or _has_expanded_attribute(names, "f_rest", 45),
     }
     raw_core = all(raw_checks[key] for key in ("position", "color", "orientation", "scale", "opacity"))
-    native_core = all(
-        native_checks[key] for key in ("position", "color_or_albedo", "orientation", "scale", "opacity")
-    )
+    native_core = all(native_checks[key] for key in ("position", "color_or_albedo", "orientation", "scale", "opacity"))
     if native_core:
         source_schema = "houdini_gsplat"
     elif raw_core:
@@ -294,9 +291,7 @@ def prepare_gsplat_sop_chain(
         convert_spherical_harmonics = False
         if schema["normalization_required"]:
             if not normalize_input:
-                raise ValueError(
-                    "Standard 3DGS PLY attributes require Houdini Bake GSplats before Labs processing"
-                )
+                raise ValueError("Standard 3DGS PLY attributes require Houdini Bake GSplats before Labs processing")
             bake = _create(parent, ("bakegsplat",), "{}_bake".format(name_prefix))
             created.append(bake)
             bake.setInput(0, current)

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -45,6 +45,52 @@ def _names(attributes: Iterable[dict]) -> set:
     return {item["name"] for item in attributes}
 
 
+def _has_expanded_attribute(names: set, base: str, count: int) -> bool:
+    """Accept the expanded PLY spellings emitted by common 3DGS exporters."""
+    return any(
+        all("{}{}{}".format(base, separator, index) in names for index in range(count))
+        for separator in ("", "_")
+    )
+
+
+def _gsplat_schema(names: set) -> dict:
+    native_checks = {
+        "position": "P" in names,
+        "color_or_albedo": bool({"Cd", "albedo"} & names),
+        "normal": "N" in names,
+        "orientation": "orient" in names,
+        "scale": bool({"scale", "pscale"} & names),
+        "opacity": bool({"GS_Alpha", "Alpha", "alpha"} & names),
+        "spherical_harmonics": {"GS_SPH_R", "GS_SPH_G", "GS_SPH_B"}.issubset(names),
+        "ambient_occlusion": "ao" in names,
+    }
+    raw_checks = {
+        "position": "P" in names,
+        "color": "f_dc" in names or _has_expanded_attribute(names, "f_dc", 3),
+        "orientation": "rot" in names or _has_expanded_attribute(names, "rot", 4),
+        "scale": "scale" in names or _has_expanded_attribute(names, "scale", 3),
+        "opacity": "opacity" in names,
+        "spherical_harmonics": "f_rest" in names or _has_expanded_attribute(names, "f_rest", 45),
+    }
+    raw_core = all(raw_checks[key] for key in ("position", "color", "orientation", "scale", "opacity"))
+    native_core = all(
+        native_checks[key] for key in ("position", "color_or_albedo", "orientation", "scale", "opacity")
+    )
+    if native_core:
+        source_schema = "houdini_gsplat"
+    elif raw_core:
+        source_schema = "standard_3dgs_ply"
+    else:
+        source_schema = "unknown"
+    return {
+        "source_schema": source_schema,
+        "native_checks": native_checks,
+        "raw_checks": raw_checks,
+        "normalization_required": source_schema == "standard_3dgs_ply",
+        "normalization_available": raw_core,
+    }
+
+
 def _find_node_type(parent: Any, aliases: Sequence[str]) -> str:
     category = parent.childTypeCategory()
     available = category.nodeTypes()
@@ -175,17 +221,10 @@ def inspect_gsplat_relighting_input(
         has_enough_views = int(source_view_count) >= 3
         captured_provenance = has_capture_type and has_enough_views and bool(camera_poses_solved)
         showcase_provenance_pass = captured_provenance or not bool(public_showcase)
-        checks = {
-            "position": "P" in names,
-            "color_or_albedo": bool({"Cd", "albedo"} & names),
-            "normal": "N" in names,
-            "orientation": "orient" in names,
-            "scale": bool({"scale", "pscale"} & names),
-            "opacity": bool({"GS_Alpha", "Alpha", "alpha"} & names),
-            "spherical_harmonics": {"GS_SPH_R", "GS_SPH_G", "GS_SPH_B"}.issubset(names),
-            "ambient_occlusion": "ao" in names,
-        }
+        schema = _gsplat_schema(names)
+        checks = schema["native_checks"]
         missing = [key for key, present in checks.items() if not present and key in ("position", "color_or_albedo")]
+        ready_for_preparation = schema["source_schema"] in ("houdini_gsplat", "standard_3dgs_ply")
         return skill_success(
             "Inspected GSplat relighting input",
             source=_summary(source),
@@ -193,6 +232,12 @@ def inspect_gsplat_relighting_input(
             primitive_count=int(geometry.primCount()),
             point_attributes=attributes,
             checks=checks,
+            raw_checks=schema["raw_checks"],
+            source_schema=schema["source_schema"],
+            normalization_required=schema["normalization_required"],
+            normalization_available=schema["normalization_available"],
+            recommended_normalizer="bakegsplat" if schema["normalization_required"] else None,
+            ready_for_preparation=ready_for_preparation,
             ready_for_relighting=not missing and showcase_provenance_pass,
             blocking_missing=missing + ([] if showcase_provenance_pass else ["captured_gsplat_provenance"]),
             provenance={
@@ -206,6 +251,7 @@ def inspect_gsplat_relighting_input(
                 "Run Labs Normals from GSplats when N is absent.",
                 "Run Labs Delight GSplats when albedo is absent or captured lighting must be removed.",
                 "Preserve GS_SPH_R/G/B when view-dependent captured appearance matters.",
+                "Run Houdini Bake GSplats before Labs when source_schema is standard_3dgs_ply.",
                 "Do not label procedural point sampling as captured GSplat reconstruction.",
             ],
         )
@@ -218,6 +264,8 @@ def prepare_gsplat_sop_chain(
     node_path: str,
     create_normals: bool = True,
     create_albedo: bool = True,
+    normalize_input: bool = True,
+    preserve_spherical_harmonics: bool = True,
     name_prefix: str = "gsplat_relight",
     cook: bool = True,
 ) -> dict:
@@ -240,6 +288,24 @@ def prepare_gsplat_sop_chain(
         if not stages:
             raise ValueError("At least one of create_normals/create_albedo must be true")
         current = source
+        names = {attrib.name() for attrib in source.geometry().pointAttribs()}
+        schema = _gsplat_schema(names)
+        normalizer = None
+        convert_spherical_harmonics = False
+        if schema["normalization_required"]:
+            if not normalize_input:
+                raise ValueError(
+                    "Standard 3DGS PLY attributes require Houdini Bake GSplats before Labs processing"
+                )
+            bake = _create(parent, ("bakegsplat",), "{}_bake".format(name_prefix))
+            created.append(bake)
+            bake.setInput(0, current)
+            convert_spherical_harmonics = bool(
+                preserve_spherical_harmonics and schema["raw_checks"]["spherical_harmonics"]
+            )
+            _set_first(bake, ("sphcoeff",), convert_spherical_harmonics)
+            current = bake
+            normalizer = _summary(bake)
         for suffix, aliases in stages:
             child = _create(parent, aliases, "{}_{}".format(name_prefix, suffix))
             created.append(child)
@@ -254,7 +320,14 @@ def prepare_gsplat_sop_chain(
             source=_summary(source),
             nodes=[_summary(item) for item in created],
             output=_summary(current),
-            output_attributes=[name for name, enabled in (("N", create_normals), ("albedo", create_albedo)) if enabled],
+            source_schema=schema["source_schema"],
+            normalized_input=normalizer is not None,
+            normalizer=normalizer,
+            output_attributes=(
+                (["Cd", "orient", "scale", "GS_Alpha"] if normalizer else [])
+                + (["GS_SPH_R", "GS_SPH_G", "GS_SPH_B"] if normalizer and convert_spherical_harmonics else [])
+                + [name for name, enabled in (("N", create_normals), ("albedo", create_albedo)) if enabled]
+            ),
             cooked=bool(cook),
         )
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
@@ -3,7 +3,9 @@ tools:
     description: >-
       Inspect a SOP GSplat output for the attributes needed by Labs normal
       reconstruction, delighting, Solaris relighting, and Copernicus
-      rasterization. Read-only and bounded to attribute metadata and counts.
+      rasterization. Detects both Houdini-native attributes and standard 3DGS
+      PLY attributes that can be normalized with Bake GSplats. Read-only and
+      bounded to attribute metadata and counts.
     source_file: scripts/inspect_gsplat_relighting_input.py
     execution: sync
     affinity: main
@@ -55,9 +57,10 @@ tools:
   - name: prepare_gsplat_sop_chain
     description: >-
       Append the installed Labs Normals from GSplats and/or Delight GSplats
-      SOPs to an existing GSplat output, preserving the source and returning
-      the actual node paths and output attributes. Rolls back newly created
-      nodes if the chain cannot be built.
+      SOPs to an existing GSplat output. Standard 3DGS PLY inputs are first
+      normalized with Houdini's Bake GSplats SOP. Preserves the source,
+      returns actual node paths and output attributes, and rolls back newly
+      created nodes if the chain cannot be built.
     source_file: scripts/prepare_gsplat_sop_chain.py
     execution: sync
     affinity: main
@@ -83,6 +86,14 @@ tools:
           type: boolean
           default: true
           description: Append Labs Delight GSplats, which writes the albedo attribute.
+        normalize_input:
+          type: boolean
+          default: true
+          description: Insert Houdini Bake GSplats when standard 3DGS PLY attributes are detected.
+        preserve_spherical_harmonics:
+          type: boolean
+          default: true
+          description: Convert f_rest coefficients to GS_SPH_R/G/B when the source provides them.
         name_prefix:
           type: string
           default: gsplat_relight

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -256,6 +256,42 @@ class TestGsplatRelightingSkills:
         assert result["context"]["ready_for_relighting"] is True
         assert result["context"]["checks"]["spherical_harmonics"] is True
 
+    def test_inspect_recognizes_standard_3dgs_ply_as_convertible(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        names = ["P", "opacity"]
+        names.extend("f_dc_{}".format(index) for index in range(3))
+        names.extend("rot_{}".format(index) for index in range(4))
+        names.extend("scale_{}".format(index) for index in range(3))
+        names.extend("f_rest_{}".format(index) for index in range(45))
+        attrs = []
+        for name in names:
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attrib.dataType.return_value.name.return_value = "Float"
+            attrib.size.return_value = 3 if name == "P" else 1
+            attrs.append(attrib)
+        geometry = MagicMock()
+        geometry.pointAttribs.return_value = attrs
+        geometry.pointCount.return_value = 70269
+        geometry.primCount.return_value = 0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/raw_ply"
+        node.name.return_value = "raw_ply"
+        node.type.return_value.name.return_value = "file"
+        node.geometry.return_value = geometry
+        with patch.dict(sys.modules, {"hou": MagicMock(node=lambda _path: node)}):
+            result = mod.inspect_gsplat_relighting_input(node_path="/obj/geo1/raw_ply")
+
+        context = result["context"]
+        assert result["success"] is True
+        assert context["source_schema"] == "standard_3dgs_ply"
+        assert context["normalization_required"] is True
+        assert context["normalization_available"] is True
+        assert context["ready_for_preparation"] is True
+        assert context["ready_for_relighting"] is False
+        assert context["raw_checks"]["spherical_harmonics"] is True
+        assert context["recommended_normalizer"] == "bakegsplat"
+
     def test_public_showcase_rejects_synthetic_point_sampling(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
         attrs = []
@@ -296,6 +332,54 @@ class TestGsplatRelightingSkills:
 
         assert result["success"] is False
         source.parent.return_value.createNode.assert_not_called()
+
+    def test_prepare_normalizes_standard_3dgs_ply_with_bake_gsplats(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        source = MagicMock()
+        source.path.return_value = "/obj/geo1/raw_ply"
+        source.name.return_value = "raw_ply"
+        source.type.return_value.name.return_value = "file"
+        attributes = []
+        names = ["P", "opacity"]
+        names.extend("f_dc_{}".format(index) for index in range(3))
+        names.extend("rot_{}".format(index) for index in range(4))
+        names.extend("scale_{}".format(index) for index in range(3))
+        names.extend("f_rest_{}".format(index) for index in range(45))
+        for name in names:
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attributes.append(attrib)
+        source.geometry.return_value.pointAttribs.return_value = attributes
+        parent = MagicMock()
+        source.parent.return_value = parent
+        bake = MagicMock()
+        bake.path.return_value = "/obj/geo1/relight_bake"
+        bake.name.return_value = "relight_bake"
+        bake.type.return_value.name.return_value = "bakegsplat"
+        normals = MagicMock()
+        normals.path.return_value = "/obj/geo1/relight_normals"
+        normals.name.return_value = "relight_normals"
+        normals.type.return_value.name.return_value = "labs::normals_from_gsplats::1.0"
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(mod, "_node", return_value=source))
+            create = stack.enter_context(patch.object(mod, "_create", side_effect=[bake, normals]))
+            set_first = stack.enter_context(patch.object(mod, "_set_first", return_value="sphcoeff"))
+            stack.enter_context(patch.dict(sys.modules, {"hou": MagicMock()}))
+            result = mod.prepare_gsplat_sop_chain(
+                node_path="/obj/geo1/raw_ply",
+                create_normals=True,
+                create_albedo=False,
+            )
+
+        assert result["success"] is True
+        assert result["context"]["normalized_input"] is True
+        assert result["context"]["source_schema"] == "standard_3dgs_ply"
+        assert result["context"]["normalizer"]["type"] == "bakegsplat"
+        assert create.call_args_list[0].args[1] == ("bakegsplat",)
+        bake.setInput.assert_called_once_with(0, source)
+        normals.setInput.assert_called_once_with(0, bake)
+        set_first.assert_any_call(bake, ("sphcoeff",), True)
 
     def test_copernicus_raster_uses_houdini_22_external_sop_and_resolution_contract(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")


### PR DESCRIPTION
## Summary
- detect standard 3DGS PLY attribute layouts
- insert Houdini Bake GSplats before Labs processing
- preserve spherical harmonics when available

## Validation
- 905 tests passed, 1 skipped
- skill lint passed with zero warnings
- verified in Houdini 22 with a captured multiview GSplat dataset