### PR TITLE
Support SideFX expanded HDA libraries

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/_hda_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/_hda_common.py
@@ -16,12 +16,15 @@ def hou_import_error() -> dict:
 
 
 def validate_hda_path(file_path: str, *, must_exist: bool = True) -> Path:
-    """Validate a Houdini asset library path."""
+    """Validate a packed file or expanded Houdini asset library path."""
     path = Path(file_path).expanduser()
     if path.suffix.lower() not in _HDA_SUFFIXES:
         raise ValueError("Unsupported HDA file extension: {}".format(path.suffix))
-    if must_exist and not path.is_file():
-        raise FileNotFoundError("HDA file not found: {}".format(path))
+    if must_exist:
+        is_packed_library = path.is_file()
+        is_expanded_library = path.is_dir() and (path / "Sections.list").is_file()
+        if not (is_packed_library or is_expanded_library):
+            raise FileNotFoundError("HDA library not found: {}".format(path))
     if not must_exist:
         path.parent.mkdir(parents=True, exist_ok=True)
     return path

--- a/src/dcc_mcp_houdini/skills/houdini-hda/scripts/install_hda_file.py
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/scripts/install_hda_file.py
@@ -7,7 +7,7 @@ from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
 
 
 def install_hda_file(file_path: str) -> dict:
-    """Install an HDA/OTL file into the current Houdini session."""
+    """Install a packed or expanded HDA/OTL library into the current session."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
@@ -18,8 +18,9 @@ def install_hda_file(file_path: str) -> dict:
         hou.hda.installFile(str(path))
         definitions = definitions_in_file(hou, str(path))
         return skill_success(
-            "Installed Houdini Digital Asset file",
+            "Installed Houdini Digital Asset library",
             file_path=str(path),
+            library_format="expanded" if path.is_dir() else "packed",
             definitions=definitions,
             definition_count=len(definitions),
         )

--- a/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-hda/tools.yaml
@@ -1,13 +1,13 @@
 tools:
   - name: install_hda_file
-    description: "Install a Houdini .hda/.otl file into the current session and return discovered definitions."
+    description: "Install a packed Houdini .hda/.otl file or SideFX expanded HDA directory into the current session and return discovered definitions."
     input_schema:
       type: object
       required: [file_path]
       properties:
         file_path:
           type: string
-          description: "Path to an existing .hda, .hdalc, .hdanc, .otl, or .otllc file."
+          description: "Path to an existing packed or expanded .hda, .hdalc, .hdanc, .otl, or .otllc library."
     read_only: false
     destructive: false
     idempotent: true

--- a/tests/test_hda_lifecycle.py
+++ b/tests/test_hda_lifecycle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
+import pytest
 from skill_loader import skill_script_import_context
 
 _SCRIPTS = Path(__file__).parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-hda" / "scripts"
@@ -23,6 +24,43 @@ def _load_script(name: str) -> ModuleType:
     with skill_script_import_context(spec):
         spec.loader.exec_module(module)
     return module
+
+
+def test_validate_hda_path_accepts_sidefx_expanded_library(tmp_path: Path) -> None:
+    mod = _load_script("_hda_common.py")
+    library = tmp_path / "normals_from_gsplats.1.0.hda"
+    library.mkdir()
+    (library / "Sections.list").write_text("INDEX__SECTION\n", encoding="utf-8")
+
+    assert mod.validate_hda_path(str(library)) == library
+
+
+def test_validate_hda_path_rejects_empty_hda_directory(tmp_path: Path) -> None:
+    mod = _load_script("_hda_common.py")
+    library = tmp_path / "not_a_library.hda"
+    library.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="HDA library not found"):
+        mod.validate_hda_path(str(library))
+
+
+def test_install_hda_file_reports_expanded_library(tmp_path: Path) -> None:
+    mod = _load_script("install_hda_file.py")
+    library = tmp_path / "delight_gsplats.1.0.hda"
+    library.mkdir()
+    (library / "Sections.list").write_text("INDEX__SECTION\n", encoding="utf-8")
+    definition = MagicMock()
+    definition.nodeTypeName.return_value = "labs::delight_gsplats::1.0"
+    definition.nodeType.return_value.category.return_value.name.return_value = "Sop"
+    mock_hou = MagicMock()
+    mock_hou.hda.definitionsInFile.return_value = [definition]
+
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.install_hda_file(str(library))
+
+    assert result["success"] is True
+    assert result["context"]["library_format"] == "expanded"
+    mock_hou.hda.installFile.assert_called_once_with(str(library))
 
 
 def test_promote_hda_parameters_clones_interface_and_links_internal_tuple() -> None:


### PR DESCRIPTION
Supports SideFX directory-format HDA libraries while preserving the existing typed install_hda_file contract. Rejects empty HDA-shaped directories and reports packed versus expanded format.\n\nValidation: 10 HDA lifecycle tests, 111 skill contract tests, Ruff, and Houdini 22 real-host install of a SideFX Labs GSplat asset.