### PR TITLE
Guard heavy Houdini viewport framing

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/SKILL.md
@@ -26,6 +26,10 @@ View tools (`frame_view`, `get_view_state`) are UI-aware: in a headless
 `framed: false` / `ui_available: false` instead of failing.
 When both a node and camera are supplied, `frame_view` frames the node first
 and activates the camera last so the returned `active_camera` is authoritative.
+To protect the Houdini UI from driver-level crashes, `frame_view` refuses to
+draw geometry above one million primitives by default and reports counts plus
+`heavy_geometry_refused: true`. Generate a viewport proxy whenever possible;
+`allow_heavy_geometry=true` is an explicit, auditable override.
 
 ## Tool groups
 

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
@@ -7,6 +7,8 @@ from typing import List, Optional
 from _camlight_common import get_node  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
+DEFAULT_MAX_VIEWPORT_PRIMITIVES = 1_000_000
+
 
 def _scene_viewer(hou):
     try:
@@ -15,9 +17,25 @@ def _scene_viewer(hou):
         return None
 
 
+def _geometry_counts(node) -> Optional[dict]:
+    """Return bounded geometry metadata without asking the viewport to draw it."""
+    try:
+        geometry_node = node.displayNode() if hasattr(node, "displayNode") else None
+        geometry_node = geometry_node or node
+        geometry = geometry_node.geometry()
+        return {
+            "points": int(geometry.intrinsicValue("pointcount")),
+            "primitives": int(geometry.intrinsicValue("primitivecount")),
+        }
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def frame_view(
     node_path: Optional[str] = None,
     camera_path: Optional[str] = None,
+    max_primitive_count: int = DEFAULT_MAX_VIEWPORT_PRIMITIVES,
+    allow_heavy_geometry: bool = False,
 ) -> dict:
     """Look through *camera_path* (optional) and frame *node_path* (optional)."""
     try:
@@ -42,14 +60,31 @@ def frame_view(
             )
         viewport = viewer.curViewport()
         framed = False
+        geometry_counts = None
+        heavy_geometry_refused = False
         if node_path:
             node = get_node(hou, node_path)
-            try:
-                node.setSelected(True, clear_all_selected=True)
-                viewport.frameSelected()
-                framed = True
-            except Exception as frame_exc:  # noqa: BLE001
-                warnings.append("Could not frame node: {}".format(frame_exc))
+            geometry_counts = _geometry_counts(node)
+            if (
+                geometry_counts is not None
+                and geometry_counts["primitives"] > max_primitive_count
+                and not allow_heavy_geometry
+            ):
+                heavy_geometry_refused = True
+                warnings.append(
+                    "Refused to frame heavy geometry with {:,} primitives; "
+                    "create a viewport proxy or explicitly set "
+                    "allow_heavy_geometry=true.".format(
+                        geometry_counts["primitives"]
+                    )
+                )
+            else:
+                try:
+                    node.setSelected(True, clear_all_selected=True)
+                    viewport.frameSelected()
+                    framed = True
+                except Exception as frame_exc:  # noqa: BLE001
+                    warnings.append("Could not frame node: {}".format(frame_exc))
         elif not camera_path:
             try:
                 viewport.frameAll()
@@ -81,6 +116,10 @@ def frame_view(
             camera_path=camera_path,
             active_camera=active_camera,
             node_path=node_path,
+            geometry_counts=geometry_counts,
+            max_primitive_count=max_primitive_count,
+            allow_heavy_geometry=allow_heavy_geometry,
+            heavy_geometry_refused=heavy_geometry_refused,
             warnings=warnings,
         )
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/scripts/frame_view.py
@@ -74,9 +74,7 @@ def frame_view(
                 warnings.append(
                     "Refused to frame heavy geometry with {:,} primitives; "
                     "create a viewport proxy or explicitly set "
-                    "allow_heavy_geometry=true.".format(
-                        geometry_counts["primitives"]
-                    )
+                    "allow_heavy_geometry=true.".format(geometry_counts["primitives"])
                 )
             else:
                 try:

--- a/src/dcc_mcp_houdini/skills/houdini-camera-light/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-camera-light/tools.yaml
@@ -96,7 +96,8 @@ tools:
     description: >-
       Frame a node and/or activate a camera in the Scene Viewer, applying the
       camera last and reporting active_camera. UI-aware: returns framed=false
-      with a warning when headless.
+      with a warning when headless. Refuses geometry above the default viewport
+      primitive budget unless the caller explicitly overrides the safety gate.
     source_file: scripts/frame_view.py
     execution: sync
     affinity: main
@@ -115,6 +116,15 @@ tools:
           type: string
         camera_path:
           type: string
+        max_primitive_count:
+          type: integer
+          minimum: 1
+          default: 1000000
+          description: Maximum primitive count that may be framed without an explicit override.
+        allow_heavy_geometry:
+          type: boolean
+          default: false
+          description: Explicitly allow framing geometry above max_primitive_count.
   - name: get_view_state
     description: Report the active Scene Viewer camera and viewport (read-only, UI-aware).
     source_file: scripts/get_view_state.py

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -597,9 +597,7 @@ class TestViewSkills:
         mock_hou.node.return_value = geo
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
-            result = mod.frame_view(
-                node_path="/obj/highpoly", allow_heavy_geometry=True
-            )
+            result = mod.frame_view(node_path="/obj/highpoly", allow_heavy_geometry=True)
 
         assert result["success"] is True
         assert result["context"]["framed"] is True

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -545,6 +545,67 @@ class TestViewSkills:
         assert result["context"]["active_camera"] == "/obj/shotcam"
         assert events == ["select", "frame", "camera"]
 
+    def test_frame_view_refuses_heavy_geometry_by_default(self) -> None:
+        mod = _load_script("houdini-camera-light", "frame_view.py")
+        geo = _node("/obj/highpoly", "highpoly")
+        display = MagicMock()
+        geometry = MagicMock()
+        geometry.intrinsicValue.side_effect = lambda name: {
+            "pointcount": 805_545,
+            "primitivecount": 1_606_745,
+        }[name]
+        display.geometry.return_value = geometry
+        geo.displayNode.return_value = display
+        viewport = MagicMock()
+        viewer = MagicMock()
+        viewer.curViewport.return_value = viewport
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+        mock_hou.node.return_value = geo
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.frame_view(node_path="/obj/highpoly")
+
+        assert result["success"] is True
+        assert result["context"]["framed"] is False
+        assert result["context"]["heavy_geometry_refused"] is True
+        assert result["context"]["geometry_counts"] == {
+            "points": 805_545,
+            "primitives": 1_606_745,
+        }
+        geo.setSelected.assert_not_called()
+        viewport.frameSelected.assert_not_called()
+
+    def test_frame_view_allows_explicit_heavy_geometry_override(self) -> None:
+        mod = _load_script("houdini-camera-light", "frame_view.py")
+        geo = _node("/obj/highpoly", "highpoly")
+        display = MagicMock()
+        geometry = MagicMock()
+        geometry.intrinsicValue.side_effect = lambda name: {
+            "pointcount": 805_545,
+            "primitivecount": 1_606_745,
+        }[name]
+        display.geometry.return_value = geometry
+        geo.displayNode.return_value = display
+        viewport = MagicMock()
+        viewer = MagicMock()
+        viewer.curViewport.return_value = viewport
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.ui.paneTabOfType.return_value = viewer
+        mock_hou.node.return_value = geo
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.frame_view(
+                node_path="/obj/highpoly", allow_heavy_geometry=True
+            )
+
+        assert result["success"] is True
+        assert result["context"]["framed"] is True
+        assert result["context"]["heavy_geometry_refused"] is False
+        viewport.frameSelected.assert_called_once_with()
+
 
 class TestViewportCapture:
     def test_capture_viewport_headless_skips(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Adds a typed primitive-budget guard to viewport framing after a real Houdini 22 high-density geometry crash. Returns geometry counts and requires an explicit override above the default budget. Includes regression coverage.