### PR TITLE
Harden GSplat output evidence and Houdini cook safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ SideFX Houdini adapter for the DCC Model Context Protocol (MCP) ecosystem.
 It embeds a Streamable HTTP MCP server inside Houdini/hython and exposes
 skills-first Houdini automation tools to agents.
 
-## Houdini 22 captured GSplat engineering validation
+## Houdini 22 interim captured-GSplat engineering validation
 
 ![Licensed multiview input for specimen UCSB-IZC00037044](docs/showcase/honeybee-ucsb-izc00037044-multiview.jpg)
 
@@ -80,6 +80,7 @@ limitations are in
 
 ![Captured GSplat animated with KineFX and Houdini Groom in an outdoor HDR environment](docs/showcase/houdini-honeybee-gsplat-kinefx-groom.gif)
 
+This is an interim engineering showcase, not the final honeybee beauty target.
 The Houdini 22 scene exercises GSplat-aware KineFX deformation, articulated
 wing/body/leg controls, a deformation-synchronized short-fur Groom, and a fixed
 camera flipbook under a neutral outdoor HDR environment. The five-frame contact
@@ -99,7 +100,8 @@ engineering evidence rather than final beauty approval: pin removal cannot
 synthesize occluded anatomy, residual
 capture-support Gaussians remain visible, and the pinned specimen cannot supply
 biological flight or foot-contact motion. A final living-bee showcase still
-requires a cleaner licensed capture and dedicated contact/occlusion review.
+requires a cleaner licensed capture, higher-fidelity reconstruction, and
+dedicated contact/occlusion review.
 
 Source attribution and the separation between captured evidence and authored
 animation are documented in
@@ -352,7 +354,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | `houdini-pipeline` | `set_project`, `get_project`, `tag_asset_metadata`, `get_asset_metadata`, `validate_scene`, `collect_dependencies`, `export_shot_package` |
 | `houdini-dev` | `attach_project`, `reload_modules`, `run_entrypoint`, `run_script`, `start_debugpy`, `introspect_hom`, `ui_snapshot`, `ui_action` |
 | `houdini-automation` | `run_python_file`, `set_frame_range`, `save_hip_file`, `load_hip_file`, `build_node_chain` |
-| `houdini-gsplat-relighting` | `inspect_gsplat_relighting_input`, `prepare_gsplat_sop_chain`, `create_gsplat_relight_lop`, `create_gsplat_copernicus_raster` |
+| `houdini-gsplat-relighting` | `inspect_gsplat_relighting_input`, `prepare_gsplat_sop_chain`, `create_gsplat_relight_lop`, `refresh_gsplat_relight_sop_bridge`, `create_gsplat_copernicus_raster`, `write_gsplat_copernicus_image` |
 
 ## CI and Houdini Docker
 

--- a/docs/showcase/honeybee-reference-license.md
+++ b/docs/showcase/honeybee-reference-license.md
@@ -1,6 +1,6 @@
 # Honeybee showcase provenance and limits
 
-## Captured GSplat engineering validation
+## Interim captured-GSplat engineering validation
 
 The current captured-data validation uses specimen `UCSB-IZC00037044` from
 the University of California, Santa Barbara dataset
@@ -18,7 +18,9 @@ preview evaluation records PSNR 21.90895, SSIM 0.84895, and LPIPS 0.14534.
 Hashes, camera conventions, thresholds, and artifact disclosures are preserved
 in [`honeybee-gsplat-validation.json`](honeybee-gsplat-validation.json).
 
-The Houdini animation and fur are downstream authored layers. KineFX does not
+The current public result is engineering evidence with `public_beauty: fail`,
+not the final high-fidelity honeybee showcase. The Houdini animation and fur
+are downstream authored layers. KineFX does not
 turn the pinned specimen into captured biological motion, and Houdini Groom
 curves are not photographed strands. The outdoor environment is presentation
 lighting, not part of the source capture. Residual support Gaussians and
@@ -39,10 +41,10 @@ are intentionally not painted out.
 
 ## Archived procedural rig validation
 
-The animated asset in this showcase is an original DCC-MCP procedural model.
-It is assembled from authored polygonal forms, curves, materials, and KineFX
-animation. It is not a SideFX sample, photogrammetry reconstruction, CT mesh,
-or trained Gaussian Splat.
+The separate archived procedural sequence is an original DCC-MCP model. It is
+assembled from authored polygonal forms, curves, materials, and KineFX
+animation. It is not the captured asset above, a SideFX sample,
+photogrammetry reconstruction, CT mesh, or trained Gaussian Splat.
 
 ## Published anatomy reference
 
@@ -61,25 +63,28 @@ The flight render uses Poly Haven's
 [Residential Garden](https://polyhaven.com/a/residential_garden) HDRI under the
 CC0 license. It is the only environment emitter in the shot.
 
-## Verified technical evidence
+## Verified technical evidence: captured GSplat
 
-- 96 frames at 1280×720 and 24 fps, rendered with Karma and displayed through
-  the Houdini 22 ACES configuration.
 - The current 5k checkpoint contains 263,630 trained Gaussians. Its Houdini
   subject-filtered engineering scene retains 15,475 Gaussians; fresh held-out
   5k image metrics remain pending and are not substituted with the older 3k
   preview metrics below.
-- Six procedural leg hierarchies with authored tarsus, pad, and claw controls.
-- Per-frame hierarchy checks keep the tested controls at or above Z=-0.003;
-  this is not a substitute for per-primitive collision or contact solving.
-- One bee instance is rendered; body motion blur is disabled to avoid apparent
-  duplicate silhouettes.
 - The Houdini UI captures are real and are not recreated product interfaces,
   but the current framing does not show the complete asset and readable node
   graph together. They are retained as internal validation evidence and are not
   presented as the final public UI acceptance frame.
 
-## Known limitations
+## Verified technical evidence: archived procedural rig
+
+- 96 frames at 1280×720 and 24 fps, rendered with Karma and displayed through
+  the Houdini 22 ACES configuration.
+- Six procedural leg hierarchies with authored tarsus, pad, and claw controls.
+- Per-frame hierarchy checks keep the tested controls at or above Z=-0.003;
+  this is not a substitute for per-primitive collision or contact solving.
+- One procedural insect instance is rendered; body motion blur is disabled to
+  avoid apparent duplicate silhouettes.
+
+## Known limitations of the archived procedural rig
 
 The current thorax, head, abdomen, legs, and wings are stylized procedural
 approximations. The silhouette reads closer to an ant-like generic insect than
@@ -92,8 +97,9 @@ The current body compliance is phase-delayed authored motion, not a biological
 soft-body simulation. Eye motion is a head/attention control, not compound-eye
 deformation. The garden render is also too dark for final LookDev acceptance.
 
-The next reconstruction stage is deliberately separate: train a real honeybee
-Gaussian Splat from a licensed multi-view capture, validate its provenance,
-deform it with the GSplat-aware KineFX tools, and generate fur with the Houdini
-Groom workflow. Until that evidence exists, this procedural asset must not be
-labelled as a real GSplat reconstruction.
+The next reconstruction stage is deliberately separate: produce a
+higher-fidelity honeybee Gaussian Splat from a cleaner licensed multi-view
+capture, validate its provenance and anatomy, deform it with the GSplat-aware
+KineFX tools, and generate fur with the Houdini Groom workflow. Until that
+evidence exists, neither the interim captured result nor the archived
+procedural rig may be presented as final honeybee beauty acceptance.

--- a/src/dcc_mcp_houdini/inline_cook_policy.py
+++ b/src/dcc_mcp_houdini/inline_cook_policy.py
@@ -1,0 +1,70 @@
+"""Safety policy for Houdini cooks that would otherwise run on the UI thread."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+DEFAULT_MAX_INLINE_INPUT_POINTS = 500_000
+_PRIVATE_PATH = re.compile(
+    r"(?:[A-Za-z]:[\\/]|\\\\|/(?:Users|home|private|var|tmp)/)",
+    re.IGNORECASE,
+)
+
+
+def public_exception_message(exc: Exception) -> str:
+    """Preserve useful messages unless they appear to contain host paths."""
+    message = str(exc).strip()
+    if not message or _PRIVATE_PATH.search(message):
+        return type(exc).__name__
+    return message
+
+
+def assess_inline_cook(
+    node: Any,
+    *,
+    max_input_points: int = DEFAULT_MAX_INLINE_INPUT_POINTS,
+) -> Optional[dict]:
+    """Return a rejection payload when cached direct inputs are too large.
+
+    Houdini HOM cooks are UI-thread-affine. Core ``execution: async`` changes
+    transport semantics but cannot preempt a single blocking ``node.cook``.
+    This conservative check inspects direct input geometry before mutation and
+    routes known-heavy work to the adapter's isolated hython cook contract.
+    Unavailable geometry is ignored so existing lightweight behavior remains.
+    """
+    inputs_method = getattr(node, "inputs", None)
+    if not callable(inputs_method):
+        return None
+    try:
+        inputs = tuple(item for item in inputs_method() if item is not None)
+    except Exception:  # noqa: BLE001
+        return None
+
+    total_points = 0
+    measured_inputs = 0
+    for input_node in inputs:
+        geometry_method = getattr(input_node, "geometry", None)
+        if not callable(geometry_method):
+            continue
+        try:
+            geometry = geometry_method()
+            point_count_method = getattr(geometry, "pointCount", None)
+            if not callable(point_count_method):
+                continue
+            count = int(point_count_method())
+        except Exception:  # noqa: BLE001
+            continue
+        if count < 0:
+            continue
+        measured_inputs += 1
+        total_points += count
+        if total_points > max_input_points:
+            return {
+                "input_point_count": total_points,
+                "measured_input_count": measured_inputs,
+                "max_inline_input_points": max_input_points,
+                "recommended_tool": "houdini_nodes__start_cook_job",
+                "reason": "direct_input_point_limit_exceeded",
+            }
+    return None

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_cook_status.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_cook_status.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from _geo_common import get_node  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+from dcc_mcp_houdini.inline_cook_policy import assess_inline_cook, public_exception_message
 
 
-def get_cook_status(node_path: str, force: bool = False) -> dict:
+def get_cook_status(node_path: str, force: bool = False, allow_heavy_inline: bool = False) -> dict:
     """Cook *node_path* and return any cook errors and warnings."""
     try:
         import hou  # noqa: PLC0415
@@ -15,11 +17,19 @@ def get_cook_status(node_path: str, force: bool = False) -> dict:
 
     try:
         node = get_node(hou, node_path)
+        rejection = None if allow_heavy_inline else assess_inline_cook(node)
+        if rejection is not None:
+            return skill_error(
+                "Inline Houdini cook rejected by safety policy",
+                "Potentially heavy SOP cook requires isolated execution",
+                node_path=node.path(),
+                **rejection,
+            )
         cook_error = None
         try:
             node.cook(force=force)
-        except Exception as exc:  # noqa: BLE001 - surface cook failure as data
-            cook_error = str(exc)
+        except Exception as exc:  # noqa: BLE001 - redact host paths from the public result
+            cook_error = public_exception_message(exc)
         errors = list(node.errors()) if hasattr(node, "errors") else []
         warnings = list(node.warnings()) if hasattr(node, "warnings") else []
         return skill_success(
@@ -31,7 +41,7 @@ def get_cook_status(node_path: str, force: bool = False) -> dict:
             warnings=warnings,
         )
     except Exception as exc:
-        return skill_exception(exc, message="Failed to cook node")
+        return skill_error("Failed to cook node", "Houdini node cook failed", error_type=type(exc).__name__)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/tools.yaml
@@ -200,7 +200,10 @@ tools:
           description: SOP node to inspect.
   - name: get_cook_status
     description: >-
-      Cook a SOP node and return cook success plus any errors and warnings.
+      Cook a lightweight SOP node and return cook success plus errors and
+      warnings. Direct inputs above the inline safety limit are rejected by
+      default because execution still occupies Houdini's UI thread; use
+      houdini_nodes__start_cook_job for potentially long cooks.
     source_file: scripts/get_cook_status.py
     execution: async
     affinity: main
@@ -224,3 +227,9 @@ tools:
           type: boolean
           default: false
           description: Force a recook even when the node is already cooked.
+        allow_heavy_inline:
+          type: boolean
+          default: false
+          description: >-
+            Explicitly accept UI-thread blocking when direct inputs exceed the
+            safety limit. Prefer the isolated node-cook job instead.

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/README.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/README.md
@@ -1,6 +1,6 @@
 # Houdini GSplat relighting
 
-![Captured honeybee GSplat animated with KineFX and Houdini Groom](../../../../docs/showcase/houdini-honeybee-gsplat-kinefx-groom-contact.png)
+![Interim captured-GSplat engineering validation with KineFX and Houdini Groom](../../../../docs/showcase/houdini-honeybee-gsplat-kinefx-groom-contact.png)
 
 Prepare an existing Gaussian Splat for interactive relighting, build its USD
 lighting stage, and produce a refined Copernicus image without falling back to
@@ -13,12 +13,27 @@ raw Python.
 2. `prepare_gsplat_sop_chain` reconstructs normals and optionally extracts
    albedo with SideFX Labs.
 3. `create_gsplat_relight_lop` creates the Solaris relighting node, camera,
-   USD lights, dome light, shadows, and shadow-bias controls.
-4. `create_gsplat_copernicus_raster` rasterizes from the camera and can append
-   resolution, sharpen, HSV, gamma, and premultiplication refinements.
+   USD lights, dome light, shadows, and shadow-bias controls. When available it
+   also returns a stable relit SOP output with point and attribute evidence.
+4. `refresh_gsplat_relight_sop_bridge` rediscovers and force-cooks that bridge
+   after Dome or relight parameter changes; callers never depend on a Labs HDA
+   internal node path.
+5. `create_gsplat_copernicus_raster` rasterizes from the camera and can append
+   resolution, sharpen, HSV, gamma, and premultiplication refinements. It can
+   also load an absolute HDR/background image and composite GSplats over it via
+   the Houdini 22 Blend COP's named `bg` and `fg` inputs.
+6. `write_gsplat_copernicus_image` creates or reuses a named `/out` Image ROP,
+   renders one frame in the foreground, and reports the freshly written file
+   plus existence and byte-size evidence.
 
 The result is a prepared SOP stream, an editable Solaris lighting stage, and a
 camera-matched COP output suitable for near-real-time look development.
+Use the Image ROP writer for acceptance; node cooking and Viewer caches alone
+do not prove that pixels were written to disk.
+
+The linked honeybee media is explicitly an interim engineering validation with
+known fixture, anatomy, and LookDev defects. It demonstrates the typed workflow
+and must not be presented as final high-fidelity honeybee beauty acceptance.
 
 Requires Houdini 22 and current SideFX Labs GSplat assets. See
 [SKILL.md](SKILL.md) for attribute and execution contracts; `tools.yaml`

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
@@ -35,10 +35,23 @@ Use the typed tools in this package for the cross-context handoff:
 3. In Solaris, use `Relight GSplats` with USD lights, a render camera, shadows,
    shadow bias, and optional dome/HDRI lighting. Use `houdini-parameters` for
    version-specific Labs parameters that are not exposed by the setup tool.
+   When Labs exposes compatible relit points, the setup tool discovers them by
+   geometry attributes and publishes a stable object-level `sop_output_path`;
+   consumers must not address `/sopmodify.../OUT` or other HDA internals.
+   After changing Dome or relight parameters, call
+   `refresh_gsplat_relight_sop_bridge` before rasterization to force-cook the
+   relight asset and refresh the stable bridge.
 4. In Copernicus, import the prepared or relit SOP result and use `Rasterize
    GSplats` with camera metadata. The setup tool can append Sharpen, HSV,
    Gamma, and Premult nodes and set the H22 network resolution; use parameter
-   skills for further interactive tuning.
+   skills for further interactive tuning. An optional absolute HDR/background
+   image creates a File COP followed by a Blend COP in bounded `over` mode.
+   The Blend connection uses H22 `setNamedInput` for `bg` and `fg`; positional
+   `setInput` is not valid evidence for this multi-input Copernicus contract.
+5. For pixel acceptance, call `write_gsplat_copernicus_image` with the returned
+   COP output and an absolute file path. It renders one frame synchronously
+   through a named Houdini 22 Image ROP and succeeds only when a fresh,
+   non-empty file is present. A cooked COP or Viewer image is not disk evidence.
 
 The expected handoff attributes are `P`, `Cd` or `albedo`, `N`, `orient`,
 `scale`/`pscale`, opacity, and optional `GS_SPH_R/G/B` plus `ao`. The setup

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import math
+import os
+import re
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def _node(hou: Any, path: str) -> Any:
@@ -23,6 +26,29 @@ def _type_name(node: Any) -> str:
 
 def _summary(node: Any) -> dict:
     return {"path": node.path(), "name": node.name(), "type": _type_name(node)}
+
+
+def _safe_public_error(message: str, error: str, exc: Exception) -> dict:
+    """Return a public failure without exception repr, traceback, or host paths."""
+    return skill_error(message, error, error_type=type(exc).__name__)
+
+
+_GSPLAT_BRIDGE_ATTRIBUTES = (
+    "P",
+    "Cd",
+    "albedo",
+    "N",
+    "orient",
+    "scale",
+    "pscale",
+    "GS_Alpha",
+    "Alpha",
+    "alpha",
+    "GS_SPH_R",
+    "GS_SPH_G",
+    "GS_SPH_B",
+    "ao",
+)
 
 
 def _attributes(geometry: Any, limit: int) -> List[dict]:
@@ -253,7 +279,7 @@ def inspect_gsplat_relighting_input(
             ],
         )
     except Exception as exc:
-        return skill_exception(exc, message="Failed to inspect GSplat input")
+        return _safe_public_error("Failed to inspect GSplat input", "Houdini GSplat inspection failed", exc)
 
 
 @skill_entry
@@ -331,7 +357,11 @@ def prepare_gsplat_sop_chain(
                 item.destroy()
             except Exception:  # noqa: BLE001
                 pass
-        return skill_exception(exc, message="Failed to prepare GSplat SOP chain; created nodes were rolled back")
+        return _safe_public_error(
+            "Failed to prepare GSplat SOP chain; created nodes were rolled back",
+            "Houdini GSplat SOP preparation failed",
+            exc,
+        )
 
 
 @skill_entry
@@ -343,6 +373,7 @@ def create_gsplat_relight_lop(
     shadow_bias: Optional[float] = None,
     lights: Optional[List[Dict[str, Any]]] = None,
     parameters: Optional[Dict[str, Any]] = None,
+    create_sop_bridge: bool = True,
 ) -> dict:
     """Create USD lights and a Labs Relight GSplats LOP."""
     try:
@@ -412,6 +443,24 @@ def create_gsplat_relight_lop(
             (applied if selected else unsupported).append(key)
         if hasattr(parent, "layoutChildren"):
             parent.layoutChildren(items=created)
+        bridge_contract = {
+            "sop_bridge_available": False,
+            "sop_output_path": None,
+            "point_count": 0,
+            "gsplat_attributes": [],
+            "bridge_refreshed": False,
+            "sop_bridge_status": "disabled",
+            "sop_bridge_error_type": None,
+        }
+        if create_sop_bridge:
+            try:
+                bridge_contract = _build_or_refresh_relight_sop_bridge(hou, relight, force=True)
+            except ValueError as exc:
+                bridge_contract["sop_bridge_status"] = "compatible_sop_output_not_available"
+                bridge_contract["sop_bridge_error_type"] = type(exc).__name__
+            except Exception as exc:  # noqa: BLE001
+                bridge_contract["sop_bridge_status"] = "bridge_refresh_failed"
+                bridge_contract["sop_bridge_error_type"] = type(exc).__name__
         return skill_success(
             "Created GSplat Solaris relighting stage",
             input=_summary(source),
@@ -420,6 +469,7 @@ def create_gsplat_relight_lop(
             applied_parameters=applied,
             unsupported_parameters=unsupported,
             output_attributes=["Cd", "GS_SPH_R", "GS_SPH_G", "GS_SPH_B"],
+            **bridge_contract,
         )
     except Exception as exc:
         for item in reversed(created):
@@ -427,9 +477,214 @@ def create_gsplat_relight_lop(
                 item.destroy()
             except Exception:  # noqa: BLE001
                 pass
-        return skill_exception(
-            exc, message="Failed to create GSplat Solaris relighting stage; created nodes were rolled back"
+        return _safe_public_error(
+            "Failed to create GSplat Solaris relighting stage; created nodes were rolled back",
+            "Houdini Solaris relighting setup failed",
+            exc,
         )
+
+
+def _node_point_contract(node: Any) -> Optional[dict]:
+    geometry_method = getattr(node, "geometry", None)
+    if not callable(geometry_method):
+        return None
+    try:
+        geometry = geometry_method()
+        point_count = int(geometry.pointCount())
+        names = {attrib.name() for attrib in geometry.pointAttribs()}
+    except Exception:  # noqa: BLE001
+        return None
+    if point_count <= 0 or "P" not in names:
+        return None
+    checks = (
+        bool({"Cd", "albedo"} & names),
+        "orient" in names,
+        bool({"scale", "pscale"} & names),
+        bool({"GS_Alpha", "Alpha", "alpha"} & names),
+    )
+    if sum(checks) < 3:
+        return None
+    attributes = sorted(names & set(_GSPLAT_BRIDGE_ATTRIBUTES))
+    score = len(attributes)
+    if {"GS_SPH_R", "GS_SPH_G", "GS_SPH_B"}.issubset(names):
+        score += 20
+    try:
+        if str(node.name()).upper() == "OUT":
+            score += 8
+    except Exception:  # noqa: BLE001
+        pass
+    for method_name in ("isDisplayFlagSet", "isRenderFlagSet"):
+        try:
+            if bool(getattr(node, method_name)()):
+                score += 4
+        except Exception:  # noqa: BLE001
+            pass
+    return {"node": node, "point_count": point_count, "gsplat_attributes": attributes, "score": score}
+
+
+def _discover_relight_sop_output(relight: Any, max_nodes: int = 256) -> dict:
+    try:
+        descendants = list(
+            relight.allSubChildren(
+                recurse_in_locked_nodes=True,
+                sync_delayed_definition=True,
+            )
+        )[:max_nodes]
+    except Exception:  # noqa: BLE001
+        descendants = []
+        pending = list(getattr(relight, "children", lambda: ())())
+        while pending and len(descendants) < max_nodes:
+            child = pending.pop(0)
+            descendants.append(child)
+            try:
+                pending.extend(child.children())
+            except Exception:  # noqa: BLE001
+                pass
+    contracts = []
+    for node in descendants:
+        contract = _node_point_contract(node)
+        if contract is not None:
+            contracts.append(contract)
+    if not contracts:
+        raise ValueError("No compatible GSplat SOP output was discovered inside the relight asset")
+    return max(contracts, key=lambda item: item["score"])
+
+
+def _bridge_child(parent: Any, name: str, type_name: str) -> Any:
+    node = parent.node(name)
+    if node is None:
+        return parent.createNode(type_name, name)
+    if _type_name(node).split("::", 1)[0] != type_name:
+        raise ValueError("Stable GSplat SOP bridge contains an incompatible node")
+    return node
+
+
+def _build_or_refresh_relight_sop_bridge(hou: Any, relight: Any, force: bool = True) -> dict:
+    relight.cook(force=bool(force))
+    discovered = _discover_relight_sop_output(relight)
+    internal_output = discovered["node"]
+    internal_output.cook(force=bool(force))
+
+    obj = _node(hou, "/obj")
+    safe_relight_name = re.sub(r"[^A-Za-z0-9_]+", "_", str(relight.name())).strip("_") or "gsplat_relight"
+    bridge_name = "dcc_mcp_{}_sop_bridge".format(safe_relight_name)[:64]
+    bridge_geo = obj.node(bridge_name)
+    if bridge_geo is None:
+        bridge_geo = obj.createNode("geo", bridge_name)
+    elif _type_name(bridge_geo).split("::", 1)[0] != "geo":
+        raise ValueError("Stable GSplat SOP bridge name is occupied by an incompatible node")
+
+    object_merge = _bridge_child(bridge_geo, "GSPLAT_RELIT_SOURCE", "object_merge")
+    output = _bridge_child(bridge_geo, "OUT", "null")
+    source_parm = object_merge.parm("objpath1")
+    if source_parm is None:
+        raise ValueError("Stable GSplat SOP bridge has no source-path parameter")
+    source_parm.deleteAllKeyframes()
+    source_parm.set(internal_output.path())
+    output.setInput(0, object_merge)
+    if hasattr(output, "setDisplayFlag"):
+        output.setDisplayFlag(True)
+    if hasattr(output, "setRenderFlag"):
+        output.setRenderFlag(True)
+    if hasattr(bridge_geo, "layoutChildren"):
+        bridge_geo.layoutChildren(items=[object_merge, output])
+    object_merge.cook(force=bool(force))
+    output.cook(force=bool(force))
+
+    output_contract = _node_point_contract(output)
+    if output_contract is None:
+        raise ValueError("Stable GSplat SOP bridge did not produce compatible point geometry")
+    if hasattr(relight, "setUserData"):
+        relight.setUserData("dcc_mcp.gsplat_relight.sop_output", output.path())
+    return {
+        "sop_bridge_available": True,
+        "sop_output_path": output.path(),
+        "point_count": output_contract["point_count"],
+        "gsplat_attributes": output_contract["gsplat_attributes"],
+        "bridge_refreshed": True,
+        "sop_bridge_status": "ready",
+    }
+
+
+@skill_entry
+def refresh_gsplat_relight_sop_bridge(relight_lop_path: str, force: bool = True) -> dict:
+    """Rediscover and force-cook the stable SOP bridge for a Labs relight LOP."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+    try:
+        relight = _node(hou, relight_lop_path)
+        contract = _build_or_refresh_relight_sop_bridge(hou, relight, force=force)
+        return skill_success("Refreshed GSplat Solaris-to-SOP bridge", relight=_summary(relight), **contract)
+    except ValueError as exc:
+        return _safe_public_error(
+            "GSplat Solaris-to-SOP bridge is unavailable",
+            "Compatible relit GSplat SOP output was not available",
+            exc,
+        )
+    except Exception as exc:
+        return _safe_public_error(
+            "Failed to refresh GSplat Solaris-to-SOP bridge",
+            "Houdini bridge refresh failed",
+            exc,
+        )
+
+
+def _cop_output_reference(source: Any) -> Any:
+    """Return a named Copernicus output when exposed, otherwise output zero."""
+    output_names_method = getattr(source, "outputNames", None)
+    if not callable(output_names_method):
+        raise ValueError("Copernicus source does not expose outputNames")
+    output_names = output_names_method()
+    if not isinstance(output_names, (list, tuple)):
+        raise ValueError("Copernicus source returned an invalid outputNames contract")
+    names = tuple(str(name) for name in output_names if str(name))
+    return names[0] if names else 0
+
+
+def _set_named_cop_input(target: Any, input_name: str, source: Any) -> Any:
+    """Connect a Houdini 22 Copernicus input by name after contract inspection."""
+    input_names_method = getattr(target, "inputNames", None)
+    set_named_input = getattr(target, "setNamedInput", None)
+    if not callable(input_names_method) or not callable(set_named_input):
+        raise ValueError("Copernicus target does not support named inputs")
+    input_names = input_names_method()
+    if not isinstance(input_names, (list, tuple)):
+        raise ValueError("Copernicus target returned an invalid inputNames contract")
+    if input_name not in tuple(str(name) for name in input_names):
+        raise ValueError("Copernicus target is missing a required named input")
+    output_reference = _cop_output_reference(source)
+    set_named_input(input_name, source, output_reference)
+    return output_reference
+
+
+def _configure_file_cop_color_output(file_cop: Any) -> str:
+    """Expose one RGBA ``C`` AOV from a Houdini 22 File COP.
+
+    File COP outputs are dynamic.  A filename alone leaves ``aovs`` at zero,
+    which can draw a cable in the network while the downstream Blend COP still
+    cooks with ``bg is missing``.  Author the same bounded AOV contract that
+    the File COP UI's *Add AOVs from File* callback would create.
+    """
+    aovs_applied = _set_first(file_cop, ("aovs",), 1)
+    if not aovs_applied:
+        raise ValueError("File COP does not expose its Houdini 22 AOV multiparm")
+    applied = {
+        "name": _set_first(file_cop, ("aov1",), "C"),
+        # Houdini 22's File COP menu uses 3 for an RGBA raster.
+        "type": _set_first(file_cop, ("type1",), 3),
+        "raw": _set_first(file_cop, ("raw1",), False),
+    }
+    if not all(applied.values()):
+        raise ValueError("File COP does not expose a complete color AOV contract")
+    cook = getattr(file_cop, "cook", None)
+    if callable(cook):
+        cook(force=True)
+    output_reference = _cop_output_reference(file_cop)
+    if output_reference != "C":
+        raise ValueError("File COP did not expose the configured color AOV")
+    return output_reference
 
 
 @skill_entry
@@ -443,17 +698,45 @@ def create_gsplat_copernicus_raster(
     saturation_scale: Optional[float] = None,
     value_scale: Optional[float] = None,
     gamma: Optional[float] = None,
-    premultiply_alpha: bool = True,
+    premultiply_alpha: bool = False,
+    background_image_path: Optional[str] = None,
+    background_mode: str = "over",
+    background_brightness: float = 1.0,
+    background_rotation: Sequence[float] = (0.0, 0.0, 0.0),
 ) -> dict:
-    """Create a camera-aware GSplat raster and optional image-refinement COPs."""
+    """Create a camera-aware GSplat raster, refinements, and optional background."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
     created = []
     try:
+        if background_mode != "over":
+            raise ValueError("background_mode must be over")
+        if (
+            isinstance(background_brightness, bool)
+            or not math.isfinite(float(background_brightness))
+            or not 0.01 <= float(background_brightness) <= 16.0
+        ):
+            raise ValueError("background_brightness must be between 0.01 and 16")
+        if not isinstance(background_rotation, (list, tuple)) or len(background_rotation) != 3:
+            raise ValueError("background_rotation must contain exactly [rx, ry, rz]")
+        if any(isinstance(value, bool) or not math.isfinite(float(value)) for value in background_rotation):
+            raise ValueError("background_rotation values must be finite numbers")
+        background_rotation = tuple(float(value) for value in background_rotation)
+        if background_image_path is not None:
+            if not isinstance(background_image_path, str) or not background_image_path.strip():
+                raise ValueError("background_image_path must be a non-empty absolute image path")
+            if not os.path.isabs(background_image_path):
+                raise ValueError("background_image_path must be an absolute image path")
+
         copnet = _node(hou, copnet_path)
         _node(hou, sop_path)
+        camera = None
+        if camera_path:
+            camera = _node(hou, camera_path)
+            if _type_name(camera).split("::", 1)[0] != "cam":
+                raise ValueError("camera_path must reference a Houdini camera node")
         sop_import = _create(copnet, ("sopimport", "sop_import"), "gsplat_sop_import")
         created.append(sop_import)
         import_applied = _set_first(sop_import, ("soppath", "sop_path", "nodepath"), sop_path)
@@ -561,6 +844,81 @@ def create_gsplat_copernicus_raster(
                 "gsplat_premult",
                 {"operation": (("op", "operation"), "mult")},
             )
+
+        background_composite = {"enabled": False}
+        if background_image_path is not None:
+            # Blend/Over consumes alpha-associated foreground color. Keep the
+            # standalone raster straight by default, but establish association
+            # automatically at the composite boundary.
+            if not premultiply_alpha:
+                append_refinement(
+                    ("premult",),
+                    "gsplat_composite_premult",
+                    {"operation": (("op", "operation"), "mult")},
+                )
+            background_file = _create(copnet, ("file",), "gsplat_background_file")
+            created.append(background_file)
+            filename_applied = _set_first(background_file, ("filename",), background_image_path)
+            if not filename_applied:
+                raise ValueError("File COP does not expose its Houdini 22 filename parameter")
+            _configure_file_cop_color_output(background_file)
+
+            # The HDRI is latitude-longitude data, not a camera plate.  Sample
+            # it as a celestial sphere into the same camera/view metadata as
+            # the rasterized GSplat before compositing.
+            background_sphere = _create(
+                copnet,
+                ("spheresample", "sphere_sample"),
+                "gsplat_background_sphere",
+            )
+            created.append(background_sphere)
+            celestial_applied = _set_first(
+                background_sphere,
+                ("celestial", "celestialsphere", "celestial_sphere"),
+                True,
+            )
+            if not celestial_applied:
+                raise ValueError("Sphere Sample COP does not expose its celestial-sphere parameter")
+            for parm_name, value in zip(("rx", "ry", "rz"), background_rotation, strict=True):
+                if not _set_first(background_sphere, (parm_name,), value):
+                    raise ValueError("Sphere Sample COP does not expose its rotation parameters")
+            # Prefer the imported camera metadata itself.  The refined GSplat
+            # layer can carry a data window but is not guaranteed to remain a
+            # valid camera reference after color operations.
+            _set_named_cop_input(background_sphere, "size_ref", camera_import or current)
+            _set_named_cop_input(background_sphere, "source", background_file)
+
+            background_bright = _create(copnet, ("bright",), "gsplat_background_brightness")
+            created.append(background_bright)
+            brightness_applied = _set_first(background_bright, ("bright",), float(background_brightness))
+            if not brightness_applied:
+                raise ValueError("Bright COP does not expose its Houdini 22 brightness parameter")
+            background_bright.setInput(0, background_sphere)
+
+            blend = _create(copnet, ("blend",), "gsplat_background_over")
+            created.append(blend)
+            mode_applied = _set_first(blend, ("mode",), background_mode)
+            if not mode_applied:
+                raise ValueError("Blend COP does not expose its Houdini 22 mode parameter")
+            alpha_applied = _set_first(blend, ("alpha",), True)
+            clip_applied = _set_first(blend, ("clipbydata",), True)
+            if not alpha_applied or not clip_applied:
+                raise ValueError("Blend COP does not expose its alpha-compositing contract")
+            background_output = _set_named_cop_input(blend, "bg", background_bright)
+            foreground_output = _set_named_cop_input(blend, "fg", current)
+            background_composite = {
+                "enabled": True,
+                "mode": background_mode,
+                "file": _summary(background_file),
+                "sphere": _summary(background_sphere),
+                "brightness": _summary(background_bright),
+                "brightness_scale": float(background_brightness),
+                "rotation": list(background_rotation),
+                "blend": _summary(blend),
+                "named_inputs": {"bg": background_output, "fg": foreground_output},
+            }
+            current = blend
+
         if hasattr(copnet, "layoutChildren"):
             copnet.layoutChildren(items=created)
         return skill_success(
@@ -570,6 +928,7 @@ def create_gsplat_copernicus_raster(
             camera_import=_summary(camera_import) if camera_import else None,
             rasterize=_summary(raster),
             refinements=refinement_results,
+            background_composite=background_composite,
             output=_summary(current),
             attribute_name=attribute_name,
             applied_parameters={
@@ -579,7 +938,11 @@ def create_gsplat_copernicus_raster(
                 "camera_path": camera_applied,
                 "resolution": resolution_applied,
             },
-            next_step="Display or render the returned output COP; parameter edits update the image interactively.",
+            next_step=(
+                "Render the returned output COP through an Image ROP for pixel-level acceptance. "
+                "Rasterize GSplats already produces alpha-associated color; append Premult only "
+                "when a downstream straight-alpha contract explicitly requires it."
+            ),
         )
     except Exception as exc:
         for item in reversed(created):
@@ -587,8 +950,136 @@ def create_gsplat_copernicus_raster(
                 item.destroy()
             except Exception:  # noqa: BLE001
                 pass
-        return skill_exception(
-            exc, message="Failed to create Copernicus GSplat raster chain; created nodes were rolled back"
+        return _safe_public_error(
+            "Failed to create Copernicus GSplat raster chain; created nodes were rolled back",
+            "Houdini Copernicus GSplat setup failed",
+            exc,
+        )
+
+
+def _required_parm(node: Any, name: str) -> Any:
+    parm = node.parm(name)
+    if parm is None:
+        raise ValueError("Houdini 22 Image ROP is missing required parameter: {}".format(name))
+    return parm
+
+
+def _file_signature(path: str) -> Optional[dict]:
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    if not os.path.isfile(path):
+        return None
+    return {"mtime_ns": int(stat.st_mtime_ns), "size_bytes": int(stat.st_size)}
+
+
+def write_gsplat_copernicus_image(
+    cop_output_path: str,
+    output_file: str,
+    frame: float,
+    resolution: Sequence[int],
+    color_conversion: str,
+    rop_name: str = "dcc_mcp_gsplat_image_proof",
+) -> dict:
+    """Render one Copernicus frame through a named Houdini 22 Image ROP."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    try:
+        if not isinstance(cop_output_path, str) or not cop_output_path.startswith("/") or ".." in cop_output_path:
+            raise ValueError("cop_output_path must be an absolute Houdini COP node path without '..'")
+        if not isinstance(output_file, str) or not os.path.isabs(output_file):
+            raise ValueError("output_file must be an absolute output file path")
+        if not output_file.strip() or os.path.basename(output_file) in ("", ".", ".."):
+            raise ValueError("output_file must name a file, not a directory")
+        if not isinstance(rop_name, str) or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", rop_name) is None:
+            raise ValueError("rop_name must be a Houdini-safe name with at most 64 characters")
+        if isinstance(frame, bool) or not math.isfinite(float(frame)):
+            raise ValueError("frame must be a finite number")
+        if not isinstance(resolution, (list, tuple)) or len(resolution) != 2:
+            raise ValueError("resolution must contain exactly [width, height]")
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in resolution):
+            raise ValueError("resolution values must be integers")
+        width, height = int(resolution[0]), int(resolution[1])
+        if not 1 <= width <= 16384 or not 1 <= height <= 16384:
+            raise ValueError("resolution values must be between 1 and 16384")
+        if color_conversion not in ("raw", "ocio", "bakeocio"):
+            raise ValueError("color_conversion must be one of: raw, ocio, bakeocio")
+
+        cop_output = _node(hou, cop_output_path)
+        out = _node(hou, "/out")
+        rop = out.node(rop_name)
+        created = rop is None
+        if created:
+            rop = out.createNode("image", rop_name)
+        elif _type_name(rop).split("::", 1)[0] != "image":
+            raise ValueError("/out/{} exists but is not a Houdini Image ROP".format(rop_name))
+
+        _required_parm(rop, "coppath").set(cop_output.path())
+        output_parm = _required_parm(rop, "copoutput")
+        # Image ROPs may ship with an expression/default tokenized path. Remove
+        # animation or expressions before assigning the caller-bounded path.
+        output_parm.deleteAllKeyframes()
+        output_parm.set(output_file)
+
+        _required_parm(rop, "trange").set(0)
+        render_frame = float(frame)
+        _required_parm(rop, "f1").set(render_frame)
+        _required_parm(rop, "f2").set(render_frame)
+        _required_parm(rop, "f3").set(1.0)
+        _required_parm(rop, "setres").set(True)
+        _required_parm(rop, "res1").set(width)
+        _required_parm(rop, "res2").set(height)
+        _required_parm(rop, "colorconversion").set(color_conversion)
+        mkpath = rop.parm("mkpath")
+        if mkpath is not None:
+            mkpath.set(True)
+
+        before = _file_signature(output_file)
+        rop.render(frame_range=(render_frame, render_frame, 1.0), verbose=False)
+        after = _file_signature(output_file)
+        exists = after is not None
+        size_bytes = after["size_bytes"] if after else 0
+        updated_by_render = bool(after and after != before)
+        evidence = {
+            "exists": exists,
+            "size_bytes": size_bytes,
+            "updated_by_render": updated_by_render,
+        }
+        if not exists or size_bytes <= 0 or not updated_by_render:
+            return skill_error(
+                "Image ROP did not produce fresh pixel evidence",
+                "The foreground render returned without creating or updating a non-empty output file",
+                written_files=[],
+                output_evidence=evidence,
+                image_rop=_summary(rop),
+            )
+
+        return skill_success(
+            "Rendered Copernicus output to a verified image file",
+            written_files=[output_file],
+            output_evidence=evidence,
+            image_rop=_summary(rop),
+            created=created,
+            cop_output_path=cop_output.path(),
+            frame=render_frame,
+            resolution=[width, height],
+            color_conversion=color_conversion,
+        )
+    except ValueError as exc:
+        return _safe_public_error(
+            "Invalid Copernicus Image ROP request",
+            "Image ROP request validation failed",
+            exc,
+        )
+    except Exception as exc:
+        return _safe_public_error(
+            "Failed to render Copernicus output through Houdini Image ROP",
+            "Houdini Image ROP operation failed",
+            exc,
         )
 
 
@@ -599,7 +1090,9 @@ def main(**kwargs: Any) -> dict:
         "inspect": inspect_gsplat_relighting_input,
         "prepare": prepare_gsplat_sop_chain,
         "relight": create_gsplat_relight_lop,
+        "refresh_relight_sop": refresh_gsplat_relight_sop_bridge,
         "rasterize": create_gsplat_copernicus_raster,
+        "write_image": write_gsplat_copernicus_image,
     }
     if action not in functions:
         return skill_error("Unknown GSplat action", "action must be one of: {}".format(", ".join(functions)))

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -879,7 +879,9 @@ def create_gsplat_copernicus_raster(
             )
             if not celestial_applied:
                 raise ValueError("Sphere Sample COP does not expose its celestial-sphere parameter")
-            for parm_name, value in zip(("rx", "ry", "rz"), background_rotation, strict=True):
+            # background_rotation is validated as exactly three values above;
+            # avoid zip(strict=...) to preserve the adapter's Python 3.8 floor.
+            for parm_name, value in zip(("rx", "ry", "rz"), background_rotation):
                 if not _set_first(background_sphere, (parm_name,), value):
                     raise ValueError("Sphere Sample COP does not expose its rotation parameters")
             # Prefer the imported camera metadata itself.  The refined GSplat

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/refresh_gsplat_relight_sop_bridge.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/refresh_gsplat_relight_sop_bridge.py
@@ -1,0 +1,15 @@
+"""Skill entrypoint for the stable Solaris-relit GSplat SOP bridge."""
+
+from dcc_mcp_core.skill import skill_entry
+from gsplat_relighting import refresh_gsplat_relight_sop_bridge
+
+
+@skill_entry
+def main(**kwargs):
+    return refresh_gsplat_relight_sop_bridge(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/write_gsplat_copernicus_image.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/write_gsplat_copernicus_image.py
@@ -1,0 +1,31 @@
+"""Skill entrypoint for verified Copernicus Image ROP output."""
+
+from typing import Sequence
+
+from dcc_mcp_core.skill import skill_entry
+from gsplat_relighting import write_gsplat_copernicus_image
+
+
+@skill_entry
+def main(
+    cop_output_path: str,
+    output_file: str,
+    frame: float,
+    resolution: Sequence[int],
+    color_conversion: str,
+    rop_name: str = "dcc_mcp_gsplat_image_proof",
+):
+    return write_gsplat_copernicus_image(
+        cop_output_path=cop_output_path,
+        output_file=output_file,
+        frame=frame,
+        resolution=resolution,
+        color_conversion=color_conversion,
+        rop_name=rop_name,
+    )
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
@@ -113,7 +113,9 @@ tools:
       Create and connect a Labs Relight GSplats LOP after a Solaris input,
       optionally adding USD Light LOPs for a key, fill, dome, or other relight
       lights. Applies only parameters that exist in the installed Houdini/Labs
-      build and reports unsupported version-specific names.
+      build, reports unsupported version-specific names, and when available
+      exposes the relit points through a stable SOP bridge instead of requiring
+      consumers to address Labs HDA internals.
     source_file: scripts/create_gsplat_relight_lop.py
     execution: sync
     affinity: main
@@ -126,6 +128,7 @@ tools:
     produces: [gsplat_relight_stage]
     input_schema:
       type: object
+      additionalProperties: false
       required: [lop_node_path]
       properties:
         lop_node_path:
@@ -162,10 +165,97 @@ tools:
         parameters:
           type: object
           description: Optional exact Labs parameter overrides for the installed build.
+        create_sop_bridge:
+          type: boolean
+          default: true
+          description: >-
+            Discover the compatible relit SOP inside the Labs asset and expose
+            it through a stable object-level SOP bridge.
+    output_schema:
+      type: object
+      required: [success, message, context]
+      properties:
+        success: {type: boolean}
+        message: {type: string}
+        context:
+          type: object
+          required: [relight, sop_bridge_available, sop_output_path, point_count, gsplat_attributes]
+          properties:
+            relight: {type: object}
+            sop_bridge_available: {type: boolean}
+            sop_output_path: {type: [string, "null"]}
+            point_count: {type: integer, minimum: 0}
+            gsplat_attributes:
+              type: array
+              items: {type: string}
+            bridge_refreshed: {type: boolean}
+            sop_bridge_status: {type: string}
+            sop_bridge_error_type: {type: [string, "null"]}
     next-tools:
       on-success:
+        - houdini_gsplat_relighting__refresh_gsplat_relight_sop_bridge
         - houdini_usd_lops__list_stage_prims
         - houdini_parameters__get_parms
+      on-failure:
+        - houdini_scene__get_node_info
+
+  - name: refresh_gsplat_relight_sop_bridge
+    description: >-
+      Force-cook an existing Labs Relight GSplats LOP, rediscover its compatible
+      SOP output without relying on an internal HDA path, update the stable
+      object-level bridge, and return its output path, point count, and key
+      GSplat attributes. Use after changing Dome or relight parameters.
+    source_file: scripts/refresh_gsplat_relight_sop_bridge.py
+    execution: sync
+    affinity: main
+    group: gsplat-solaris
+    read_only: false
+    destructive: false
+    idempotent: true
+    tool_role: mutation
+    risk: medium
+    search_aliases: [refresh relit gsplat sop, recook dome relight, solaris sop bridge, update gsplat lighting]
+    produces: [gsplat_relight_sop_bridge]
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [relight_lop_path]
+      properties:
+        relight_lop_path:
+          type: string
+          pattern: ^/
+          description: Absolute path to the Labs Relight GSplats LOP returned by the setup tool.
+        force:
+          type: boolean
+          default: true
+          description: Force-cook the relight LOP, discovered source SOP, and stable bridge nodes.
+    output_schema:
+      type: object
+      required: [success, message, context]
+      properties:
+        success: {type: boolean}
+        message: {type: string}
+        context:
+          type: object
+          required: [sop_output_path, point_count, gsplat_attributes, bridge_refreshed]
+          properties:
+            sop_output_path: {type: string}
+            point_count: {type: integer, minimum: 1}
+            gsplat_attributes:
+              type: array
+              items: {type: string}
+            bridge_refreshed: {type: boolean}
+            sop_bridge_available: {type: boolean}
+            sop_bridge_status: {type: string}
+            relight: {type: object}
+    call_examples:
+      - arguments:
+          relight_lop_path: /stage/gsplat_relight
+          force: true
+        note: Recompute the stable relit SOP after changing Dome-light parameters.
+    next-tools:
+      on-success:
+        - houdini_gsplat_relighting__create_gsplat_copernicus_raster
       on-failure:
         - houdini_scene__get_node_info
 
@@ -173,8 +263,10 @@ tools:
     description: >-
       Create a Copernicus SOP Import plus Rasterize GSplats chain, optionally
       wiring a Camera Import COP and Sharpen, HSV, Gamma, and Premult image
-      refinement nodes. Enables H22 external-SOP mode, applies the native
-      Copernicus resolution contract, and reports every created output.
+      refinement nodes. An optional absolute background image is composited by
+      a File COP and Blend COP using the H22 named bg/fg input contract. Enables
+      external-SOP mode, applies the native resolution contract, and reports
+      every created output.
     source_file: scripts/create_gsplat_copernicus_raster.py
     execution: sync
     affinity: main
@@ -187,6 +279,7 @@ tools:
     produces: [gsplat_copernicus_chain]
     input_schema:
       type: object
+      additionalProperties: false
       required: [copnet_path, sop_path]
       properties:
         copnet_path:
@@ -226,11 +319,139 @@ tools:
           description: Optional Gamma COP value.
         premultiply_alpha:
           type: boolean
-          default: true
-          description: Append a Premult COP as the final display/render output.
+          default: false
+          description: >-
+            Append a Premult COP only for an explicit straight-alpha downstream
+            contract. Rasterize GSplats output is already alpha-associated, so
+            enabling this by default would darken translucent splats twice.
+        background_image_path:
+          type: string
+          minLength: 1
+          description: >-
+            Optional absolute HDR or image path loaded by a Houdini 22 File COP.
+            The path is consumed by Houdini but is not echoed in the public result.
+        background_mode:
+          type: string
+          enum: [over]
+          default: over
+          description: >-
+            Bounded Blend COP composite mode. The GSplat output is connected to
+            named fg and the background File COP to named bg.
+        background_brightness:
+          type: number
+          minimum: 0.01
+          maximum: 16.0
+          default: 1.0
+          description: >-
+            Linear brightness multiplier applied only to the camera-projected
+            background branch, without changing Solaris relighting exposure.
+        background_rotation:
+          type: array
+          items: {type: number}
+          minItems: 3
+          maxItems: 3
+          default: [0.0, 0.0, 0.0]
+          description: >-
+            Camera-visible HDR sphere rotation as [rx, ry, rz] degrees. Use the
+            same rotation on the Solaris Dome Light to keep lighting and plate
+            directions physically consistent.
     next-tools:
       on-success:
+        - houdini_gsplat_relighting__write_gsplat_copernicus_image
         - houdini_parameters__set_parms
         - houdini_render__capture_viewport
+      on-failure:
+        - houdini_scene__get_node_info
+
+  - name: write_gsplat_copernicus_image
+    description: >-
+      Render one existing Copernicus output through a clearly named Houdini 22
+      Image ROP under /out. Clears any default output expression before setting
+      the caller-provided absolute file, performs a synchronous foreground
+      render for one frame, and accepts the result only when the file was
+      created or updated with non-zero bytes.
+    source_file: scripts/write_gsplat_copernicus_image.py
+    execution: sync
+    affinity: main
+    group: gsplat-copernicus
+    read_only: false
+    destructive: true
+    idempotent: true
+    tool_role: mutation
+    risk: medium
+    search_aliases: [write gsplat pixels, copernicus image rop, render cop to disk, verify gsplat image]
+    produces: [gsplat_pixel_evidence]
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [cop_output_path, output_file, frame, resolution, color_conversion]
+      properties:
+        cop_output_path:
+          type: string
+          pattern: ^/
+          description: Absolute path to the existing Copernicus output node to render.
+        output_file:
+          type: string
+          minLength: 1
+          description: Absolute image file path. An existing file may be overwritten.
+        frame:
+          type: number
+          minimum: -1000000
+          maximum: 1000000
+          description: Single frame to render synchronously in the current Houdini process.
+        resolution:
+          type: array
+          items: {type: integer, minimum: 1, maximum: 16384}
+          minItems: 2
+          maxItems: 2
+          description: Image ROP default resolution as [width, height].
+        color_conversion:
+          type: string
+          enum: [raw, ocio, bakeocio]
+          description: Houdini 22 Image ROP Colorspace Conversion token.
+        rop_name:
+          type: string
+          pattern: ^[A-Za-z_][A-Za-z0-9_]{0,63}$
+          default: dcc_mcp_gsplat_image_proof
+          description: Fixed child name to create or reuse directly under /out.
+    output_schema:
+      type: object
+      required: [success, message, context]
+      properties:
+        success: {type: boolean}
+        message: {type: string}
+        context:
+          type: object
+          required: [written_files, output_evidence, image_rop, created, frame, resolution, color_conversion]
+          properties:
+            written_files:
+              type: array
+              items: {type: string}
+            output_evidence:
+              type: object
+              required: [exists, size_bytes, updated_by_render]
+              properties:
+                exists: {type: boolean}
+                size_bytes: {type: integer, minimum: 0}
+                updated_by_render: {type: boolean}
+            image_rop: {type: object}
+            created: {type: boolean}
+            cop_output_path: {type: string}
+            frame: {type: number}
+            resolution:
+              type: array
+              items: {type: integer}
+              minItems: 2
+              maxItems: 2
+            color_conversion: {type: string}
+    call_examples:
+      - arguments:
+          cop_output_path: /img/gsplat_final/OUT
+          output_file: D:/renders/gsplat-proof.exr
+          frame: 48
+          resolution: [1280, 720]
+          color_conversion: raw
+        note: Write one linear EXR frame and verify the file was freshly produced.
+    next-tools:
       on-failure:
         - houdini_scene__get_node_info

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/cook_node.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/cook_node.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from _node_common import get_node, hou_import_error, node_summary
-from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
+
+from dcc_mcp_houdini.inline_cook_policy import assess_inline_cook
 
 
 def _call_string_list(node, method_name: str) -> list:
@@ -16,7 +18,7 @@ def _call_string_list(node, method_name: str) -> list:
         return []
 
 
-def cook_node(node_path: str, force: bool = False) -> dict:
+def cook_node(node_path: str, force: bool = False, allow_heavy_inline: bool = False) -> dict:
     """Cook a Houdini node."""
     try:
         import hou  # noqa: PLC0415
@@ -26,6 +28,15 @@ def cook_node(node_path: str, force: bool = False) -> dict:
     node = None
     try:
         node = get_node(hou, node_path)
+        rejection = None if allow_heavy_inline else assess_inline_cook(node)
+        if rejection is not None:
+            return skill_error(
+                "Inline Houdini cook rejected by safety policy",
+                "Potentially heavy SOP cook requires isolated execution",
+                node=node_summary(node),
+                force=force,
+                **rejection,
+            )
         node.cook(force=force)
         return skill_success(
             "Cooked Houdini node",
@@ -35,7 +46,11 @@ def cook_node(node_path: str, force: bool = False) -> dict:
             warnings=_call_string_list(node, "warnings"),
         )
     except Exception as exc:
-        result = skill_exception(exc, message="Failed to cook Houdini node")
+        result = skill_error(
+            "Failed to cook Houdini node",
+            "Houdini node cook failed",
+            error_type=type(exc).__name__,
+        )
         if node is not None:
             context = result.setdefault("context", {})
             context.update(

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/create_node.py
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/scripts/create_node.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from _node_common import get_node, hou_import_error, node_summary
-from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def create_node(
@@ -40,7 +40,11 @@ def create_node(
             node=node_summary(node),
         )
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create Houdini node")
+        return skill_error(
+            "Failed to create Houdini node",
+            "Houdini node creation failed",
+            error_type=type(exc).__name__,
+        )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-nodes/tools.yaml
@@ -145,8 +145,9 @@ tools:
 
   - name: cook_node
     description: >-
-      Cook a Houdini node and return errors/warnings when available. Useful
-      after creating SOP networks, ROPs, or HDA instances.
+      Cook a lightweight Houdini node and return errors/warnings when
+      available. Direct inputs above the inline safety limit are rejected by
+      default; use start_cook_job for potentially long cooks.
     input_schema:
       type: object
       required: [node_path]
@@ -158,6 +159,12 @@ tools:
           type: boolean
           default: false
           description: "Force a recook when supported."
+        allow_heavy_inline:
+          type: boolean
+          default: false
+          description: >-
+            Explicitly accept UI-thread blocking when direct inputs exceed the
+            safety limit. Prefer start_cook_job for potentially long cooks.
     read_only: false
     destructive: false
     idempotent: false

--- a/tests/test_geometry_mesh_skills.py
+++ b/tests/test_geometry_mesh_skills.py
@@ -404,6 +404,65 @@ class TestGeometrySkills:
         assert result["context"]["cooked"] is False
         assert result["context"]["cook_error"] == "cook failed"
 
+    def test_get_cook_status_redacts_host_path_from_cook_error(self) -> None:
+        mod = _load_script("houdini-geometry", "get_cook_status.py")
+        node = _node("/obj/geo1/box1", "box1")
+        node.cook.side_effect = RuntimeError(r"failed in C:\Users\private-user\asset.hip")
+        node.errors.return_value = []
+        node.warnings.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_cook_status("/obj/geo1/box1")
+
+        assert result["success"] is True
+        assert result["context"]["cook_error"] == "RuntimeError"
+        assert "private-user" not in str(result)
+
+    def test_get_cook_status_rejects_heavy_inline_cook(self) -> None:
+        mod = _load_script("houdini-geometry", "get_cook_status.py")
+        source = _node("/obj/geo1/points", "points")
+        source_geo = MagicMock()
+        source_geo.pointCount.return_value = 1_005_483
+        source.geometry.return_value = source_geo
+        node = _node("/obj/geo1/surface", "surface")
+        node.inputs.return_value = (source,)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_cook_status("/obj/geo1/surface", force=True)
+
+        assert result["success"] is False
+        assert result["error"] == "Potentially heavy SOP cook requires isolated execution"
+        assert result["context"]["input_point_count"] == 1_005_483
+        assert result["context"]["recommended_tool"] == "houdini_nodes__start_cook_job"
+        node.cook.assert_not_called()
+
+    def test_get_cook_status_allows_explicit_heavy_inline_override(self) -> None:
+        mod = _load_script("houdini-geometry", "get_cook_status.py")
+        source = _node("/obj/geo1/points", "points")
+        source_geo = MagicMock()
+        source_geo.pointCount.return_value = 1_005_483
+        source.geometry.return_value = source_geo
+        node = _node("/obj/geo1/surface", "surface")
+        node.inputs.return_value = (source,)
+        node.errors.return_value = []
+        node.warnings.return_value = []
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_cook_status(
+                "/obj/geo1/surface",
+                force=True,
+                allow_heavy_inline=True,
+            )
+
+        assert result["success"] is True
+        node.cook.assert_called_once_with(force=True)
+
 
 class TestMeshOpsSkills:
     def _wire_downstream(self, optype: str = "xform"):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1557,9 +1557,7 @@ class TestNodeSkills:
     def test_create_node_failure_does_not_expose_traceback_or_host_path(self) -> None:
         mod = _load_script("houdini-nodes", "create_node.py")
         parent = MagicMock()
-        parent.createNode.side_effect = RuntimeError(
-            r"Failed inside C:\Users\private-user\project\asset.hip"
-        )
+        parent.createNode.side_effect = RuntimeError(r"Failed inside C:\Users\private-user\project\asset.hip")
         mock_hou = MagicMock()
         mock_hou.node.return_value = parent
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from contextlib import ExitStack
 from pathlib import Path
@@ -205,6 +206,423 @@ def test_stage_loader_maps_bootstrap_and_scene() -> None:
 
 
 class TestGsplatRelightingSkills:
+    def test_public_exception_results_redact_tracebacks_and_local_paths(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        sensitive_error = RuntimeError(r"C:\Users\private-user\secret_asset\lighting.hdr")
+        calls = (
+            lambda: mod.inspect_gsplat_relighting_input(node_path="/obj/gsplat/OUT"),
+            lambda: mod.prepare_gsplat_sop_chain(node_path="/obj/gsplat/OUT"),
+            lambda: mod.create_gsplat_relight_lop(lop_node_path="/stage/gsplat"),
+            lambda: mod.refresh_gsplat_relight_sop_bridge(relight_lop_path="/stage/gsplat_relight"),
+            lambda: mod.create_gsplat_copernicus_raster(
+                copnet_path="/img/gsplat",
+                sop_path="/obj/gsplat/OUT",
+            ),
+            lambda: mod.write_gsplat_copernicus_image(
+                cop_output_path="/img/gsplat/OUT",
+                output_file=str(tmp_path / "proof.exr"),
+                frame=1,
+                resolution=[640, 480],
+                color_conversion="raw",
+            ),
+        )
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            for call_public_tool in calls:
+                with patch.object(mod, "_node", side_effect=sensitive_error):
+                    result = call_public_tool()
+
+                serialized = json.dumps(result, sort_keys=True)
+                assert result["success"] is False
+                assert result["context"]["error_type"] == "RuntimeError"
+                assert "traceback" not in serialized.lower()
+                assert "RuntimeError(" not in serialized
+                assert "C:" not in serialized
+                assert "private-user" not in serialized
+                assert "secret_asset" not in serialized
+
+        source = (_SKILLS_ROOT / "houdini-gsplat-relighting" / "scripts" / "gsplat_relighting.py").read_text(
+            encoding="utf-8"
+        )
+        assert "skill_exception" not in source
+
+    def test_optional_bridge_failure_reports_safe_status_without_failing_relight(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        source = MagicMock()
+        source.path.return_value = "/stage/gsplat_source"
+        source.name.return_value = "gsplat_source"
+        source.type.return_value.name.return_value = "sopimport"
+        parent = MagicMock()
+        source.parent.return_value = parent
+        relight = MagicMock()
+        relight.path.return_value = "/stage/gsplat_relight"
+        relight.name.return_value = "gsplat_relight"
+        relight.type.return_value.name.return_value = "labs::relight_gsplats::1.0"
+        sensitive_error = RuntimeError(r"D:\Users\private-user\secret_asset\bridge.bgeo")
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.dict(sys.modules, {"hou": MagicMock()}))
+            stack.enter_context(patch.object(mod, "_node", return_value=source))
+            stack.enter_context(patch.object(mod, "_create", return_value=relight))
+            stack.enter_context(patch.object(mod, "_resolve_parm", return_value=None))
+            stack.enter_context(patch.object(mod, "_build_or_refresh_relight_sop_bridge", side_effect=sensitive_error))
+            result = mod.create_gsplat_relight_lop(lop_node_path="/stage/gsplat_source")
+
+        serialized = json.dumps(result, sort_keys=True)
+        assert result["success"] is True
+        assert result["context"]["sop_bridge_status"] == "bridge_refresh_failed"
+        assert result["context"]["sop_bridge_error_type"] == "RuntimeError"
+        assert "traceback" not in serialized.lower()
+        assert "D:" not in serialized
+        assert "private-user" not in serialized
+        assert "secret_asset" not in serialized
+
+    def test_create_relight_returns_stable_sop_bridge_contract_when_available(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        source = MagicMock()
+        source.path.return_value = "/stage/gsplat_source"
+        source.name.return_value = "gsplat_source"
+        source.type.return_value.name.return_value = "sopimport"
+        parent = MagicMock()
+        source.parent.return_value = parent
+        relight = MagicMock()
+        relight.path.return_value = "/stage/gsplat_relight"
+        relight.name.return_value = "gsplat_relight"
+        relight.type.return_value.name.return_value = "labs::relight_gsplats::1.0"
+        bridge_contract = {
+            "sop_bridge_available": True,
+            "sop_output_path": "/obj/dcc_mcp_gsplat_relight_sop_bridge/OUT",
+            "point_count": 58324,
+            "gsplat_attributes": ["P", "Cd", "orient", "scale", "GS_Alpha"],
+            "bridge_refreshed": True,
+        }
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.dict(sys.modules, {"hou": MagicMock()}))
+            stack.enter_context(patch.object(mod, "_node", return_value=source))
+            stack.enter_context(patch.object(mod, "_create", return_value=relight))
+            stack.enter_context(patch.object(mod, "_resolve_parm", return_value=None))
+            refresh = stack.enter_context(
+                patch.object(mod, "_build_or_refresh_relight_sop_bridge", return_value=bridge_contract)
+            )
+            result = mod.create_gsplat_relight_lop(lop_node_path="/stage/gsplat_source")
+
+        assert result["success"] is True
+        assert result["context"]["sop_output_path"] == "/obj/dcc_mcp_gsplat_relight_sop_bridge/OUT"
+        assert result["context"]["point_count"] == 58324
+        assert result["context"]["gsplat_attributes"] == ["P", "Cd", "orient", "scale", "GS_Alpha"]
+        refresh.assert_called_once()
+        assert refresh.call_args.args[1] is relight
+        assert refresh.call_args.kwargs == {"force": True}
+
+    def test_refresh_relight_bridge_force_cooks_and_hides_internal_sop_path(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        relight = MagicMock()
+        relight.path.return_value = "/stage/gsplat_relight"
+        relight.name.return_value = "gsplat_relight"
+        relight.type.return_value.name.return_value = "labs::relight_gsplats::1.0"
+        internal = MagicMock()
+        internal.path.return_value = "/stage/gsplat_relight/internal_versioned_source/OUT"
+        internal.name.return_value = "OUT"
+        internal.type.return_value.name.return_value = "null"
+        attributes = []
+        for name in ("P", "Cd", "orient", "scale", "GS_Alpha", "GS_SPH_R", "GS_SPH_G", "GS_SPH_B"):
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attributes.append(attrib)
+        geometry = MagicMock()
+        geometry.pointCount.return_value = 58324
+        geometry.pointAttribs.return_value = attributes
+        internal.geometry.return_value = geometry
+        relight.allSubChildren.return_value = (internal,)
+
+        obj = MagicMock()
+        bridge_geo = MagicMock()
+        bridge_geo.path.return_value = "/obj/dcc_mcp_gsplat_relight_sop_bridge"
+        bridge_geo.name.return_value = "dcc_mcp_gsplat_relight_sop_bridge"
+        bridge_geo.type.return_value.name.return_value = "geo"
+        object_merge = MagicMock()
+        object_merge.path.return_value = "/obj/dcc_mcp_gsplat_relight_sop_bridge/GSPLAT_RELIT_SOURCE"
+        object_merge.name.return_value = "GSPLAT_RELIT_SOURCE"
+        object_merge.type.return_value.name.return_value = "object_merge"
+        source_parm = MagicMock()
+        object_merge.parm.side_effect = lambda name: source_parm if name == "objpath1" else None
+        output = MagicMock()
+        output.path.return_value = "/obj/dcc_mcp_gsplat_relight_sop_bridge/OUT"
+        output.name.return_value = "OUT"
+        output.type.return_value.name.return_value = "null"
+        output.geometry.return_value = geometry
+        obj.node.return_value = None
+        obj.createNode.return_value = bridge_geo
+        bridge_geo.node.side_effect = lambda name: None
+        bridge_geo.createNode.side_effect = [object_merge, output]
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {"/stage/gsplat_relight": relight, "/obj": obj}.get(path)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.refresh_gsplat_relight_sop_bridge(
+                relight_lop_path="/stage/gsplat_relight",
+                force=True,
+            )
+
+        assert result["success"] is True
+        context = result["context"]
+        assert context["sop_output_path"] == "/obj/dcc_mcp_gsplat_relight_sop_bridge/OUT"
+        assert context["point_count"] == 58324
+        assert context["gsplat_attributes"] == [
+            "Cd",
+            "GS_Alpha",
+            "GS_SPH_B",
+            "GS_SPH_G",
+            "GS_SPH_R",
+            "P",
+            "orient",
+            "scale",
+        ]
+        assert "internal_sop_path" not in context
+        relight.cook.assert_called_once_with(force=True)
+        internal.cook.assert_called_once_with(force=True)
+        object_merge.cook.assert_called_once_with(force=True)
+        output.cook.assert_called_once_with(force=True)
+        source_parm.deleteAllKeyframes.assert_called_once_with()
+        source_parm.set.assert_called_once_with("/stage/gsplat_relight/internal_versioned_source/OUT")
+
+    def test_refresh_relight_bridge_has_bounded_public_schema(self) -> None:
+        tools = yaml.safe_load((_SKILLS_ROOT / "houdini-gsplat-relighting" / "tools.yaml").read_text(encoding="utf-8"))[
+            "tools"
+        ]
+        tool = next(item for item in tools if item["name"] == "refresh_gsplat_relight_sop_bridge")
+
+        assert tool["source_file"] == "scripts/refresh_gsplat_relight_sop_bridge.py"
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert tool["input_schema"]["additionalProperties"] is False
+        assert tool["input_schema"]["required"] == ["relight_lop_path"]
+        assert set(tool["input_schema"]["properties"]) == {"relight_lop_path", "force"}
+        assert tool["next-tools"]["on-success"] == ["houdini_gsplat_relighting__create_gsplat_copernicus_raster"]
+
+    def test_write_copernicus_image_creates_named_image_rop_and_reports_file_evidence(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        output_file = tmp_path / "gsplat-proof.png"
+        cop_output = MagicMock()
+        cop_output.path.return_value = "/img/gsplat_final/OUT"
+        out = MagicMock()
+        out.path.return_value = "/out"
+        rop = MagicMock()
+        rop.path.return_value = "/out/dcc_mcp_gsplat_image_proof"
+        rop.name.return_value = "dcc_mcp_gsplat_image_proof"
+        rop.type.return_value.name.return_value = "image"
+        parms = {
+            "coppath": MagicMock(),
+            "copoutput": MagicMock(),
+            "trange": MagicMock(),
+            "f1": MagicMock(),
+            "f2": MagicMock(),
+            "f3": MagicMock(),
+            "setres": MagicMock(),
+            "res1": MagicMock(),
+            "res2": MagicMock(),
+            "colorconversion": MagicMock(),
+            "mkpath": MagicMock(),
+        }
+        rop.parm.side_effect = lambda name: parms.get(name)
+        out.node.return_value = None
+        out.createNode.return_value = rop
+
+        def render(**_kwargs):
+            output_file.write_bytes(b"png-pixel-evidence")
+
+        rop.render.side_effect = render
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {
+            "/img/gsplat_final/OUT": cop_output,
+            "/out": out,
+        }.get(path)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.write_gsplat_copernicus_image(
+                cop_output_path="/img/gsplat_final/OUT",
+                output_file=str(output_file),
+                frame=48,
+                resolution=[1280, 720],
+                color_conversion="ocio",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["written_files"] == [str(output_file)]
+        assert result["context"]["output_evidence"] == {
+            "exists": True,
+            "size_bytes": len(b"png-pixel-evidence"),
+            "updated_by_render": True,
+        }
+        out.createNode.assert_called_once_with("image", "dcc_mcp_gsplat_image_proof")
+        parms["coppath"].set.assert_called_once_with("/img/gsplat_final/OUT")
+        parms["copoutput"].deleteAllKeyframes.assert_called_once_with()
+        parms["copoutput"].set.assert_called_once_with(str(output_file))
+        parms["trange"].set.assert_called_once_with(0)
+        parms["f1"].set.assert_called_once_with(48.0)
+        parms["f2"].set.assert_called_once_with(48.0)
+        parms["f3"].set.assert_called_once_with(1.0)
+        parms["setres"].set.assert_called_once_with(True)
+        parms["res1"].set.assert_called_once_with(1280)
+        parms["res2"].set.assert_called_once_with(720)
+        parms["colorconversion"].set.assert_called_once_with("ocio")
+        parms["mkpath"].set.assert_called_once_with(True)
+        rop.render.assert_called_once_with(frame_range=(48.0, 48.0, 1.0), verbose=False)
+
+    def test_write_copernicus_image_reuses_only_matching_named_image_rop(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        output_file = tmp_path / "proof.exr"
+        cop_output = MagicMock()
+        out = MagicMock()
+        existing = MagicMock()
+        existing.type.return_value.name.return_value = "image"
+        existing.path.return_value = "/out/GSPLAT_PIXEL_PROOF"
+        existing.name.return_value = "GSPLAT_PIXEL_PROOF"
+        parms = {
+            name: MagicMock()
+            for name in (
+                "coppath",
+                "copoutput",
+                "trange",
+                "f1",
+                "f2",
+                "f3",
+                "setres",
+                "res1",
+                "res2",
+                "colorconversion",
+                "mkpath",
+            )
+        }
+        existing.parm.side_effect = lambda name: parms.get(name)
+        existing.render.side_effect = lambda **_kwargs: output_file.write_bytes(b"exr")
+        out.node.return_value = existing
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {
+            "/img/copnet/OUT": cop_output,
+            "/out": out,
+        }.get(path)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.write_gsplat_copernicus_image(
+                cop_output_path="/img/copnet/OUT",
+                output_file=str(output_file),
+                frame=1,
+                resolution=[640, 480],
+                color_conversion="raw",
+                rop_name="GSPLAT_PIXEL_PROOF",
+            )
+
+        assert result["success"] is True
+        assert result["context"]["created"] is False
+        out.createNode.assert_not_called()
+
+    def test_write_copernicus_image_rejects_render_without_disk_pixels(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        output_file = tmp_path / "missing.png"
+        cop_output = MagicMock()
+        cop_output.path.return_value = "/img/copnet/OUT"
+        out = MagicMock()
+        rop = MagicMock()
+        rop.path.return_value = "/out/dcc_mcp_gsplat_image_proof"
+        rop.name.return_value = "dcc_mcp_gsplat_image_proof"
+        rop.type.return_value.name.return_value = "image"
+        parms = {
+            name: MagicMock()
+            for name in (
+                "coppath",
+                "copoutput",
+                "trange",
+                "f1",
+                "f2",
+                "f3",
+                "setres",
+                "res1",
+                "res2",
+                "colorconversion",
+                "mkpath",
+            )
+        }
+        rop.parm.side_effect = lambda name: parms.get(name)
+        out.node.return_value = None
+        out.createNode.return_value = rop
+        mock_hou = MagicMock()
+        mock_hou.node.side_effect = lambda path: {
+            "/img/copnet/OUT": cop_output,
+            "/out": out,
+        }.get(path)
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.write_gsplat_copernicus_image(
+                cop_output_path="/img/copnet/OUT",
+                output_file=str(output_file),
+                frame=1,
+                resolution=[640, 480],
+                color_conversion="raw",
+            )
+
+        assert result["success"] is False
+        assert result["context"]["written_files"] == []
+        assert result["context"]["output_evidence"] == {
+            "exists": False,
+            "size_bytes": 0,
+            "updated_by_render": False,
+        }
+
+    @pytest.mark.parametrize(
+        ("cop_output_path", "output_file", "private_fragment"),
+        (
+            ("img/copnet/OUT", "C:/renders/proof.exr", "C:/renders"),
+            ("/img/copnet/OUT", "proof.exr", "proof.exr"),
+        ),
+    )
+    def test_write_copernicus_image_rejects_unbounded_paths(
+        self,
+        cop_output_path: str,
+        output_file: str,
+        private_fragment: str,
+    ) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.write_gsplat_copernicus_image(
+                cop_output_path=cop_output_path,
+                output_file=output_file,
+                frame=1,
+                resolution=[640, 480],
+                color_conversion="raw",
+            )
+
+        assert result["success"] is False
+        assert result["message"] == "Invalid Copernicus Image ROP request"
+        assert result["error"] == "Image ROP request validation failed"
+        assert result["context"]["error_type"] == "ValueError"
+        assert private_fragment not in json.dumps(result)
+
+    def test_write_copernicus_image_has_bounded_public_schema(self) -> None:
+        tools = yaml.safe_load((_SKILLS_ROOT / "houdini-gsplat-relighting" / "tools.yaml").read_text(encoding="utf-8"))[
+            "tools"
+        ]
+        tool = next(item for item in tools if item["name"] == "write_gsplat_copernicus_image")
+
+        assert tool["source_file"] == "scripts/write_gsplat_copernicus_image.py"
+        assert tool["execution"] == "sync"
+        assert tool["affinity"] == "main"
+        assert tool["input_schema"]["additionalProperties"] is False
+        assert tool["input_schema"]["required"] == [
+            "cop_output_path",
+            "output_file",
+            "frame",
+            "resolution",
+            "color_conversion",
+        ]
+        assert tool["input_schema"]["properties"]["color_conversion"]["enum"] == [
+            "raw",
+            "ocio",
+            "bakeocio",
+        ]
+        assert tool["output_schema"]["required"] == ["success", "message", "context"]
+
     def test_find_node_type_accepts_houdini_versioned_labs_name(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
         parent = MagicMock()
@@ -457,6 +875,7 @@ class TestGsplatRelightingSkills:
                 copnet_path="/img/copnet1",
                 sop_path="/obj/geo1/OUT",
                 resolution=[960, 540],
+                premultiply_alpha=True,
             )
 
         assert result["success"] is True
@@ -504,6 +923,7 @@ class TestGsplatRelightingSkills:
                 saturation_scale=1.1,
                 value_scale=1.2,
                 gamma=0.8,
+                premultiply_alpha=True,
             )
 
         assert result["success"] is True
@@ -519,6 +939,203 @@ class TestGsplatRelightingSkills:
         hsv.setInput.assert_called_once_with(0, sharpen)
         gamma_node.setInput.assert_called_once_with(0, hsv)
         premult.setInput.assert_called_once_with(0, gamma_node)
+
+    def test_copernicus_raster_composites_background_with_named_h22_inputs(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+
+        def node(path: str, name: str, type_name: str) -> MagicMock:
+            value = MagicMock()
+            value.path.return_value = path
+            value.name.return_value = name
+            value.type.return_value.name.return_value = type_name
+            return value
+
+        background_path = tmp_path / "garden.exr"
+        copnet = node("/img/copnet1", "copnet1", "copnet")
+        source = node("/obj/geo1/OUT", "OUT", "null")
+        sop_import = node("/img/copnet1/import", "import", "sopimport")
+        raster = node("/img/copnet1/raster", "raster", "rasterizegsplats")
+        background = node("/img/copnet1/background", "background", "file")
+        sphere = node("/img/copnet1/sphere", "sphere", "spheresample")
+        bright = node("/img/copnet1/bright", "bright", "bright")
+        composite_premult = node("/img/copnet1/composite_premult", "composite_premult", "premult")
+        blend = node("/img/copnet1/over", "over", "blend")
+        raster.outputNames.return_value = ("color",)
+        background.outputNames.return_value = ("C",)
+        sphere.outputNames.return_value = ("transform", "mask")
+        sphere.inputNames.return_value = ("size_ref", "source")
+        bright.outputNames.return_value = ("bright",)
+        composite_premult.outputNames.return_value = ("color",)
+        blend.inputNames.return_value = ("bg", "fg", "mask")
+
+        selected = []
+
+        def set_first(target, names, value):
+            selected.append((target, tuple(names), value))
+            return names[0]
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(mod, "_node", side_effect=[copnet, source]))
+            create = stack.enter_context(
+                patch.object(
+                    mod,
+                    "_create",
+                    side_effect=[sop_import, raster, composite_premult, background, sphere, bright, blend],
+                )
+            )
+            stack.enter_context(patch.object(mod, "_set_first", side_effect=set_first))
+            stack.enter_context(patch.dict(sys.modules, {"hou": MagicMock()}))
+            result = mod.create_gsplat_copernicus_raster(
+                copnet_path="/img/copnet1",
+                sop_path="/obj/geo1/OUT",
+                background_image_path=str(background_path),
+                background_mode="over",
+            )
+
+        assert result["success"] is True
+        assert [call.args[2] for call in create.call_args_list] == [
+            "gsplat_sop_import",
+            "gsplat_rasterize",
+            "gsplat_composite_premult",
+            "gsplat_background_file",
+            "gsplat_background_sphere",
+            "gsplat_background_brightness",
+            "gsplat_background_over",
+        ]
+        assert any(target is background and names[0] == "filename" for target, names, _ in selected)
+        assert any(
+            target is composite_premult and names[0] == "op" and value == "mult" for target, names, value in selected
+        )
+        composite_premult.setInput.assert_called_once_with(0, raster)
+        assert any(target is blend and names[0] == "mode" and value == "over" for target, names, value in selected)
+        assert any(target is background and names == ("aovs",) and value == 1 for target, names, value in selected)
+        assert any(target is background and names == ("aov1",) and value == "C" for target, names, value in selected)
+        assert any(target is background and names == ("type1",) and value == 3 for target, names, value in selected)
+        assert any(target is background and names == ("raw1",) and value is False for target, names, value in selected)
+        background.cook.assert_called_once_with(force=True)
+        sphere.setNamedInput.assert_any_call("size_ref", composite_premult, "color")
+        sphere.setNamedInput.assert_any_call("source", background, "C")
+        bright.setInput.assert_called_once_with(0, sphere)
+        blend.setNamedInput.assert_any_call("bg", bright, "bright")
+        blend.setNamedInput.assert_any_call("fg", composite_premult, composite_premult.outputNames.return_value[0])
+        blend.setInput.assert_not_called()
+        assert result["context"]["output"]["path"] == "/img/copnet1/over"
+        assert result["context"]["background_composite"] == {
+            "enabled": True,
+            "mode": "over",
+            "file": {
+                "path": "/img/copnet1/background",
+                "name": "background",
+                "type": "file",
+            },
+            "sphere": {
+                "path": "/img/copnet1/sphere",
+                "name": "sphere",
+                "type": "spheresample",
+            },
+            "brightness": {
+                "path": "/img/copnet1/bright",
+                "name": "bright",
+                "type": "bright",
+            },
+            "brightness_scale": 1.0,
+            "rotation": [0.0, 0.0, 0.0],
+            "blend": {
+                "path": "/img/copnet1/over",
+                "name": "over",
+                "type": "blend",
+            },
+            "named_inputs": {"bg": "bright", "fg": "color"},
+        }
+        assert str(background_path) not in json.dumps(result)
+
+    def test_copernicus_raster_rejects_missing_camera_before_mutation(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        copnet = MagicMock()
+        source = MagicMock()
+        hou = MagicMock()
+
+        with ExitStack() as stack:
+            node_lookup = stack.enter_context(
+                patch.object(mod, "_node", side_effect=[copnet, source, ValueError("missing camera")])
+            )
+            create = stack.enter_context(patch.object(mod, "_create"))
+            stack.enter_context(patch.dict(sys.modules, {"hou": hou}))
+            result = mod.create_gsplat_copernicus_raster(
+                copnet_path="/img/copnet1",
+                sop_path="/obj/geo1/OUT",
+                camera_path="/obj/missing_camera",
+            )
+
+        assert result["success"] is False
+        assert result["error"] == "Houdini Copernicus GSplat setup failed"
+        assert result["context"]["error_type"] == "ValueError"
+        assert node_lookup.call_count == 3
+        create.assert_not_called()
+
+    def test_copernicus_background_missing_named_bg_rolls_back_and_redacts(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        background_path = tmp_path / "private-user" / "garden.exr"
+        copnet = MagicMock()
+        source = MagicMock()
+        sop_import = MagicMock()
+        raster = MagicMock()
+        composite_premult = MagicMock()
+        background = MagicMock()
+        sphere = MagicMock()
+        bright = MagicMock()
+        blend = MagicMock()
+        background.outputNames.return_value = ("C",)
+        raster.outputNames.return_value = ("color",)
+        composite_premult.outputNames.return_value = ("color",)
+        sphere.outputNames.return_value = ("transform", "mask")
+        sphere.inputNames.return_value = ("size_ref", "source")
+        bright.outputNames.return_value = ("bright",)
+        blend.inputNames.return_value = ("foreground", "mask")
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(mod, "_node", side_effect=[copnet, source]))
+            stack.enter_context(
+                patch.object(
+                    mod,
+                    "_create",
+                    side_effect=[sop_import, raster, composite_premult, background, sphere, bright, blend],
+                )
+            )
+            stack.enter_context(patch.object(mod, "_set_first", side_effect=lambda _node, names, _value: names[0]))
+            stack.enter_context(patch.dict(sys.modules, {"hou": MagicMock()}))
+            result = mod.create_gsplat_copernicus_raster(
+                copnet_path="/img/copnet1",
+                sop_path="/obj/geo1/OUT",
+                background_image_path=str(background_path),
+            )
+
+        serialized = json.dumps(result, sort_keys=True)
+        assert result["success"] is False
+        assert result["error"] == "Houdini Copernicus GSplat setup failed"
+        assert result["context"]["error_type"] == "ValueError"
+        assert "traceback" not in serialized.lower()
+        assert "private-user" not in serialized
+        blend.setNamedInput.assert_not_called()
+        for created in (blend, bright, sphere, background, composite_premult, raster, sop_import):
+            created.destroy.assert_called_once_with()
+
+    def test_copernicus_background_has_bounded_public_schema(self) -> None:
+        tools = yaml.safe_load((_SKILLS_ROOT / "houdini-gsplat-relighting" / "tools.yaml").read_text(encoding="utf-8"))[
+            "tools"
+        ]
+        tool = next(item for item in tools if item["name"] == "create_gsplat_copernicus_raster")
+        schema = tool["input_schema"]
+
+        assert schema["additionalProperties"] is False
+        assert schema["properties"]["background_mode"]["enum"] == ["over"]
+        assert schema["properties"]["background_mode"]["default"] == "over"
+        assert schema["properties"]["background_image_path"]["type"] == "string"
+        assert schema["properties"]["background_brightness"]["minimum"] == 0.01
+        assert schema["properties"]["background_brightness"]["maximum"] == 16.0
+        assert schema["properties"]["background_rotation"]["minItems"] == 3
+        assert schema["properties"]["background_rotation"]["maxItems"] == 3
+        assert "python" not in {name.lower() for name in schema["properties"]}
 
     def test_copernicus_raster_rejects_partial_resolution_contract(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
@@ -542,7 +1159,8 @@ class TestGsplatRelightingSkills:
             )
 
         assert result["success"] is False
-        assert "resolution parameters" in result["error"]
+        assert result["error"] == "Houdini Copernicus GSplat setup failed"
+        assert result["context"]["error_type"] == "ValueError"
         raster.destroy.assert_called_once_with()
         sop_import.destroy.assert_called_once_with()
 
@@ -935,6 +1553,44 @@ class TestNodeSkills:
         assert result["success"] is True
         parent.createNode.assert_called_once()
         assert result["context"]["node"]["path"] == "/obj/geo1"
+
+    def test_create_node_failure_does_not_expose_traceback_or_host_path(self) -> None:
+        mod = _load_script("houdini-nodes", "create_node.py")
+        parent = MagicMock()
+        parent.createNode.side_effect = RuntimeError(
+            r"Failed inside C:\Users\private-user\project\asset.hip"
+        )
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.create_node("/obj", "invalid")
+
+        assert result["success"] is False
+        assert "traceback" not in result["context"]
+        assert "private-user" not in result["message"]
+        assert "private-user" not in result["error"]
+        assert result["context"]["error_type"] == "RuntimeError"
+
+    def test_cook_node_rejects_heavy_inline_cook(self) -> None:
+        mod = _load_script("houdini-nodes", "cook_node.py")
+        source = MagicMock()
+        source_geo = MagicMock()
+        source_geo.pointCount.return_value = 1_005_483
+        source.geometry.return_value = source_geo
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/surface"
+        node.inputs.return_value = (source,)
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = node
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.cook_node("/obj/geo1/surface", force=True)
+
+        assert result["success"] is False
+        assert result["error"] == "Potentially heavy SOP cook requires isolated execution"
+        assert result["context"]["recommended_tool"] == "houdini_nodes__start_cook_job"
+        node.cook.assert_not_called()
 
     def test_set_node_parms_with_scalar_tuple_and_button(self) -> None:
         mod = _load_script("houdini-nodes", "set_node_parms.py")


### PR DESCRIPTION
## Summary
- add stable Solaris-to-SOP relight bridge and verified Copernicus Image ROP output
- support bounded Houdini 22 background compositing with redacted failures
- route oversized inline SOP cooks toward isolated cook jobs
- clarify the honeybee media as interim engineering evidence, not final beauty acceptance

## Validation
- 933 passed, 1 skipped, 3 deselected
- scoped Ruff checks passed
- diff and sensitive-information checks passed