### PR TITLE
Fix headless shutdown drain race

### DIFF
--- a/src/dcc_mcp_houdini/host.py
+++ b/src/dcc_mcp_houdini/host.py
@@ -384,6 +384,10 @@ class HoudiniHost(HostAdapter):
         super().__init__(dispatcher, name=kwargs.pop("name", "houdini-host"), **kwargs)
         self._callback: Optional[Callable[[], bool]] = None
         self._tick_thread_ident: Optional[int] = None
+        self._headless_state_lock = threading.Lock()
+        self._headless_run_thread_ident: Optional[int] = None
+        self._headless_run_exited = threading.Event()
+        self._headless_run_exited.set()
 
     @property
     def tick_thread_ident(self) -> Optional[int]:
@@ -401,8 +405,37 @@ class HoudiniHost(HostAdapter):
 
     def run_headless(self, stop_event: Optional[threading.Event] = None) -> None:
         """Pump on Hython's owning thread until shutdown is requested."""
-        self._tick_thread_ident = threading.get_ident()
-        super().run_headless(stop_event=stop_event)
+        thread_ident = threading.get_ident()
+        with self._headless_state_lock:
+            self._tick_thread_ident = thread_ident
+            self._headless_run_thread_ident = thread_ident
+            self._headless_run_exited.clear()
+        try:
+            super().run_headless(stop_event=stop_event)
+        finally:
+            with self._headless_state_lock:
+                self._headless_run_thread_ident = None
+                self._headless_run_exited.set()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Stop only after a caller-owned blocking tick releases its drain lock."""
+        started_wait = time.monotonic()
+        with self._headless_state_lock:
+            run_thread_ident = self._headless_run_thread_ident
+            run_active = not self._headless_run_exited.is_set()
+
+        if run_active:
+            self._stop_event.set()
+            if run_thread_ident == threading.get_ident():
+                # A signal handler can re-enter shutdown on the same thread
+                # while the native blocking tick still owns its receiver lock.
+                # Let run_headless unwind; its finally path performs teardown.
+                return
+            if not self._headless_run_exited.wait(timeout=max(timeout, 0.0)):
+                raise RuntimeError(f"Houdini headless pump did not stop within {timeout}s")
+
+        remaining = max(timeout - (time.monotonic() - started_wait), 0.0)
+        super().stop(timeout=remaining)
 
     def attach_tick(self, tick_fn: TickFn) -> None:
         """Register ``tick_fn`` with ``hou.ui.addEventLoopCallback``."""

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -31,6 +31,31 @@ class _FakeHoudiniUi:
         self.callbacks.remove(callback)
 
 
+class _BlockingProbeDispatcher:
+    """Model a headless dispatcher whose blocking tick owns the drain lock."""
+
+    def __init__(self) -> None:
+        self.tick_entered = threading.Event()
+        self.release_tick = threading.Event()
+        self.tick_active = threading.Event()
+        self.shutdown_called = threading.Event()
+        self.shutdown_while_ticking = False
+
+    def tick_blocking(self, max_jobs: int, timeout_ms: int) -> None:
+        _ = (max_jobs, timeout_ms)
+        self.tick_active.set()
+        self.tick_entered.set()
+        self.release_tick.wait(timeout=1)
+        self.tick_active.clear()
+
+    def is_shutdown(self) -> bool:
+        return self.shutdown_called.is_set()
+
+    def shutdown(self) -> None:
+        self.shutdown_while_ticking = self.tick_active.is_set()
+        self.shutdown_called.set()
+
+
 def _fake_hou(ui_available: bool = True):
     ui = _FakeHoudiniUi()
     return SimpleNamespace(isUIAvailable=lambda: ui_available, ui=ui), ui
@@ -75,6 +100,31 @@ def test_legacy_houdini_host_retains_headless_bootstrap_contract() -> None:
     stop = threading.Event()
     stop.set()
     HoudiniHost(BlockingDispatcher()).run_headless(stop_event=stop)
+
+
+def test_headless_stop_waits_for_calling_thread_tick_before_dispatcher_shutdown() -> None:
+    """External shutdown must not race a caller-owned blocking drain."""
+    from dcc_mcp_houdini.host import HoudiniHost
+
+    dispatcher = _BlockingProbeDispatcher()
+    host = HoudiniHost(dispatcher)
+    runner = threading.Thread(target=host.run_headless)
+    runner.start()
+    assert dispatcher.tick_entered.wait(timeout=1)
+
+    stopper = threading.Thread(target=lambda: host.stop(timeout=1))
+    stopper.start()
+    assert not dispatcher.shutdown_called.wait(timeout=0.05)
+    assert stopper.is_alive(), "stop should wait for the active blocking tick"
+
+    dispatcher.release_tick.set()
+    stopper.join(timeout=1)
+    runner.join(timeout=1)
+
+    assert not stopper.is_alive()
+    assert not runner.is_alive()
+    assert dispatcher.shutdown_called.is_set()
+    assert dispatcher.shutdown_while_ticking is False
 
 
 def test_event_loop_adapter_throttles_due_ticks_and_isolates_exceptions() -> None:


### PR DESCRIPTION
## Summary
- wait for the caller-owned headless pump to release its blocking tick before dispatcher shutdown
- keep same-thread signal re-entry non-blocking
- add a concurrent shutdown regression test

## Validation
- 914 passed, 1 skipped, 3 deselected
- Ruff passed
- git diff --check passed