### PR TITLE
Gate GSplat showcase quality

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/README.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/README.md
@@ -9,7 +9,11 @@ raw Python.
 ## Workflow
 
 1. `inspect_gsplat_relighting_input` validates the source SOP and required
-   point attributes.
+   point attributes. Public showcase validation also requires every region in
+   the fixed 12-region anatomy checklist—including a distinct tarsi/claws
+   region—to pass, silhouette IoU >= 0.90,
+   normalized landmark error <= 0.03, thin-structure recall >= 0.85, and at
+   least three measured novel views.
 2. `prepare_gsplat_sop_chain` reconstructs normals and optionally extracts
    albedo with SideFX Labs.
 3. `create_gsplat_relight_lop` creates the Solaris relighting node, camera,

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
@@ -29,6 +29,9 @@ Use the typed tools in this package for the cross-context handoff:
    3DGS PLY exports (`f_dc*`, `rot*`, `scale*`, `opacity`, and `f_rest*`). A
    public reconstruction showcase requires splats trained from at least three
    views of the same subject with solved camera poses. It also requires
+   a typed camera-pose source and validation state when the capture uses a
+   calibrated or estimated turntable. Estimated turntable poses remain blocked
+   from public showcase use until optimizer or reprojection validation passes.
    complete subject coverage and held-out evaluation over at least eight views
    with PSNR >= 25, SSIM >= 0.8, and LPIPS <= 0.2. These are publication gates,
    not guarantees that anatomy or identity is correct.

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
@@ -28,7 +28,10 @@ Use the typed tools in this package for the cross-context handoff:
    changing it. The preflight recognizes Houdini-native GSplats and standard
    3DGS PLY exports (`f_dc*`, `rot*`, `scale*`, `opacity`, and `f_rest*`). A
    public reconstruction showcase requires splats trained from at least three
-   views of the same subject with solved camera poses.
+   views of the same subject with solved camera poses. It also requires
+   complete subject coverage and held-out evaluation over at least eight views
+   with PSNR >= 25, SSIM >= 0.8, and LPIPS <= 0.2. These are publication gates,
+   not guarantees that anatomy or identity is correct.
 2. Prepare it with Houdini `Bake GSplats` when normalization is required, then
    Labs `Normals from GSplats` and/or `Delight GSplats`. Keep spherical
    harmonics enabled when the source provides `f_rest*` coefficients.

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/SKILL.md
@@ -32,9 +32,13 @@ Use the typed tools in this package for the cross-context handoff:
    a typed camera-pose source and validation state when the capture uses a
    calibrated or estimated turntable. Estimated turntable poses remain blocked
    from public showcase use until optimizer or reprojection validation passes.
-   complete subject coverage and held-out evaluation over at least eight views
+   It requires complete subject coverage and held-out evaluation over at least eight views
    with PSNR >= 25, SSIM >= 0.8, and LPIPS <= 0.2. These are publication gates,
-   not guarantees that anatomy or identity is correct.
+   not guarantees that anatomy or identity is correct. Anatomy fidelity is a
+   separate mandatory public-showcase gate: all evaluated regions from the
+   fixed 12-region checklist must pass, silhouette IoU must be >= 0.90,
+   normalized landmark error <= 0.03, thin-structure recall >= 0.85, and at
+   least three novel views must be evaluated.
 2. Prepare it with Houdini `Bake GSplats` when normalization is required, then
    Labs `Normals from GSplats` and/or `Delight GSplats`. Keep spherical
    harmonics enabled when the source provides `f_rest*` coefficients.
@@ -54,6 +58,14 @@ vary between Houdini 22 builds.
 Procedural meshes sampled into points are synthetic point clouds, not captured
 Gaussian Splat reconstructions. They may test relighting mechanics, but must not
 be presented as reconstruction evidence or public GSplat showcase input.
+
+The fixed anatomy checklist covers the head capsule, compound eyes, antennae,
+mouthparts, thorax, abdomen, forewings, hindwings, forelegs, middle legs, and
+hind legs, plus tarsi/claws as an independent region across all six legs.
+`anatomy_region_count` may include additional documented regions,
+but `anatomy_regions_passed` must equal the total evaluated count. The bounded
+public inputs accept at most 64 regions and 64 novel views; normalized metrics
+must be finite values in [0, 1].
 
 ## Trained checkpoint and subject-cleanup contract
 

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -2,9 +2,40 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_MAX_ANATOMY_REGIONS = 64
+_MAX_NOVEL_VIEWS = 64
+_PUBLIC_SHOWCASE_ANATOMY_REGIONS = 12
+
+
+def _optional_bounded_integer(
+    name: str,
+    value: Optional[int],
+    minimum: int,
+    maximum: int,
+) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("{} must be an integer".format(name))
+    if not minimum <= value <= maximum:
+        raise ValueError("{} must be between {} and {}".format(name, minimum, maximum))
+    return value
+
+
+def _optional_unit_interval(name: str, value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("{} must be a number".format(name))
+    measured = float(value)
+    if not math.isfinite(measured) or not 0.0 <= measured <= 1.0:
+        raise ValueError("{} must be a finite number between 0 and 1".format(name))
+    return measured
 
 
 def _node(hou: Any, path: str) -> Any:
@@ -201,6 +232,12 @@ def inspect_gsplat_relighting_input(
     heldout_psnr: Optional[float] = None,
     heldout_ssim: Optional[float] = None,
     heldout_lpips: Optional[float] = None,
+    anatomy_region_count: Optional[int] = None,
+    anatomy_regions_passed: Optional[int] = None,
+    silhouette_iou: Optional[float] = None,
+    normalized_landmark_error: Optional[float] = None,
+    thin_structure_recall: Optional[float] = None,
+    novel_view_count: Optional[int] = None,
     public_showcase: bool = False,
 ) -> dict:
     """Report the point attributes used by the Labs GSplat workflow."""
@@ -246,6 +283,38 @@ def inspect_gsplat_relighting_input(
             raise ValueError("heldout_ssim must be between 0 and 1")
         if heldout_lpips is not None and not 0 <= float(heldout_lpips) <= 1:
             raise ValueError("heldout_lpips must be between 0 and 1")
+        anatomy_region_count = _optional_bounded_integer(
+            "anatomy_region_count",
+            anatomy_region_count,
+            1,
+            _MAX_ANATOMY_REGIONS,
+        )
+        anatomy_regions_passed = _optional_bounded_integer(
+            "anatomy_regions_passed",
+            anatomy_regions_passed,
+            0,
+            _MAX_ANATOMY_REGIONS,
+        )
+        if (anatomy_region_count is None) != (anatomy_regions_passed is None):
+            raise ValueError("anatomy_region_count and anatomy_regions_passed must be provided together")
+        if (
+            anatomy_region_count is not None
+            and anatomy_regions_passed is not None
+            and anatomy_regions_passed > anatomy_region_count
+        ):
+            raise ValueError("anatomy_regions_passed cannot exceed anatomy_region_count")
+        silhouette_iou = _optional_unit_interval("silhouette_iou", silhouette_iou)
+        normalized_landmark_error = _optional_unit_interval(
+            "normalized_landmark_error",
+            normalized_landmark_error,
+        )
+        thin_structure_recall = _optional_unit_interval("thin_structure_recall", thin_structure_recall)
+        novel_view_count = _optional_bounded_integer(
+            "novel_view_count",
+            novel_view_count,
+            0,
+            _MAX_NOVEL_VIEWS,
+        )
         has_capture_type = provenance_type == "captured"
         has_enough_views = int(source_view_count) >= 3
         captured_provenance = has_capture_type and has_enough_views and bool(camera_poses_solved)
@@ -259,7 +328,20 @@ def inspect_gsplat_relighting_input(
             "heldout_ssim": heldout_ssim is not None and float(heldout_ssim) >= 0.8,
             "heldout_lpips": heldout_lpips is not None and float(heldout_lpips) <= 0.2,
         }
-        showcase_quality_pass = all(quality_checks.values()) or not bool(public_showcase)
+        anatomy_checks = {
+            "anatomy_regions": (
+                anatomy_region_count is not None
+                and anatomy_regions_passed is not None
+                and anatomy_region_count >= _PUBLIC_SHOWCASE_ANATOMY_REGIONS
+                and anatomy_regions_passed == anatomy_region_count
+            ),
+            "silhouette_iou": silhouette_iou is not None and silhouette_iou >= 0.90,
+            "normalized_landmark_error": (normalized_landmark_error is not None and normalized_landmark_error <= 0.03),
+            "thin_structure_recall": thin_structure_recall is not None and thin_structure_recall >= 0.85,
+            "novel_view_count": novel_view_count is not None and novel_view_count >= 3,
+        }
+        showcase_anatomy_pass = all(anatomy_checks.values()) or not bool(public_showcase)
+        showcase_quality_pass = (all(quality_checks.values()) and showcase_anatomy_pass) or not bool(public_showcase)
         schema = _gsplat_schema(names)
         checks = schema["native_checks"]
         missing = [key for key, present in checks.items() if not present and key in ("position", "color_or_albedo")]
@@ -282,6 +364,7 @@ def inspect_gsplat_relighting_input(
                 missing
                 + ([] if showcase_provenance_pass else ["captured_gsplat_provenance"])
                 + ([] if showcase_quality_pass else [name for name, passed in quality_checks.items() if not passed])
+                + ([] if showcase_anatomy_pass else [name for name, passed in anatomy_checks.items() if not passed])
             ),
             provenance={
                 "type": provenance_type,
@@ -300,6 +383,23 @@ def inspect_gsplat_relighting_input(
                 "heldout_lpips": None if heldout_lpips is None else float(heldout_lpips),
                 "checks": quality_checks,
                 "public_showcase_pass": showcase_quality_pass,
+                "anatomy_fidelity": {
+                    "anatomy_region_count": anatomy_region_count,
+                    "anatomy_regions_passed": anatomy_regions_passed,
+                    "silhouette_iou": silhouette_iou,
+                    "normalized_landmark_error": normalized_landmark_error,
+                    "thin_structure_recall": thin_structure_recall,
+                    "novel_view_count": novel_view_count,
+                    "checks": anatomy_checks,
+                    "public_showcase_pass": showcase_anatomy_pass,
+                    "thresholds": {
+                        "minimum_anatomy_regions": _PUBLIC_SHOWCASE_ANATOMY_REGIONS,
+                        "minimum_silhouette_iou": 0.90,
+                        "maximum_normalized_landmark_error": 0.03,
+                        "minimum_thin_structure_recall": 0.85,
+                        "minimum_novel_views": 3,
+                    },
+                },
                 "thresholds": {
                     "minimum_evaluation_views": 8,
                     "minimum_psnr": 25.0,
@@ -314,6 +414,7 @@ def inspect_gsplat_relighting_input(
                 "Run Houdini Bake GSplats before Labs when source_schema is standard_3dgs_ply.",
                 "Do not label procedural point sampling as captured GSplat reconstruction.",
                 "Use held-out views and complete subject coverage before publishing a GSplat showcase.",
+                "Require all fixed anatomy regions and measured silhouette, landmark, thin-structure, and novel-view gates before publication.",
             ],
         )
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -194,6 +194,11 @@ def inspect_gsplat_relighting_input(
     provenance_type: str = "unknown",
     source_view_count: int = 0,
     camera_poses_solved: bool = False,
+    capture_coverage: str = "unknown",
+    evaluation_view_count: int = 0,
+    heldout_psnr: Optional[float] = None,
+    heldout_ssim: Optional[float] = None,
+    heldout_lpips: Optional[float] = None,
     public_showcase: bool = False,
 ) -> dict:
     """Report the point attributes used by the Labs GSplat workflow."""
@@ -214,10 +219,29 @@ def inspect_gsplat_relighting_input(
             raise ValueError("provenance_type must be captured, synthetic, or unknown")
         if isinstance(source_view_count, bool) or int(source_view_count) < 0:
             raise ValueError("source_view_count must be a non-negative integer")
+        capture_coverage = str(capture_coverage or "unknown").lower()
+        if capture_coverage not in {"complete", "partial", "unknown"}:
+            raise ValueError("capture_coverage must be complete, partial, or unknown")
+        if isinstance(evaluation_view_count, bool) or int(evaluation_view_count) < 0:
+            raise ValueError("evaluation_view_count must be a non-negative integer")
+        if heldout_psnr is not None and float(heldout_psnr) < 0:
+            raise ValueError("heldout_psnr must be non-negative")
+        if heldout_ssim is not None and not 0 <= float(heldout_ssim) <= 1:
+            raise ValueError("heldout_ssim must be between 0 and 1")
+        if heldout_lpips is not None and not 0 <= float(heldout_lpips) <= 1:
+            raise ValueError("heldout_lpips must be between 0 and 1")
         has_capture_type = provenance_type == "captured"
         has_enough_views = int(source_view_count) >= 3
         captured_provenance = has_capture_type and has_enough_views and bool(camera_poses_solved)
         showcase_provenance_pass = captured_provenance or not bool(public_showcase)
+        quality_checks = {
+            "complete_capture_coverage": capture_coverage == "complete",
+            "evaluation_views": int(evaluation_view_count) >= 8,
+            "heldout_psnr": heldout_psnr is not None and float(heldout_psnr) >= 25.0,
+            "heldout_ssim": heldout_ssim is not None and float(heldout_ssim) >= 0.8,
+            "heldout_lpips": heldout_lpips is not None and float(heldout_lpips) <= 0.2,
+        }
+        showcase_quality_pass = all(quality_checks.values()) or not bool(public_showcase)
         schema = _gsplat_schema(names)
         checks = schema["native_checks"]
         missing = [key for key, present in checks.items() if not present and key in ("position", "color_or_albedo")]
@@ -235,8 +259,12 @@ def inspect_gsplat_relighting_input(
             normalization_available=schema["normalization_available"],
             recommended_normalizer="bakegsplat" if schema["normalization_required"] else None,
             ready_for_preparation=ready_for_preparation,
-            ready_for_relighting=not missing and showcase_provenance_pass,
-            blocking_missing=missing + ([] if showcase_provenance_pass else ["captured_gsplat_provenance"]),
+            ready_for_relighting=not missing and showcase_provenance_pass and showcase_quality_pass,
+            blocking_missing=(
+                missing
+                + ([] if showcase_provenance_pass else ["captured_gsplat_provenance"])
+                + ([] if showcase_quality_pass else [name for name, passed in quality_checks.items() if not passed])
+            ),
             provenance={
                 "type": provenance_type,
                 "source_view_count": int(source_view_count),
@@ -244,12 +272,28 @@ def inspect_gsplat_relighting_input(
                 "captured_gsplat": captured_provenance,
                 "public_showcase_pass": showcase_provenance_pass,
             },
+            quality={
+                "capture_coverage": capture_coverage,
+                "evaluation_view_count": int(evaluation_view_count),
+                "heldout_psnr": None if heldout_psnr is None else float(heldout_psnr),
+                "heldout_ssim": None if heldout_ssim is None else float(heldout_ssim),
+                "heldout_lpips": None if heldout_lpips is None else float(heldout_lpips),
+                "checks": quality_checks,
+                "public_showcase_pass": showcase_quality_pass,
+                "thresholds": {
+                    "minimum_evaluation_views": 8,
+                    "minimum_psnr": 25.0,
+                    "minimum_ssim": 0.8,
+                    "maximum_lpips": 0.2,
+                },
+            },
             recommendations=[
                 "Run Labs Normals from GSplats when N is absent.",
                 "Run Labs Delight GSplats when albedo is absent or captured lighting must be removed.",
                 "Preserve GS_SPH_R/G/B when view-dependent captured appearance matters.",
                 "Run Houdini Bake GSplats before Labs when source_schema is standard_3dgs_ply.",
                 "Do not label procedural point sampling as captured GSplat reconstruction.",
+                "Use held-out views and complete subject coverage before publishing a GSplat showcase.",
             ],
         )
     except Exception as exc:

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -230,14 +230,11 @@ def inspect_gsplat_relighting_input(
             "unknown",
         }:
             raise ValueError(
-                "camera_pose_source must be sfm, calibrated_turntable, "
-                "estimated_turntable, legacy, or unknown"
+                "camera_pose_source must be sfm, calibrated_turntable, estimated_turntable, legacy, or unknown"
             )
         camera_pose_validation = str(camera_pose_validation or "unknown").lower()
         if camera_pose_validation not in {"validated", "pending", "failed", "legacy", "unknown"}:
-            raise ValueError(
-                "camera_pose_validation must be validated, pending, failed, legacy, or unknown"
-            )
+            raise ValueError("camera_pose_validation must be validated, pending, failed, legacy, or unknown")
         capture_coverage = str(capture_coverage or "unknown").lower()
         if capture_coverage not in {"complete", "partial", "unknown"}:
             raise ValueError("capture_coverage must be complete, partial, or unknown")

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/scripts/gsplat_relighting.py
@@ -194,6 +194,8 @@ def inspect_gsplat_relighting_input(
     provenance_type: str = "unknown",
     source_view_count: int = 0,
     camera_poses_solved: bool = False,
+    camera_pose_source: str = "legacy",
+    camera_pose_validation: str = "legacy",
     capture_coverage: str = "unknown",
     evaluation_view_count: int = 0,
     heldout_psnr: Optional[float] = None,
@@ -219,6 +221,23 @@ def inspect_gsplat_relighting_input(
             raise ValueError("provenance_type must be captured, synthetic, or unknown")
         if isinstance(source_view_count, bool) or int(source_view_count) < 0:
             raise ValueError("source_view_count must be a non-negative integer")
+        camera_pose_source = str(camera_pose_source or "unknown").lower()
+        if camera_pose_source not in {
+            "sfm",
+            "calibrated_turntable",
+            "estimated_turntable",
+            "legacy",
+            "unknown",
+        }:
+            raise ValueError(
+                "camera_pose_source must be sfm, calibrated_turntable, "
+                "estimated_turntable, legacy, or unknown"
+            )
+        camera_pose_validation = str(camera_pose_validation or "unknown").lower()
+        if camera_pose_validation not in {"validated", "pending", "failed", "legacy", "unknown"}:
+            raise ValueError(
+                "camera_pose_validation must be validated, pending, failed, legacy, or unknown"
+            )
         capture_coverage = str(capture_coverage or "unknown").lower()
         if capture_coverage not in {"complete", "partial", "unknown"}:
             raise ValueError("capture_coverage must be complete, partial, or unknown")
@@ -235,6 +254,8 @@ def inspect_gsplat_relighting_input(
         captured_provenance = has_capture_type and has_enough_views and bool(camera_poses_solved)
         showcase_provenance_pass = captured_provenance or not bool(public_showcase)
         quality_checks = {
+            "camera_pose_source": camera_pose_source in {"sfm", "calibrated_turntable", "legacy"},
+            "camera_pose_validation": camera_pose_validation in {"validated", "legacy"},
             "complete_capture_coverage": capture_coverage == "complete",
             "evaluation_views": int(evaluation_view_count) >= 8,
             "heldout_psnr": heldout_psnr is not None and float(heldout_psnr) >= 25.0,
@@ -269,6 +290,8 @@ def inspect_gsplat_relighting_input(
                 "type": provenance_type,
                 "source_view_count": int(source_view_count),
                 "camera_poses_solved": bool(camera_poses_solved),
+                "camera_pose_source": camera_pose_source,
+                "camera_pose_validation": camera_pose_validation,
                 "captured_gsplat": captured_provenance,
                 "public_showcase_pass": showcase_provenance_pass,
             },

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
@@ -44,10 +44,34 @@ tools:
           type: boolean
           default: false
           description: Whether source camera poses were reconstructed and retained.
+        capture_coverage:
+          type: string
+          enum: [complete, partial, unknown]
+          default: unknown
+          description: Whether the captured views cover the complete subject without known missing regions.
+        evaluation_view_count:
+          type: integer
+          minimum: 0
+          default: 0
+          description: Number of held-out views used for reconstruction quality evaluation.
+        heldout_psnr:
+          type: number
+          minimum: 0
+          description: Mean PSNR measured on held-out source views.
+        heldout_ssim:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Mean SSIM measured on held-out source views.
+        heldout_lpips:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Mean LPIPS measured on held-out source views.
         public_showcase:
           type: boolean
           default: false
-          description: Enforce captured-GSplat provenance before allowing public showcase use.
+          description: Enforce captured provenance, complete coverage, and held-out quality thresholds before public showcase use.
     next-tools:
       on-success:
         - houdini_gsplat_relighting__prepare_gsplat_sop_chain

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
@@ -78,10 +78,40 @@ tools:
           minimum: 0
           maximum: 1
           description: Mean LPIPS measured on held-out source views.
+        anatomy_region_count:
+          type: integer
+          minimum: 1
+          maximum: 64
+          description: Number of fixed anatomy checklist regions evaluated; public showcase evaluation requires at least 12, including a distinct tarsi/claws region.
+        anatomy_regions_passed:
+          type: integer
+          minimum: 0
+          maximum: 64
+          description: Anatomy checklist regions that passed; cannot exceed anatomy_region_count and must equal it for public showcase use.
+        silhouette_iou:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Multi-view silhouette intersection-over-union against approved references.
+        normalized_landmark_error:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Mean anatomical landmark error normalized by subject scale; lower is better.
+        thin_structure_recall:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Recall for antennae, legs, wing edges, and other reference thin structures.
+        novel_view_count:
+          type: integer
+          minimum: 0
+          maximum: 64
+          description: Number of independent novel views used for anatomy fidelity evaluation.
         public_showcase:
           type: boolean
           default: false
-          description: Enforce captured provenance, complete coverage, and held-out quality thresholds before public showcase use.
+          description: Enforce captured provenance, complete coverage, held-out image quality, and anatomy fidelity thresholds before public showcase use.
     next-tools:
       on-success:
         - houdini_gsplat_relighting__prepare_gsplat_sop_chain

--- a/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-gsplat-relighting/tools.yaml
@@ -44,6 +44,16 @@ tools:
           type: boolean
           default: false
           description: Whether source camera poses were reconstructed and retained.
+        camera_pose_source:
+          type: string
+          enum: [sfm, calibrated_turntable, estimated_turntable, legacy, unknown]
+          default: legacy
+          description: Typed origin of the retained camera poses; estimated turntable poses require validation before showcase use.
+        camera_pose_validation:
+          type: string
+          enum: [validated, pending, failed, legacy, unknown]
+          default: legacy
+          description: Independent validation state for source poses, such as held-out reprojection or calibrated turntable checks.
         capture_coverage:
           type: string
           enum: [complete, partial, unknown]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -367,6 +367,94 @@ class TestGsplatRelightingSkills:
         assert result["context"]["provenance"]["public_showcase_pass"] is False
         assert "captured_gsplat_provenance" in result["context"]["blocking_missing"]
 
+    @pytest.mark.parametrize(
+        ("capture_coverage", "psnr", "ssim", "lpips", "expected_blocker"),
+        [
+            ("partial", 27.0, 0.86, 0.12, "complete_capture_coverage"),
+            ("complete", 24.11, 0.86, 0.12, "heldout_psnr"),
+            ("complete", 27.0, 0.725, 0.12, "heldout_ssim"),
+            ("complete", 27.0, 0.86, 0.24, "heldout_lpips"),
+        ],
+    )
+    def test_public_showcase_rejects_incomplete_or_low_quality_capture(
+        self,
+        capture_coverage: str,
+        psnr: float,
+        ssim: float,
+        lpips: float,
+        expected_blocker: str,
+    ) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        attrs = []
+        for name in ("P", "Cd", "orient", "pscale", "GS_Alpha"):
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attrib.dataType.return_value.name.return_value = "Float"
+            attrib.size.return_value = 3
+            attrs.append(attrib)
+        geometry = MagicMock()
+        geometry.pointAttribs.return_value = attrs
+        geometry.pointCount.return_value = 100
+        geometry.primCount.return_value = 0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/OUT"
+        node.name.return_value = "OUT"
+        node.type.return_value.name.return_value = "null"
+        node.geometry.return_value = geometry
+        with patch.dict(sys.modules, {"hou": MagicMock(node=lambda _path: node)}):
+            result = mod.inspect_gsplat_relighting_input(
+                node_path="/obj/geo1/OUT",
+                provenance_type="captured",
+                source_view_count=31,
+                camera_poses_solved=True,
+                capture_coverage=capture_coverage,
+                evaluation_view_count=18,
+                heldout_psnr=psnr,
+                heldout_ssim=ssim,
+                heldout_lpips=lpips,
+                public_showcase=True,
+            )
+
+        assert result["context"]["ready_for_relighting"] is False
+        assert result["context"]["provenance"]["public_showcase_pass"] is True
+        assert result["context"]["quality"]["public_showcase_pass"] is False
+        assert expected_blocker in result["context"]["blocking_missing"]
+
+    def test_public_showcase_accepts_measured_complete_capture(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        attrs = []
+        for name in ("P", "Cd", "orient", "pscale", "GS_Alpha"):
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attrib.dataType.return_value.name.return_value = "Float"
+            attrib.size.return_value = 3
+            attrs.append(attrib)
+        geometry = MagicMock()
+        geometry.pointAttribs.return_value = attrs
+        geometry.pointCount.return_value = 100
+        geometry.primCount.return_value = 0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/OUT"
+        node.name.return_value = "OUT"
+        node.type.return_value.name.return_value = "null"
+        node.geometry.return_value = geometry
+        with patch.dict(sys.modules, {"hou": MagicMock(node=lambda _path: node)}):
+            result = mod.inspect_gsplat_relighting_input(
+                node_path="/obj/geo1/OUT",
+                provenance_type="captured",
+                source_view_count=96,
+                camera_poses_solved=True,
+                capture_coverage="complete",
+                evaluation_view_count=12,
+                heldout_psnr=27.5,
+                heldout_ssim=0.86,
+                heldout_lpips=0.12,
+                public_showcase=True,
+            )
+
+        assert result["context"]["ready_for_relighting"] is True
+        assert result["context"]["blocking_missing"] == []
+
     def test_prepare_rolls_back_when_labs_node_is_missing(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
         source = MagicMock()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -455,6 +455,44 @@ class TestGsplatRelightingSkills:
         assert result["context"]["ready_for_relighting"] is True
         assert result["context"]["blocking_missing"] == []
 
+    def test_public_showcase_rejects_unvalidated_estimated_turntable_poses(self) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        attrs = []
+        for name in ("P", "Cd", "orient", "pscale", "GS_Alpha"):
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attrib.dataType.return_value.name.return_value = "Float"
+            attrib.size.return_value = 3
+            attrs.append(attrib)
+        geometry = MagicMock()
+        geometry.pointAttribs.return_value = attrs
+        geometry.pointCount.return_value = 100
+        geometry.primCount.return_value = 0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/OUT"
+        node.name.return_value = "OUT"
+        node.type.return_value.name.return_value = "null"
+        node.geometry.return_value = geometry
+        with patch.dict(sys.modules, {"hou": MagicMock(node=lambda _path: node)}):
+            result = mod.inspect_gsplat_relighting_input(
+                node_path="/obj/geo1/OUT",
+                provenance_type="captured",
+                source_view_count=142,
+                camera_poses_solved=True,
+                camera_pose_source="estimated_turntable",
+                camera_pose_validation="pending",
+                capture_coverage="complete",
+                evaluation_view_count=15,
+                heldout_psnr=27.5,
+                heldout_ssim=0.86,
+                heldout_lpips=0.12,
+                public_showcase=True,
+            )
+
+        assert result["context"]["ready_for_relighting"] is False
+        assert "camera_pose_source" in result["context"]["blocking_missing"]
+        assert "camera_pose_validation" in result["context"]["blocking_missing"]
+
     def test_prepare_rolls_back_when_labs_node_is_missing(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
         source = MagicMock()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -449,11 +449,164 @@ class TestGsplatRelightingSkills:
                 heldout_psnr=27.5,
                 heldout_ssim=0.86,
                 heldout_lpips=0.12,
+                anatomy_region_count=12,
+                anatomy_regions_passed=12,
+                silhouette_iou=0.90,
+                normalized_landmark_error=0.03,
+                thin_structure_recall=0.85,
+                novel_view_count=3,
                 public_showcase=True,
             )
 
         assert result["context"]["ready_for_relighting"] is True
         assert result["context"]["blocking_missing"] == []
+        anatomy = result["context"]["quality"]["anatomy_fidelity"]
+        assert anatomy["public_showcase_pass"] is True
+        assert anatomy["checks"] == {
+            "anatomy_regions": True,
+            "silhouette_iou": True,
+            "normalized_landmark_error": True,
+            "thin_structure_recall": True,
+            "novel_view_count": True,
+        }
+
+    @pytest.mark.parametrize(
+        ("overrides", "expected_blocker"),
+        [
+            ({"anatomy_region_count": 11, "anatomy_regions_passed": 11}, "anatomy_regions"),
+            ({"anatomy_region_count": 12, "anatomy_regions_passed": 11}, "anatomy_regions"),
+            ({"anatomy_region_count": None, "anatomy_regions_passed": None}, "anatomy_regions"),
+            ({"silhouette_iou": 0.899999}, "silhouette_iou"),
+            ({"silhouette_iou": None}, "silhouette_iou"),
+            ({"normalized_landmark_error": 0.030001}, "normalized_landmark_error"),
+            ({"normalized_landmark_error": None}, "normalized_landmark_error"),
+            ({"thin_structure_recall": 0.849999}, "thin_structure_recall"),
+            ({"thin_structure_recall": None}, "thin_structure_recall"),
+            ({"novel_view_count": 2}, "novel_view_count"),
+            ({"novel_view_count": None}, "novel_view_count"),
+        ],
+    )
+    def test_public_showcase_rejects_anatomy_fidelity_below_gate(
+        self,
+        overrides: dict[str, object],
+        expected_blocker: str,
+    ) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        attrs = []
+        for name in ("P", "Cd", "orient", "pscale", "GS_Alpha"):
+            attrib = MagicMock()
+            attrib.name.return_value = name
+            attrib.dataType.return_value.name.return_value = "Float"
+            attrib.size.return_value = 3
+            attrs.append(attrib)
+        geometry = MagicMock()
+        geometry.pointAttribs.return_value = attrs
+        geometry.pointCount.return_value = 100
+        geometry.primCount.return_value = 0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/OUT"
+        node.name.return_value = "OUT"
+        node.type.return_value.name.return_value = "null"
+        node.geometry.return_value = geometry
+        inputs: dict[str, object] = {
+            "node_path": "/obj/geo1/OUT",
+            "provenance_type": "captured",
+            "source_view_count": 96,
+            "camera_poses_solved": True,
+            "capture_coverage": "complete",
+            "evaluation_view_count": 12,
+            "heldout_psnr": 27.5,
+            "heldout_ssim": 0.86,
+            "heldout_lpips": 0.12,
+            "anatomy_region_count": 12,
+            "anatomy_regions_passed": 12,
+            "silhouette_iou": 0.90,
+            "normalized_landmark_error": 0.03,
+            "thin_structure_recall": 0.85,
+            "novel_view_count": 3,
+            "public_showcase": True,
+        }
+        inputs.update(overrides)
+
+        with patch.dict(sys.modules, {"hou": MagicMock(node=lambda _path: node)}):
+            result = mod.inspect_gsplat_relighting_input(**inputs)
+
+        assert result["context"]["ready_for_relighting"] is False
+        assert result["context"]["quality"]["anatomy_fidelity"]["public_showcase_pass"] is False
+        assert expected_blocker in result["context"]["blocking_missing"]
+
+    @pytest.mark.parametrize(
+        ("invalid_input", "expected_parameter"),
+        [
+            ({"anatomy_region_count": 0}, "anatomy_region_count"),
+            ({"anatomy_region_count": 65}, "anatomy_region_count"),
+            ({"anatomy_region_count": True}, "anatomy_region_count"),
+            ({"anatomy_region_count": "11"}, "anatomy_region_count"),
+            (
+                {"anatomy_region_count": 11, "anatomy_regions_passed": 12},
+                "anatomy_regions_passed",
+            ),
+            ({"silhouette_iou": -0.001}, "silhouette_iou"),
+            ({"silhouette_iou": 1.001}, "silhouette_iou"),
+            ({"silhouette_iou": float("nan")}, "silhouette_iou"),
+            ({"normalized_landmark_error": -0.001}, "normalized_landmark_error"),
+            ({"normalized_landmark_error": 1.001}, "normalized_landmark_error"),
+            ({"thin_structure_recall": -0.001}, "thin_structure_recall"),
+            ({"thin_structure_recall": 1.001}, "thin_structure_recall"),
+            ({"novel_view_count": -1}, "novel_view_count"),
+            ({"novel_view_count": 65}, "novel_view_count"),
+            ({"novel_view_count": 3.0}, "novel_view_count"),
+        ],
+    )
+    def test_anatomy_fidelity_inputs_are_strictly_bounded_and_typed(
+        self,
+        invalid_input: dict[str, object],
+        expected_parameter: str,
+    ) -> None:
+        mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")
+        geometry = MagicMock()
+        geometry.pointAttribs.return_value = []
+        geometry.pointCount.return_value = 0
+        geometry.primCount.return_value = 0
+        node = MagicMock()
+        node.path.return_value = "/obj/geo1/OUT"
+        node.name.return_value = "OUT"
+        node.type.return_value.name.return_value = "null"
+        node.geometry.return_value = geometry
+
+        with patch.dict(sys.modules, {"hou": MagicMock(node=lambda _path: node)}):
+            result = mod.inspect_gsplat_relighting_input(
+                node_path="/obj/geo1/OUT",
+                **invalid_input,
+            )
+
+        assert result["success"] is False
+        assert expected_parameter in str(result)
+
+    def test_gsplat_anatomy_fidelity_schema_is_bounded(self) -> None:
+        tools_path = _SKILLS_ROOT / "houdini-gsplat-relighting" / "tools.yaml"
+        tools = yaml.safe_load(tools_path.read_text(encoding="utf-8"))["tools"]
+        inspect_tool = next(tool for tool in tools if tool["name"] == "inspect_gsplat_relighting_input")
+        properties = inspect_tool["input_schema"]["properties"]
+
+        assert properties["anatomy_region_count"] == {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 64,
+            "description": (
+                "Number of fixed anatomy checklist regions evaluated; public showcase evaluation requires at least 12, "
+                "including a distinct tarsi/claws region."
+            ),
+        }
+        assert properties["anatomy_regions_passed"]["minimum"] == 0
+        assert properties["anatomy_regions_passed"]["maximum"] == 64
+        for metric in ("silhouette_iou", "normalized_landmark_error", "thin_structure_recall"):
+            assert properties[metric]["type"] == "number"
+            assert properties[metric]["minimum"] == 0
+            assert properties[metric]["maximum"] == 1
+        assert properties["novel_view_count"]["type"] == "integer"
+        assert properties["novel_view_count"]["minimum"] == 0
+        assert properties["novel_view_count"]["maximum"] == 64
 
     def test_public_showcase_rejects_unvalidated_estimated_turntable_poses(self) -> None:
         mod = _load_script("houdini-gsplat-relighting", "gsplat_relighting.py")


### PR DESCRIPTION
## Summary
- require complete capture coverage for public GSplat showcases
- gate held-out PSNR, SSIM, and LPIPS metrics
- report explicit quality blockers and thresholds

## Validation
- 116 skill tests passed
- Ruff passed
- skill schema lint passed