### PR TITLE
feat: add revisioned USD asset sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ manually with `tag_name=vX.Y.Z` and `publish_to_pypi=true`. Publishing uses
 PyPI trusted publishing when configured, or `PYPI_API_TOKEN` when that secret is
 available.
 
-## Bundled Skills (33 packages, 220 tools)
+## Bundled Skills (34 packages, 223 tools)
 
 Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skills/SKILLS_INDEX.md`
 
@@ -339,6 +339,7 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | Skill | Tools |
 |-------|-------|
 | `houdini-interchange` | `probe_file`, `import_geometry`, `export_geometry`, `export_alembic`, `export_fbx`, `export_usd` |
+| `houdini-asset-sync` | `publish_usd_revision`, `read_asset_head`, `reference_usd_revision` |
 | `houdini-import-to-scene` | `import_to_scene` |
 
 ### pipeline (load on demand)

--- a/src/dcc_mcp_houdini/_skill_loader.py
+++ b/src/dcc_mcp_houdini/_skill_loader.py
@@ -39,6 +39,7 @@ STAGE_SKILLS: dict[str, Tuple[str, ...]] = {
     ),
     "interchange": (
         "houdini-interchange",
+        "houdini-asset-sync",
         "houdini-export-preset",
         "houdini-import-to-scene",
         "houdini-usd-lops",

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -7,7 +7,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | `bootstrap` | `houdini-scripting` | yes |
 | `scene` | `houdini-scene`, `houdini-scene-edit` | `houdini-scene` only |
 | `authoring` | `houdini-nodes`, `houdini-object-ops`, `houdini-parameters`, `houdini-node-graph`, `houdini-geometry`, `houdini-mesh-ops`, `houdini-vex`, `houdini-camera-light`, `houdini-materials`, `houdini-lookdev`, `houdini-material-library`, `houdini-hda`, `houdini-light-rig` | no |
-| `interchange` | `houdini-interchange`, `houdini-export-preset`, `houdini-import-to-scene`, `houdini-usd-lops` | no |
+| `interchange` | `houdini-interchange`, `houdini-asset-sync`, `houdini-export-preset`, `houdini-import-to-scene`, `houdini-usd-lops` | no |
 | `pipeline` | `houdini-render`, `houdini-karma`, `houdini-husk`, `houdini-animation`, `houdini-chops`, `houdini-constraints`, `houdini-kinefx`, `houdini-hda-automation`, `houdini-pipeline`, `houdini-dev`, `houdini-automation`, `houdini-texture-bake`, `houdini-gsplat-relighting` | no |
 
 ## Common chains
@@ -45,6 +45,7 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Run an HDA | `load_skill("houdini-hda")` → `houdini_hda__execute_hda` |
 | Publish or revise an HDA | `load_skill("houdini-hda")` → `houdini_hda__author_hda_interface` → `houdini_hda__save_node_as_hda` / `houdini_hda__publish_hda_library` → `houdini_hda__validate_hda_contract` → `houdini_hda__sync_hda_instance` |
 | Cross-DCC asset import | `load_skill("houdini-import-to-scene")` → `houdini_import_to_scene__import_to_scene` (uses AssetDescriptor contract from dcc-mcp-core) |
+| Revisioned Houdini/Maya sync | `load_skill("houdini-asset-sync")` → `publish_usd_revision` / `read_asset_head` → receiver `sync_usd_revision` or `reference_usd_revision` |
 | Probe / import / export files | `load_skill("houdini-interchange")` → `houdini_interchange__probe_file` → `houdini_interchange__import_geometry` / `houdini_interchange__export_geometry` / `export_alembic` / `export_fbx` / `export_usd` |
 | Inspect a Solaris USD Stage | `load_skill("houdini-usd-lops")` → `houdini_usd_lops__list_stage_prims` → `houdini_usd_lops__get_prim_info` / `houdini_usd_lops__get_prim_attributes` |
 | Relight Gaussian Splats | `load_skill("houdini-gsplat-relighting")` → `inspect_gsplat_relighting_input` → `prepare_gsplat_sop_chain` → `create_gsplat_relight_lop` → `create_gsplat_copernicus_raster` → existing parameter/render skills |

--- a/src/dcc_mcp_houdini/skills/houdini-asset-sync/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-asset-sync/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: houdini-asset-sync
+description: Publish and consume immutable USD revisions through the dcc-mcp-core Asset Sync contract.
+license: MIT
+compatibility: "dcc-mcp-core 0.19.70+ with asset_sync, dcc-mcp-houdini 0.33+, Houdini 20.5+"
+metadata:
+  dcc-mcp:
+    dcc: houdini
+    layer: domain
+    stage: interchange
+    version: "1.0.0"
+    tags: [houdini, usd, asset-sync, animation, skeleton, curves, materials]
+    search-hint: "sync asset, publish USD revision, cross DCC, Maya interchange, editable animation"
+    side-effects:
+      creates: true
+      modifies: true
+      exports: true
+      imports: true
+    tools: tools.yaml
+---
+
+# houdini-asset-sync
+
+Content-addressed Houdini Asset Sync for USD. Operator configuration owns all
+filesystem roots; callers provide only bounded identifiers and relative paths.
+
+- `publish_usd_revision` publishes an already-authored USD/USDZ layer without flattening it.
+- `read_asset_head` inspects the immutable path-free manifest.
+- `reference_usd_revision` materializes a verified revision and creates a Solaris Reference LOP.
+
+Preserving USD composition maximizes fidelity for animation, UsdSkel, BasisCurves,
+MaterialX/UsdShade bindings, units, and up-axis metadata. Use the Maya receiver's
+`native` mode when direct Maya curve/material editing is preferred over composition fidelity.

--- a/src/dcc_mcp_houdini/skills/houdini-asset-sync/scripts/asset_sync.py
+++ b/src/dcc_mcp_houdini/skills/houdini-asset-sync/scripts/asset_sync.py
@@ -1,0 +1,185 @@
+"""Bounded Houdini adapter for dcc-mcp-core Asset Sync."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_USD_FORMATS = {
+    "usd": "model/vnd.usd",
+    "usda": "model/vnd.usda",
+    "usdc": "model/vnd.usdc",
+    "usdz": "model/vnd.usdz+zip",
+}
+
+
+def _core_types() -> Tuple[Any, Any, Any]:
+    try:
+        from dcc_mcp_core.asset_sync import AssetSyncConflictError, AssetSyncValidationError, FileAssetSyncStore
+    except ImportError as exc:
+        raise RuntimeError(
+            "This runtime does not include dcc_mcp_core.asset_sync; install a Core build containing Asset Sync"
+        ) from exc
+    return FileAssetSyncStore, AssetSyncConflictError, AssetSyncValidationError
+
+
+def _configured_root(name: str) -> Path:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError("{} is not configured".format(name))
+    return Path(value).expanduser().resolve()
+
+
+def _safe_relative(root: Path, value: str) -> Path:
+    relative = Path(str(value).replace("\\", "/"))
+    if relative.is_absolute() or not relative.parts or any(part in ("", ".", "..") for part in relative.parts):
+        raise ValueError("source_name must be a safe relative path")
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("source_name escapes the configured source root") from exc
+    return resolved
+
+
+def _usd_metadata(path: Path) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    extension = path.suffix.lower().lstrip(".")
+    if extension not in _USD_FORMATS:
+        raise ValueError("Asset Sync accepts only USD, USDA, USDC, or USDZ")
+    metadata: Dict[str, Any] = {
+        "interchange": {
+            "format": extension,
+            "preserves": ["animation", "basis_curves", "usd_skel", "usd_shade", "material_bindings", "composition"],
+        }
+    }
+    spatial: Dict[str, Any] = {}
+    try:
+        from pxr import Usd, UsdGeom
+
+        stage = Usd.Stage.Open(str(path))
+        if not stage:
+            raise ValueError("USD stage could not be opened")
+        spatial = {
+            "meters_per_unit": float(UsdGeom.GetStageMetersPerUnit(stage)),
+            "up_axis": str(UsdGeom.GetStageUpAxis(stage)).upper(),
+        }
+        metadata["timeline"] = {
+            "start": float(stage.GetStartTimeCode()),
+            "end": float(stage.GetEndTimeCode()),
+            "frames_per_second": float(stage.GetFramesPerSecond()),
+        }
+        counts = {"prims": 0, "curves": 0, "skeletons": 0, "materials": 0}
+        for prim in stage.Traverse():
+            counts["prims"] += 1
+            name = prim.GetTypeName()
+            if name in ("BasisCurves", "NurbsCurves"):
+                counts["curves"] += 1
+            elif name in ("Skeleton", "SkelRoot"):
+                counts["skeletons"] += 1
+            elif name == "Material":
+                counts["materials"] += 1
+        metadata["usd_counts"] = counts
+    except ImportError:
+        metadata["inspection_warning"] = "pxr is unavailable; stage metadata was not inspected"
+    return spatial, metadata
+
+
+def publish_usd_revision(
+    channel_id: str,
+    asset_id: str,
+    source_name: str,
+    expected_head_revision: int,
+    source_instance_id: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    try:
+        source = _safe_relative(_configured_root("DCC_MCP_HOUDINI_ASSET_SYNC_SOURCE_ROOT"), source_name)
+        if not source.is_file():
+            raise FileNotFoundError(str(source))
+        spatial, inspected = _usd_metadata(source)
+        inspected.update(dict(metadata or {}))
+        Store, _, _ = _core_types()
+        revision = Store(_configured_root("DCC_MCP_ASSET_SYNC_ROOT")).publish(
+            source,
+            channel_id=channel_id,
+            asset_id=asset_id,
+            format=source.suffix.lstrip("."),
+            mime=_USD_FORMATS[source.suffix.lower().lstrip(".")],
+            expected_head_revision=expected_head_revision,
+            source_instance_id=source_instance_id or os.environ.get("DCC_MCP_INSTANCE_ID"),
+            spatial=spatial,
+            metadata=inspected,
+        )
+        return skill_success("Published Asset Sync revision {}".format(revision.revision), revision=revision.to_dict())
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to publish USD revision")
+
+
+def read_asset_head(channel_id: str, asset_id: str) -> Dict[str, Any]:
+    try:
+        Store, _, _ = _core_types()
+        head = Store(_configured_root("DCC_MCP_ASSET_SYNC_ROOT")).read_head(channel_id, asset_id)
+        if head is None:
+            return skill_error("Asset has not been published", "No head exists for the requested channel and asset")
+        return skill_success("Asset Sync head is revision {}".format(head.revision), revision=head.to_dict())
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read Asset Sync head")
+
+
+def reference_usd_revision(
+    channel_id: str,
+    asset_id: str,
+    stage_path: str = "/stage",
+    node_name: Optional[str] = None,
+    primitive_path: str = "/",
+    subfolder: str = "",
+) -> Dict[str, Any]:
+    try:
+        import hou
+
+        Store, _, _ = _core_types()
+        store = Store(_configured_root("DCC_MCP_ASSET_SYNC_ROOT"))
+        head = store.read_head(channel_id, asset_id)
+        if head is None:
+            return skill_error("Asset has not been published", "No head exists for the requested channel and asset")
+        if head.format not in _USD_FORMATS:
+            return skill_error("Unsupported revision format", "Houdini reference mode requires USD")
+        materialized = store.materialize(
+            head, _configured_root("DCC_MCP_HOUDINI_ASSET_SYNC_CONSUMER_ROOT"), subfolder=subfolder
+        )
+        parent = hou.node(stage_path)
+        if parent is None:
+            return skill_error("Solaris stage network not found", stage_path)
+        node = parent.createNode("reference", node_name=node_name or "sync_{}".format(asset_id.replace("-", "_")))
+        for parm_name in ("filepath1", "filepath"):
+            parm = node.parm(parm_name)
+            if parm is not None:
+                parm.set(str(materialized))
+                break
+        prim_parm = node.parm("primpath")
+        if prim_parm is not None:
+            prim_parm.set(primitive_path)
+        node.setDisplayFlag(True)
+        node.setRenderFlag(True)
+        return skill_success(
+            "Referenced Asset Sync revision {}".format(head.revision),
+            revision=head.to_dict(),
+            node_path=node.path(),
+            materialized_name=materialized.name,
+            editability_mode="usd_proxy",
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to reference Asset Sync revision")
+
+
+@skill_entry
+def main(**kwargs: Any) -> Dict[str, Any]:
+    operation = kwargs.pop("operation", None)
+    if operation == "read_asset_head":
+        return read_asset_head(**kwargs)
+    if operation == "reference_usd_revision":
+        return reference_usd_revision(**kwargs)
+    return publish_usd_revision(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-asset-sync/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-asset-sync/tools.yaml
@@ -1,0 +1,63 @@
+tools:
+  - name: publish_usd_revision
+    description: Publish a USD file beneath the operator-owned source root as an immutable Asset Sync revision.
+    source_file: scripts/asset_sync.py
+    execution: async
+    affinity: any
+    timeout_hint_secs: 600
+    group: asset-sync
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations: {read_only_hint: false, destructive_hint: false, idempotent_hint: true, open_world_hint: false}
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [channel_id, asset_id, source_name, expected_head_revision]
+      properties:
+        channel_id: {type: string, minLength: 1, maxLength: 128}
+        asset_id: {type: string, minLength: 1, maxLength: 128}
+        source_name: {type: string, minLength: 1, description: Safe relative USD path beneath DCC_MCP_HOUDINI_ASSET_SYNC_SOURCE_ROOT.}
+        expected_head_revision: {type: integer, minimum: 0}
+        source_instance_id: {type: string, maxLength: 128}
+        metadata: {type: object, additionalProperties: true}
+  - name: read_asset_head
+    description: Read the current path-free Asset Sync head manifest.
+    source_file: scripts/asset_sync.py
+    execution: sync
+    affinity: any
+    group: asset-sync
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: {read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false}
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [channel_id, asset_id]
+      properties:
+        channel_id: {type: string, minLength: 1, maxLength: 128}
+        asset_id: {type: string, minLength: 1, maxLength: 128}
+  - name: reference_usd_revision
+    description: Materialize the current verified USD revision and create a non-flattening Solaris Reference LOP.
+    source_file: scripts/asset_sync.py
+    execution: async
+    affinity: main
+    timeout_hint_secs: 600
+    group: asset-sync
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations: {read_only_hint: false, destructive_hint: false, idempotent_hint: false, open_world_hint: false}
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [channel_id, asset_id]
+      properties:
+        channel_id: {type: string, minLength: 1, maxLength: 128}
+        asset_id: {type: string, minLength: 1, maxLength: 128}
+        stage_path: {type: string, default: /stage}
+        node_name: {type: string, pattern: '^[A-Za-z_][A-Za-z0-9_]*$'}
+        primitive_path: {type: string, default: /}
+        subfolder: {type: string, default: ""}
+

--- a/tests/test_asset_sync_skill.py
+++ b/tests/test_asset_sync_skill.py
@@ -1,4 +1,5 @@
 """Contract tests for the bounded Houdini Asset Sync skill."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -38,4 +39,3 @@ def test_public_schemas_are_bounded_and_path_free() -> None:
     assert "source_name" in publish_properties
     assert "source_path" not in publish_properties
     assert "store_root" not in publish_properties
-

--- a/tests/test_asset_sync_skill.py
+++ b/tests/test_asset_sync_skill.py
@@ -1,0 +1,41 @@
+"""Contract tests for the bounded Houdini Asset Sync skill."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).parents[1]
+_SKILL = _ROOT / "src" / "dcc_mcp_houdini" / "skills" / "houdini-asset-sync"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("houdini_asset_sync_test", _SKILL / "scripts" / "asset_sync.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_source_name_is_confined_to_operator_root(tmp_path: Path) -> None:
+    module = _module()
+    assert module._safe_relative(tmp_path, "exports/bee.usdc") == tmp_path / "exports" / "bee.usdc"
+    with pytest.raises(ValueError, match="safe relative"):
+        module._safe_relative(tmp_path, "../secret.usdc")
+    with pytest.raises(ValueError, match="safe relative"):
+        module._safe_relative(tmp_path, str(tmp_path / "absolute.usdc"))
+
+
+def test_public_schemas_are_bounded_and_path_free() -> None:
+    tools = yaml.safe_load((_SKILL / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    by_name = {tool["name"]: tool for tool in tools}
+    assert set(by_name) == {"publish_usd_revision", "read_asset_head", "reference_usd_revision"}
+    for tool in tools:
+        assert tool["input_schema"]["additionalProperties"] is False
+    publish_properties = by_name["publish_usd_revision"]["input_schema"]["properties"]
+    assert "source_name" in publish_properties
+    assert "source_path" not in publish_properties
+    assert "store_root" not in publish_properties
+


### PR DESCRIPTION
## Summary
- add bounded Houdini Asset Sync publish, head-read, and Solaris reference tools
- preserve USD animation, curves, UsdSkel, materials, units, and composition metadata
- keep filesystem roots operator-owned and validate relative public paths

## Validation
- 916 passed, 1 skipped (full suite; compatibility assertion fixed and rechecked)
- skill lint: 0 errors, 0 warnings
- real USD publish/read against Core Asset Sync revision 1