### PR TITLE
Add anatomy-region insect Groom profiles

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-groom/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-groom/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     dcc: houdini
     layer: domain
     stage: authoring
-    version: "1.0.0"
+    version: "1.1.0"
     tags: [houdini, groom, fur, hair, guides, insect, creature, deformation]
     search-hint: "insect fuzz bee fur hair generate guide deform animated skin groom"
     tools: tools.yaml
@@ -26,8 +26,12 @@ thread affinity because they create and wire Houdini nodes.
 ## Workflow
 
 1. Prepare a polygon rest skin and optional root-to-tip guides.
-2. Call `build_short_fur_groom` with an optional animated skin.
-3. Inspect the returned Hair Generate and Guide Deform nodes before rendering.
+2. Call `build_short_fur_groom` with an optional animated skin. For anatomical
+   variation, pass `region_profiles` such as `head`, `thorax`, and `abdomen`;
+   each region may override its skin group, guides, density, length, segments,
+   and clump strength.
+3. Inspect the returned per-region Hair Generate/Clump nodes, shared Merge,
+   and Guide Deform before rendering.
 
 For insect fuzz, start with short lengths and Surface Deform. Use explicit
 guides for directional thorax and abdomen hair.

--- a/src/dcc_mcp_houdini/skills/houdini-groom/scripts/build_short_fur_groom.py
+++ b/src/dcc_mcp_houdini/skills/houdini-groom/scripts/build_short_fur_groom.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Mapping
 from typing import Optional, Sequence
 
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_REGION_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
+_REGION_KEYS = {"name", "skin_group", "guides", "density", "length", "segments", "clump_strength"}
 
 
 def _node(hou, path: str):
@@ -50,6 +55,76 @@ def _validate_surface_pair(rest, animated) -> None:
         )
 
 
+def _validate_fur_values(density: float, length: float, segments: int, clump_strength: float) -> None:
+    if not 0.001 <= float(density) <= 10000000:
+        raise ValueError("density must be between 0.001 and 10000000")
+    if not 0 < float(length) <= 10:
+        raise ValueError("length must be greater than 0 and at most 10")
+    if isinstance(segments, bool) or not 2 <= int(segments) <= 64:
+        raise ValueError("segments must be between 2 and 64")
+    if not 0 <= float(clump_strength) <= 1:
+        raise ValueError("clump_strength must be between 0 and 1")
+
+
+def _normalize_regions(
+    region_profiles,
+    *,
+    skin_group: str,
+    guides: Optional[str],
+    density: float,
+    length: float,
+    segments: int,
+    clump_strength: float,
+) -> list[dict]:
+    if region_profiles is None:
+        _validate_fur_values(density, length, segments, clump_strength)
+        return [
+            {
+                "name": None,
+                "skin_group": str(skin_group),
+                "guides": guides,
+                "density": float(density),
+                "length": float(length),
+                "segments": int(segments),
+                "clump_strength": float(clump_strength),
+            }
+        ]
+    if not isinstance(region_profiles, (list, tuple)) or not 1 <= len(region_profiles) <= 16:
+        raise ValueError("region_profiles must contain between 1 and 16 region objects")
+
+    normalized = []
+    names = set()
+    for index, profile in enumerate(region_profiles):
+        if not isinstance(profile, Mapping):
+            raise ValueError("region profile {} must be an object".format(index))
+        unknown = sorted(set(profile) - _REGION_KEYS)
+        if unknown:
+            raise ValueError("region profile {} contains unsupported keys: {}".format(index, ", ".join(unknown)))
+        name = profile.get("name")
+        group = profile.get("skin_group")
+        if not isinstance(name, str) or _REGION_NAME_RE.fullmatch(name) is None:
+            raise ValueError("region name must start with a letter and contain only letters, numbers, or underscores")
+        if name in names:
+            raise ValueError("region names must be unique: {}".format(name))
+        if not isinstance(group, str) or not group.strip():
+            raise ValueError("region skin_group must be a non-empty string")
+        names.add(name)
+        region = {
+            "name": name,
+            "skin_group": group,
+            "guides": profile.get("guides", guides),
+            "density": float(profile.get("density", density)),
+            "length": float(profile.get("length", length)),
+            "segments": int(profile.get("segments", segments)),
+            "clump_strength": float(profile.get("clump_strength", clump_strength)),
+        }
+        if region["guides"] is not None and not isinstance(region["guides"], str):
+            raise ValueError("region guides must be a SOP node name")
+        _validate_fur_values(region["density"], region["length"], region["segments"], region["clump_strength"])
+        normalized.append(region)
+    return normalized
+
+
 def build_short_fur_groom(
     geo_path: str,
     rest_skin: str,
@@ -60,6 +135,7 @@ def build_short_fur_groom(
     length: float = 0.025,
     segments: int = 5,
     clump_strength: float = 0.15,
+    region_profiles=None,
     deform_method: str = "surface",
     name_prefix: str = "insect_fur",
 ) -> dict:
@@ -71,50 +147,80 @@ def build_short_fur_groom(
 
     created = []
     try:
-        if not 0.001 <= float(density) <= 10000000:
-            raise ValueError("density must be between 0.001 and 10000000")
-        if not 0 < float(length) <= 10:
-            raise ValueError("length must be greater than 0 and at most 10")
-        if isinstance(segments, bool) or not 2 <= int(segments) <= 64:
-            raise ValueError("segments must be between 2 and 64")
-        if not 0 <= float(clump_strength) <= 1:
-            raise ValueError("clump_strength must be between 0 and 1")
         if deform_method not in {"surface", "guide_shape", "point"}:
             raise ValueError("deform_method must be surface, guide_shape, or point")
+        regions = _normalize_regions(
+            region_profiles,
+            skin_group=skin_group,
+            guides=guides,
+            density=density,
+            length=length,
+            segments=segments,
+            clump_strength=clump_strength,
+        )
 
         geo = _node(hou, geo_path)
         rest = _node(hou, "{}/{}".format(geo.path(), rest_skin))
         animated = _node(hou, "{}/{}".format(geo.path(), animated_skin)) if animated_skin else None
-        guide_node = _node(hou, "{}/{}".format(geo.path(), guides)) if guides else None
+        guide_nodes = {
+            region["name"]: _node(hou, "{}/{}".format(geo.path(), region["guides"])) if region["guides"] else None
+            for region in regions
+        }
         if animated is not None and deform_method == "surface":
             _validate_surface_pair(rest, animated)
 
         hair_type = _find_type(geo, ("hairgen::2.0", "hairgen"))
-        hair = geo.createNode(hair_type, node_name="{}_generate".format(name_prefix))
-        created.append(hair)
-        hair.setInput(0, rest, 0)
-        if guide_node is not None:
-            hair.setInput(1, guide_node, 0)
-        configured = {
-            "density": _set_first(hair, ("density", "hairdensity"), float(density)),
-            "length": _set_first(hair, ("unguidedlength", "length", "hairlength"), float(length)),
-            "segments": _set_first(hair, ("unguidedsegments", "segments", "hairsegments"), int(segments)),
-            "group": _set_first(hair, ("group",), str(skin_group)),
-        }
+        region_outputs = []
+        region_context = []
+        for region in regions:
+            suffix = "_{}".format(region["name"]) if region["name"] else ""
+            hair = geo.createNode(hair_type, node_name="{}{}_generate".format(name_prefix, suffix))
+            created.append(hair)
+            hair.setInput(0, rest, 0)
+            guide_node = guide_nodes[region["name"]]
+            if guide_node is not None:
+                hair.setInput(1, guide_node, 0)
+            configured = {
+                "density": _set_first(hair, ("density", "hairdensity"), region["density"]),
+                "length": _set_first(hair, ("unguidedlength", "length", "hairlength"), region["length"]),
+                "segments": _set_first(hair, ("unguidedsegments", "segments", "hairsegments"), region["segments"]),
+                "group": _set_first(hair, ("group",), region["skin_group"]),
+            }
 
-        current = hair
-        clump_path = None
-        if clump_strength > 0:
-            clump_type = _find_type(geo, ("hairclump::2.0", "hairclump"))
-            clump = geo.createNode(clump_type, node_name="{}_clump".format(name_prefix))
-            created.append(clump)
-            clump.setFirstInput(current)
-            clump.setInput(1, rest, 0)
-            configured["clump_strength"] = _set_first(
-                clump, ("blend", "strength", "clumpstrength"), float(clump_strength)
+            current = hair
+            clump_path = None
+            if region["clump_strength"] > 0:
+                clump_type = _find_type(geo, ("hairclump::2.0", "hairclump"))
+                clump = geo.createNode(clump_type, node_name="{}{}_clump".format(name_prefix, suffix))
+                created.append(clump)
+                clump.setFirstInput(current)
+                clump.setInput(1, rest, 0)
+                configured["clump_strength"] = _set_first(
+                    clump, ("blend", "strength", "clumpstrength"), region["clump_strength"]
+                )
+                current = clump
+                clump_path = clump.path()
+            region_outputs.append(current)
+            region_context.append(
+                {
+                    **region,
+                    "guides": guide_node.path() if guide_node is not None else None,
+                    "hair_generate_path": hair.path(),
+                    "hair_clump_path": clump_path,
+                    "configured_parameters": configured,
+                }
             )
-            current = clump
-            clump_path = clump.path()
+
+        merge_path = None
+        if len(region_outputs) > 1:
+            merge = geo.createNode("merge", node_name="{}_merge".format(name_prefix))
+            created.append(merge)
+            for index, output in enumerate(region_outputs):
+                merge.setInput(index, output, 0)
+            current = merge
+            merge_path = merge.path()
+        else:
+            current = region_outputs[0]
 
         deform_path = None
         if animated is not None:
@@ -146,14 +252,17 @@ def build_short_fur_groom(
         return skill_success(
             "Built short-fur groom",
             output_node_path=current.path(),
-            hair_generate_path=hair.path(),
-            hair_clump_path=clump_path,
+            hair_generate_path=region_context[0]["hair_generate_path"],
+            hair_clump_path=region_context[0]["hair_clump_path"],
+            merge_path=merge_path,
             guide_deform_path=deform_path,
             rest_skin=rest.path(),
             animated_skin=animated.path() if animated is not None else None,
-            guides=guide_node.path() if guide_node is not None else None,
+            guides=region_context[0]["guides"] if len(region_context) == 1 else None,
+            region_count=len(region_context),
+            regions=region_context,
             deform_method=deform_method if animated is not None else None,
-            configured_parameters=configured,
+            configured_parameters=region_context[0]["configured_parameters"],
             output_point_count=output_counts[0],
             output_primitive_count=output_counts[1],
         )

--- a/src/dcc_mcp_houdini/skills/houdini-groom/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-groom/tools.yaml
@@ -28,6 +28,29 @@ tools:
         length: {type: number, exclusiveMinimum: 0, maximum: 10, default: 0.025, description: Fur length in scene units.}
         segments: {type: integer, minimum: 2, maximum: 64, default: 5, description: Segments per unguided hair.}
         clump_strength: {type: number, minimum: 0, maximum: 1, default: 0.15, description: Optional Hair Clump strength.}
+        region_profiles:
+          type: array
+          minItems: 1
+          maxItems: 16
+          description: >-
+            Optional anatomy regions. Each region creates an independent Hair
+            Generate and optional Hair Clump chain before a shared merge and
+            animated Guide Deform. Omitted values inherit top-level defaults.
+          items:
+            type: object
+            additionalProperties: false
+            required: [name, skin_group]
+            properties:
+              name:
+                type: string
+                pattern: "^[A-Za-z][A-Za-z0-9_]{0,31}$"
+                description: Stable region and node-name suffix such as head, thorax, or abdomen.
+              skin_group: {type: string, minLength: 1, description: Skin group for this fur region.}
+              guides: {type: string, minLength: 1, description: Optional region-specific guide curve SOP name.}
+              density: {type: number, minimum: 0.001, maximum: 10000000}
+              length: {type: number, exclusiveMinimum: 0, maximum: 10}
+              segments: {type: integer, minimum: 2, maximum: 64}
+              clump_strength: {type: number, minimum: 0, maximum: 1}
         deform_method:
           type: string
           enum: [surface, guide_shape, point]

--- a/tests/test_groom_skills.py
+++ b/tests/test_groom_skills.py
@@ -82,6 +82,107 @@ def test_build_short_fur_groom_with_animated_skin() -> None:
     assert result["context"]["output_primitive_count"] == 100
 
 
+def test_build_short_fur_groom_builds_anatomy_regions() -> None:
+    mod = _load_script()
+    geo = MagicMock()
+    geo.path.return_value = "/obj/bee"
+    geo.childTypeCategory.return_value.nodeTypes.return_value = {
+        "hairgen::2.0": MagicMock(),
+        "hairclump::2.0": MagicMock(),
+        "guidedeform::2.0": MagicMock(),
+    }
+    rest, animated, body_guides, abdomen_guides = (MagicMock() for _ in range(4))
+    rest.path.return_value = "/obj/bee/rest_skin"
+    animated.path.return_value = "/obj/bee/animated_skin"
+    body_guides.path.return_value = "/obj/bee/body_guides"
+    abdomen_guides.path.return_value = "/obj/bee/abdomen_guides"
+    for skin in (rest, animated):
+        skin.geometry.return_value.intrinsicValue.side_effect = lambda name: {
+            "pointcount": 100,
+            "primitivecount": 50,
+        }[name]
+
+    head_hair, abdomen_hair, abdomen_clump, merge, deform = (MagicMock() for _ in range(5))
+    head_hair.path.return_value = "/obj/bee/bee_fur_head_generate"
+    abdomen_hair.path.return_value = "/obj/bee/bee_fur_abdomen_generate"
+    abdomen_clump.path.return_value = "/obj/bee/bee_fur_abdomen_clump"
+    merge.path.return_value = "/obj/bee/bee_fur_merge"
+    deform.path.return_value = "/obj/bee/bee_fur_deform"
+    geo.createNode.side_effect = [head_hair, abdomen_hair, abdomen_clump, merge, deform]
+    for node in (head_hair, abdomen_hair, abdomen_clump, merge, deform):
+        node.parm.side_effect = lambda _name: MagicMock()
+    deform.errors.return_value = ()
+    deform.geometry.return_value.intrinsicValue.side_effect = lambda name: {
+        "pointcount": 900,
+        "primitivecount": 150,
+    }[name]
+
+    mock_hou = MagicMock()
+    mock_hou.node.side_effect = {
+        "/obj/bee": geo,
+        "/obj/bee/rest_skin": rest,
+        "/obj/bee/animated_skin": animated,
+        "/obj/bee/body_guides": body_guides,
+        "/obj/bee/abdomen_guides": abdomen_guides,
+    }.get
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.build_short_fur_groom(
+            "/obj/bee",
+            "rest_skin",
+            animated_skin="animated_skin",
+            guides="body_guides",
+            name_prefix="bee_fur",
+            region_profiles=[
+                {
+                    "name": "head",
+                    "skin_group": "head_fur",
+                    "density": 80000,
+                    "length": 0.018,
+                    "segments": 4,
+                    "clump_strength": 0.0,
+                },
+                {
+                    "name": "abdomen",
+                    "skin_group": "abdomen_fur",
+                    "guides": "abdomen_guides",
+                    "density": 150000,
+                    "length": 0.035,
+                    "segments": 6,
+                    "clump_strength": 0.25,
+                },
+            ],
+        )
+
+    assert result["success"] is True
+    head_hair.setInput.assert_any_call(0, rest, 0)
+    head_hair.setInput.assert_any_call(1, body_guides, 0)
+    abdomen_hair.setInput.assert_any_call(1, abdomen_guides, 0)
+    abdomen_clump.setFirstInput.assert_called_once_with(abdomen_hair)
+    merge.setInput.assert_any_call(0, head_hair, 0)
+    merge.setInput.assert_any_call(1, abdomen_clump, 0)
+    deform.setInput.assert_any_call(0, merge, 0)
+    assert result["context"]["region_count"] == 2
+    assert result["context"]["merge_path"] == "/obj/bee/bee_fur_merge"
+    assert [region["name"] for region in result["context"]["regions"]] == ["head", "abdomen"]
+
+
+def test_build_short_fur_groom_rejects_invalid_region_before_mutation() -> None:
+    mod = _load_script()
+    geo = MagicMock()
+    geo.path.return_value = "/obj/bee"
+    mock_hou = MagicMock()
+    mock_hou.node.side_effect = {"/obj/bee": geo, "/obj/bee/rest_skin": MagicMock()}.get
+    with patch.dict(sys.modules, {"hou": mock_hou}):
+        result = mod.build_short_fur_groom(
+            "/obj/bee",
+            "rest_skin",
+            region_profiles=[{"name": "../bad", "skin_group": "head_fur"}],
+        )
+
+    assert result["success"] is False
+    geo.createNode.assert_not_called()
+
+
 def test_build_short_fur_groom_rejects_surface_topology_mismatch() -> None:
     mod = _load_script()
     geo, rest, animated = MagicMock(), MagicMock(), MagicMock()


### PR DESCRIPTION
## Summary
- add bounded anatomy-region profiles to the Houdini short-fur Groom workflow
- support independent groups, guides, density, length, segments, and clumping before a shared deform
- preserve the legacy single-region result contract

## Validation
- 915 tests passed, 1 skipped, 3 deselected
- Ruff check and format check passed
- Houdini 22.0.368: two-region Hair Generate/Clump/Merge network cooked successfully with 3,067 primitives and 14,112 points