### PR TITLE
fix: reject empty viewport captures

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-render/SKILL.md
@@ -56,7 +56,7 @@ or Karma/Husk for batch rendering.
 1. `houdini_camera_light__create_camera(name="rendercam")`
 2. `set_render_settings(rop_path="/out/mantra1", camera="/obj/rendercam", resolution=[1280,720], output_path="/tmp/beauty.exr")`
 3. `get_render_settings("/out/mantra1")` → verify
-4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only)
+4. `capture_viewport(output_path="/tmp/preview.jpg")` for a quick look (UI only; decoded dimensions and pixel extrema are verified, and degenerate frames fail closed)
 5. `flipbook(output_path="/tmp/preview.$F4.jpg", frame_range=[1,24,4], camera_path="/obj/rendercam")` for a sparse camera preview (UI only)
 6. `render_rop("/out/mantra1", frame_range=[1,1])` → background `job_id` in interactive or headless Houdini
 

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/capture_viewport.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/capture_viewport.py
@@ -3,10 +3,99 @@
 from __future__ import annotations
 
 import os
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from _render_common import clamp_resolution, scene_viewer  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _rgb_statistics(data: bytes, width: int, height: int, bytes_per_line: int) -> Dict[str, Any]:
+    """Return exact RGB extrema for a packed RGB888 image buffer."""
+    row_bytes = width * 3
+    required_bytes = bytes_per_line * height
+    if width < 1 or height < 1 or bytes_per_line < row_bytes or len(data) < required_bytes:
+        raise ValueError("Invalid RGB888 image buffer")
+
+    rgb_min = [255, 255, 255]
+    rgb_max = [0, 0, 0]
+    for row_index in range(height):
+        offset = row_index * bytes_per_line
+        row = data[offset : offset + row_bytes]
+        for channel in range(3):
+            values = row[channel::3]
+            rgb_min[channel] = min(rgb_min[channel], min(values))
+            rgb_max[channel] = max(rgb_max[channel], max(values))
+
+    return {
+        "rgb_min": rgb_min,
+        "rgb_max": rgb_max,
+        "single_color": rgb_min == rgb_max,
+        "all_black": rgb_max == [0, 0, 0],
+    }
+
+
+def _inspect_capture(output_path: str) -> Dict[str, Any]:
+    """Decode *output_path* with Houdini's Qt runtime and inspect every pixel."""
+    try:
+        from PySide6.QtGui import QImage  # type: ignore[import-not-found]  # noqa: PLC0415
+    except ImportError:
+        try:
+            from PySide2.QtGui import QImage  # type: ignore[import-not-found]  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError("Houdini Qt image decoder is unavailable") from exc
+
+    image = QImage(output_path)
+    if image.isNull():
+        raise ValueError("Captured file is not a decodable image")
+    rgb888 = getattr(QImage, "Format_RGB888", None)
+    if rgb888 is None:
+        rgb888 = QImage.Format.Format_RGB888
+    image = image.convertToFormat(rgb888)
+    byte_count = image.sizeInBytes() if hasattr(image, "sizeInBytes") else image.byteCount()
+    pointer = image.constBits()
+    if hasattr(pointer, "setsize"):
+        pointer.setsize(byte_count)
+    data = bytes(pointer)
+    width = int(image.width())
+    height = int(image.height())
+    statistics = _rgb_statistics(data, width, height, int(image.bytesPerLine()))
+    return {"dimensions": [width, height], **statistics}
+
+
+def _node_path(node: Any) -> Optional[str]:
+    try:
+        path = node.path()
+    except Exception:  # noqa: BLE001
+        return None
+    return path if isinstance(path, str) else None
+
+
+def _viewer_context(viewer: Any, viewport: Any) -> Dict[str, Optional[str]]:
+    """Collect bounded, JSON-safe Scene Viewer diagnostics."""
+    try:
+        viewer_type = viewer.type().name()
+    except Exception:  # noqa: BLE001
+        viewer_type = None
+    if not isinstance(viewer_type, str):
+        viewer_type = None
+    try:
+        pwd = viewer.pwd()
+    except Exception:  # noqa: BLE001
+        pwd = None
+    try:
+        display_node = pwd.displayNode() if pwd is not None else None
+    except Exception:  # noqa: BLE001
+        display_node = None
+    try:
+        camera = viewport.camera()
+    except Exception:  # noqa: BLE001
+        camera = None
+    return {
+        "type": viewer_type,
+        "pwd": _node_path(pwd),
+        "camera": _node_path(camera),
+        "display_node": _node_path(display_node),
+    }
 
 
 def capture_viewport(
@@ -63,9 +152,81 @@ def capture_viewport(
                 settings.resolution(tuple(clamped))
             except Exception as res_exc:  # noqa: BLE001
                 warnings.append("Could not set resolution: {}".format(res_exc))
-        viewer.flipbook(viewer.curViewport(), settings)
+        viewport = viewer.curViewport()
+        viewer_context = _viewer_context(viewer, viewport)
+        viewer.flipbook(viewport, settings)
         written = [output_path] if os.path.isfile(output_path) else []
         skipped = [] if written else [output_path]
+        if not written:
+            return skill_error(
+                "Viewport capture did not write an image",
+                "CAPTURE_NOT_WRITTEN",
+                prompt="Confirm the output directory is writable and retry the viewport capture.",
+                code="CAPTURE_NOT_WRITTEN",
+                captured=False,
+                output_path=output_path,
+                frame=target_frame,
+                resolution=clamped,
+                written_files=written,
+                skipped=skipped,
+                warnings=warnings,
+                viewer=viewer_context,
+            )
+        try:
+            validation = _inspect_capture(output_path)
+        except Exception as validation_exc:  # noqa: BLE001
+            return skill_error(
+                "Viewport capture could not be verified",
+                "CAPTURE_VALIDATION_FAILED",
+                prompt="Use a Qt-decodable image format such as PNG or JPEG, then retry the capture.",
+                code="CAPTURE_VALIDATION_FAILED",
+                captured=False,
+                output_path=output_path,
+                frame=target_frame,
+                resolution=clamped,
+                written_files=written,
+                skipped=skipped,
+                warnings=warnings,
+                viewer=viewer_context,
+                validation_error="{}: {}".format(type(validation_exc).__name__, validation_exc),
+            )
+        if clamped is not None and validation["dimensions"] != clamped:
+            return skill_error(
+                "Viewport capture has unexpected dimensions",
+                "CAPTURE_DIMENSION_MISMATCH",
+                prompt="Redraw the Scene Viewer and retry with the requested resolution.",
+                code="CAPTURE_DIMENSION_MISMATCH",
+                captured=False,
+                output_path=output_path,
+                frame=target_frame,
+                resolution=clamped,
+                expected_dimensions=clamped,
+                written_files=written,
+                skipped=skipped,
+                warnings=warnings,
+                viewer=viewer_context,
+                validation=validation,
+            )
+        if validation["single_color"]:
+            return skill_error(
+                "Viewport capture contains no usable visual information",
+                "EMPTY_VIEWPORT_CAPTURE",
+                prompt="Redraw and frame the active Scene Viewer, confirm its display node and camera, then retry.",
+                possible_solutions=[
+                    "Set the Scene Viewer pwd to the geometry network and frame the displayed geometry.",
+                    "Confirm the intended display node and camera are active before capturing.",
+                ],
+                code="EMPTY_VIEWPORT_CAPTURE",
+                captured=False,
+                output_path=output_path,
+                frame=target_frame,
+                resolution=clamped,
+                written_files=written,
+                skipped=skipped,
+                warnings=warnings,
+                viewer=viewer_context,
+                validation=validation,
+            )
         return skill_success(
             "Captured viewport",
             captured=bool(written),
@@ -75,6 +236,8 @@ def capture_viewport(
             written_files=written,
             skipped=skipped,
             warnings=warnings,
+            viewer=viewer_context,
+            validation=validation,
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to capture viewport")

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -2,7 +2,9 @@ tools:
   - name: capture_viewport
     description: >-
       Capture the current Scene Viewer to an image file for a single frame via
-      flipbook, with clamped resolution. UI-aware (headless returns a warning).
+      flipbook, with clamped resolution. Decodes the written image and rejects
+      wrong-size, all-black, or single-color captures. UI-aware (headless
+      returns a warning).
     source_file: scripts/capture_viewport.py
     execution: async
     affinity: main

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -629,7 +629,14 @@ class TestViewportCapture:
         mock_hou.frame.return_value = 1.0
         mock_hou.ui.paneTabOfType.return_value = viewer
 
-        with patch.dict(sys.modules, {"hou": mock_hou}):
+        inspection = {
+            "dimensions": [4096, 720],
+            "rgb_min": [0, 0, 0],
+            "rgb_max": [255, 255, 255],
+            "single_color": False,
+            "all_black": False,
+        }
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod, "_inspect_capture", return_value=inspection):
             result = mod.capture_viewport(str(out), resolution=[99999, 720])
 
         assert result["success"] is True
@@ -637,6 +644,105 @@ class TestViewportCapture:
         assert result["context"]["written_files"] == [str(out)]
         # resolution clamped to MAX_DIMENSION
         assert result["context"]["resolution"] == [4096, 720]
+        assert result["context"]["validation"] == inspection
+
+    @pytest.mark.parametrize(
+        ("inspection", "reason"),
+        [
+            (
+                {
+                    "dimensions": [1280, 960],
+                    "rgb_min": [0, 0, 0],
+                    "rgb_max": [0, 0, 0],
+                    "single_color": True,
+                    "all_black": True,
+                },
+                "all_black",
+            ),
+            (
+                {
+                    "dimensions": [1280, 960],
+                    "rgb_min": [24, 48, 72],
+                    "rgb_max": [24, 48, 72],
+                    "single_color": True,
+                    "all_black": False,
+                },
+                "single_color",
+            ),
+        ],
+    )
+    def test_capture_viewport_rejects_degenerate_frame(self, tmp_path: Path, inspection: dict, reason: str) -> None:
+        mod = _load_script("houdini-render", "capture_viewport.py")
+        out = tmp_path / "frame.png"
+        viewer = MagicMock()
+        viewer.flipbookSettings.return_value.stash.return_value = MagicMock()
+        viewer.flipbook.side_effect = lambda vp, settings: out.write_bytes(b"image")
+        viewer.pwd.return_value = _node("/obj/geo1", "geo1")
+        viewer.curViewport.return_value.camera.return_value = _node("/obj/cam1", "cam1", "cam")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.frame.return_value = 12.0
+        mock_hou.ui.paneTabOfType.return_value = viewer
+
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod, "_inspect_capture", return_value=inspection):
+            result = mod.capture_viewport(str(out), resolution=[1280, 960])
+
+        assert result["success"] is False
+        assert result["error"] == "EMPTY_VIEWPORT_CAPTURE"
+        assert result["context"]["code"] == "EMPTY_VIEWPORT_CAPTURE"
+        assert result["context"]["captured"] is False
+        assert result["context"]["written_files"] == [str(out)]
+        assert result["context"]["validation"][reason] is True
+        assert result["context"]["viewer"]["pwd"] == "/obj/geo1"
+        assert result["context"]["viewer"]["camera"] == "/obj/cam1"
+        assert result["context"]["frame"] == 12.0
+
+    def test_capture_viewport_rejects_wrong_decoded_dimensions(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-render", "capture_viewport.py")
+        out = tmp_path / "frame.png"
+        viewer = MagicMock()
+        viewer.flipbookSettings.return_value.stash.return_value = MagicMock()
+        viewer.flipbook.side_effect = lambda vp, settings: out.write_bytes(b"image")
+        mock_hou = MagicMock()
+        mock_hou.isUIAvailable.return_value = True
+        mock_hou.frame.return_value = 1.0
+        mock_hou.ui.paneTabOfType.return_value = viewer
+        inspection = {
+            "dimensions": [640, 480],
+            "rgb_min": [0, 0, 0],
+            "rgb_max": [255, 255, 255],
+            "single_color": False,
+            "all_black": False,
+        }
+
+        with patch.dict(sys.modules, {"hou": mock_hou}), patch.object(mod, "_inspect_capture", return_value=inspection):
+            result = mod.capture_viewport(str(out), resolution=[1280, 960])
+
+        assert result["success"] is False
+        assert result["error"] == "CAPTURE_DIMENSION_MISMATCH"
+        assert result["context"]["expected_dimensions"] == [1280, 960]
+        assert result["context"]["validation"] == inspection
+
+    def test_capture_rgb_statistics_detect_degenerate_and_varied_frames(self) -> None:
+        mod = _load_script("houdini-render", "capture_viewport.py")
+
+        black = mod._rgb_statistics(bytes([0, 0, 0, 0, 0, 0]), width=2, height=1, bytes_per_line=6)
+        solid = mod._rgb_statistics(bytes([8, 16, 24, 8, 16, 24]), width=2, height=1, bytes_per_line=6)
+        varied = mod._rgb_statistics(bytes([0, 0, 0, 255, 128, 64]), width=2, height=1, bytes_per_line=6)
+
+        assert black == {"rgb_min": [0, 0, 0], "rgb_max": [0, 0, 0], "single_color": True, "all_black": True}
+        assert solid == {
+            "rgb_min": [8, 16, 24],
+            "rgb_max": [8, 16, 24],
+            "single_color": True,
+            "all_black": False,
+        }
+        assert varied == {
+            "rgb_min": [0, 0, 0],
+            "rgb_max": [255, 128, 64],
+            "single_color": False,
+            "all_black": False,
+        }
 
     def test_flipbook_launch_returns_job_id(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "flipbook.py")


### PR DESCRIPTION
## Summary
- decode viewport captures and verify their actual dimensions
- reject all-black and other single-color frames with stable recovery context
- preserve written-file evidence and bounded Scene Viewer diagnostics on failure

## Validation
- `python -m pytest -q` — 973 passed, 1 skipped
- packaging tests, Ruff, format, Python 3.7 syntax, and skill lint passed
- wheel/sdist and Twine checks passed
- win64, Linux, and macOS quickinstall assemble/verify passed

No live Houdini GUI was available, so interactive viewport capture remains unverified.

Fixes #236