### PR TITLE
fix: route Solaris LOP renders explicitly

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -42,7 +42,9 @@ hython worker so Karma cannot occupy Houdini's UI thread.
 3. `set_husk_options(node_path="/stage/karmarenderproduct1", options={"threads": 8, "verbose": true})`
 4. `create_checkpoint(usd_file="/tmp/scene_snapshot.usd", checkpoint_path="/tmp/checkpoint_001.usd")`
 5. `render_with_husk(usd_file="/tmp/scene_snapshot.usd", output_path="/tmp/render/beauty.$F4.exr", renderer="karma", resolution=[1920, 1080], frame_range=[1, 120])` → `job_id`
-6. `get_husk_job(job_id="...")` until `state` is terminal → `written_files`, `elapsed_secs`
+6. `get_husk_job(job_id="...")` until `state` is terminal → inspect
+   `render_outcome`, `render_errors`, `warnings`, `written_files`, and
+   `output_verification`; verified partial files do not override procedural errors.
 
 `use_hython_fallback=true` is rejected because in-process rendering can freeze
 the Houdini event loop. Export a USD snapshot and use the isolated native Husk

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -38,7 +38,7 @@ hython worker so Karma cannot occupy Houdini's UI thread.
 ## Tracer-bullet flow
 
 1. `set_husk_options(list_options=true, category="render")` → browse available options
-2. `create_snapshot(source_path="/stage", snapshot_path="/tmp/scene_snapshot.usd", flatten=true)`
+2. `create_snapshot(source_path="/stage", snapshot_path="/tmp/scene_snapshot.usd", flatten=true)` (a LOP or `lopnet` under `/obj` is also accepted)
 3. `set_husk_options(node_path="/stage/karmarenderproduct1", options={"threads": 8, "verbose": true})`
 4. `create_checkpoint(usd_file="/tmp/scene_snapshot.usd", checkpoint_path="/tmp/checkpoint_001.usd")`
 5. `render_with_husk(usd_file="/tmp/scene_snapshot.usd", output_path="/tmp/render/beauty.$F4.exr", renderer="karma", resolution=[1920, 1080], frame_range=[1, 120])` → `job_id`

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_jobs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_jobs.py
@@ -35,6 +35,9 @@ def launch_husk_job(
             "expected_outputs": list(expected_outputs),
             "output_glob": output_glob,
             "timeout_secs": int(timeout_secs),
+            "render_outcome": "pending",
+            "render_errors": [],
+            "warnings": [],
         }
     )
     worker_path = Path(__file__).resolve().parent / "_husk_worker.py"

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -12,6 +13,17 @@ import traceback
 from pathlib import Path
 
 from dcc_mcp_houdini._status_io import read_status, write_status
+
+_STDERR_SCAN_BYTES = 64 * 1024
+_MAX_DIAGNOSTICS = 32
+_MAX_DIAGNOSTIC_CHARS = 1000
+_PROCEDURAL_FAILURE = re.compile(
+    r"(?:\bprocedural\b.*\b(?:error|failed|failure|unable)\b|"
+    r"\b(?:error|failed|failure|unable)\b.*\bprocedural\b)",
+    re.IGNORECASE,
+)
+_RENDERER_ERROR = re.compile(r"(?:^|\s)Error:\s*", re.IGNORECASE)
+_RENDERER_WARNING = re.compile(r"(?:^|\s)Warning:\s*", re.IGNORECASE)
 
 
 def _written_files(status: dict) -> list:
@@ -21,10 +33,53 @@ def _written_files(status: dict) -> list:
     return written
 
 
+def _bounded_stderr(path_value) -> str:
+    if not path_value:
+        return ""
+    try:
+        with Path(str(path_value)).open("rb") as stream:
+            stream.seek(0, os.SEEK_END)
+            stream.seek(max(0, stream.tell() - _STDERR_SCAN_BYTES))
+            payload = stream.read(_STDERR_SCAN_BYTES)
+    except OSError:
+        return ""
+    return payload.decode("utf-8", errors="replace")
+
+
+def _render_diagnostics(stderr: str):
+    render_errors = []
+    warnings = []
+    for raw_line in stderr.splitlines():
+        message = " ".join(raw_line.split())[:_MAX_DIAGNOSTIC_CHARS]
+        if not message:
+            continue
+        if "hou.OperationFailed" in message:
+            target = render_errors
+            code = "HOUDINI_OPERATION_FAILED"
+        elif _PROCEDURAL_FAILURE.search(message):
+            target = render_errors
+            code = "PROCEDURAL_INVOCATION_FAILED"
+        elif _RENDERER_ERROR.search(message):
+            target = render_errors
+            code = "RENDERER_ERROR"
+        elif _RENDERER_WARNING.search(message):
+            target = warnings
+            code = "RENDERER_WARNING"
+        else:
+            continue
+        diagnostic = {"code": code, "message": message}
+        if diagnostic not in target and len(target) < _MAX_DIAGNOSTICS:
+            target.append(diagnostic)
+    return render_errors, warnings
+
+
 def main() -> None:
     status_path = Path(sys.argv[1])
     command = json.loads(sys.argv[2])
     status = read_status(status_path)
+    status.setdefault("render_outcome", "pending")
+    status.setdefault("render_errors", [])
+    status.setdefault("warnings", [])
     started = time.time()
     status.update({"state": "running", "started_at": started, "worker_pid": os.getpid()})
     write_status(status_path, status)
@@ -36,10 +91,26 @@ def main() -> None:
             check=False,
         )
         written_files = _written_files(status)
+        render_errors, warnings = _render_diagnostics(_bounded_stderr(status.get("stderr_path")))
+        if process.returncode != 0:
+            state = "failed"
+            render_outcome = "failed"
+        elif render_errors:
+            state = "failed"
+            render_outcome = "completed_with_render_errors"
+        elif warnings:
+            state = "completed"
+            render_outcome = "completed_with_warnings"
+        else:
+            state = "completed"
+            render_outcome = "completed_clean"
         status.update(
             {
-                "state": "completed" if process.returncode == 0 else "failed",
+                "state": state,
+                "render_outcome": render_outcome,
                 "returncode": process.returncode,
+                "render_errors": render_errors,
+                "warnings": warnings,
                 "written_files": written_files,
                 "output_verification": {
                     "state": "verified" if written_files else "not_observed",
@@ -50,10 +121,13 @@ def main() -> None:
         )
         if process.returncode != 0:
             status["error"] = "husk exited with code {}".format(process.returncode)
+        elif render_errors:
+            status["error"] = "Husk reported procedural or renderer errors"
     except subprocess.TimeoutExpired:
         status.update(
             {
                 "state": "failed",
+                "render_outcome": "failed",
                 "error": "Husk render exceeded the configured timeout",
                 "written_files": _written_files(status),
             }
@@ -62,6 +136,7 @@ def main() -> None:
         status.update(
             {
                 "state": "failed",
+                "render_outcome": "failed",
                 "error": str(exc),
                 "traceback": traceback.format_exc(),
                 "written_files": _written_files(status),

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/create_snapshot.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/create_snapshot.py
@@ -9,6 +9,32 @@ from _husk_common import get_node, set_parm_if_exists  # noqa: E402
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
 
 
+def _node_type_name(node) -> Optional[str]:
+    try:
+        name = node.type().name().split("::", 1)[0]
+    except Exception:  # noqa: BLE001
+        return None
+    return name if isinstance(name, str) else None
+
+
+def _is_lop_node(node) -> bool:
+    try:
+        category_name = node.type().category().name()
+    except Exception:  # noqa: BLE001
+        return False
+    return category_name == "Lop"
+
+
+def _resolve_lop_source(node):
+    path = node.path()
+    if path == "/stage" or _node_type_name(node) == "lopnet":
+        display_node = node.displayNode()
+        return display_node
+    if path.startswith("/stage/") or _is_lop_node(node):
+        return node
+    return None
+
+
 def create_snapshot(
     source_path: str = "/stage",
     snapshot_path: str = "/tmp/husk_snapshot.usd",
@@ -23,79 +49,83 @@ def create_snapshot(
 
     try:
         node = get_node(hou, source_path)
-        if source_path.startswith("/stage"):
-            source = node.displayNode() if node.path() == "/stage" else node
-            if source is None:
+        source = _resolve_lop_source(node)
+        if source is None:
+            if node.path() == "/stage" or _node_type_name(node) == "lopnet":
                 return skill_error(
-                    "Snapshot creation failed", "Solaris network has no displayed LOP", source=source_path
+                    "Snapshot creation failed",
+                    "EMPTY_LOP_NETWORK",
+                    code="EMPTY_LOP_NETWORK",
+                    source=source_path,
                 )
-
-            output_frame = float(frame) if frame is not None else float(hou.frame())
-            expand_at_frame = getattr(getattr(hou, "text", None), "expandStringAtFrame", None)
-            if not callable(expand_at_frame):
-                expand_at_frame = getattr(hou, "expandStringAtFrame", None)
-            expanded_snapshot_path = (
-                expand_at_frame(snapshot_path, output_frame)
-                if callable(expand_at_frame)
-                else hou.expandString(snapshot_path)
+            return skill_error(
+                "Snapshot source is not a Solaris LOP",
+                "UNSUPPORTED_SNAPSHOT_SOURCE",
+                prompt="Export this source with the typed interchange tool before Husk rendering.",
+                code="UNSUPPORTED_SNAPSHOT_SOURCE",
+                source=node.path(),
+                suggested_snapshot=snapshot_path,
+                dcc={"next_tools": ["houdini_interchange__export_usd"]},
             )
-            output_dir = os.path.dirname(os.path.abspath(expanded_snapshot_path))
-            os.makedirs(output_dir, exist_ok=True)
-            previous = os.stat(expanded_snapshot_path) if os.path.isfile(expanded_snapshot_path) else None
-            usd_rop = None
-            try:
-                usd_rop = source.parent().createNode("usd_rop", node_name="snapshot_export")
-                usd_rop.setInput(0, source)
-                required = {
-                    "lopoutput": snapshot_path,
-                    "savestyle": "flattenstage" if flatten else "flattenimplicitlayers",
-                    "trange": 1 if frame is not None else 0,
-                }
-                if frame is not None:
-                    required.update({"f1": float(frame), "f2": float(frame), "f3": 1.0})
-                missing = [name for name, value in required.items() if not set_parm_if_exists(usd_rop, name, value)]
-                execute = usd_rop.parm("execute")
-                if missing or execute is None:
-                    raise RuntimeError("USD ROP is missing parameters: {}".format(", ".join(missing or ["execute"])))
-                execute.pressButton()
 
-                current = os.stat(expanded_snapshot_path) if os.path.isfile(expanded_snapshot_path) else None
-                written = (
-                    current is not None
-                    and current.st_size > 0
-                    and (
-                        previous is None
-                        or (current.st_mtime_ns, current.st_size) != (previous.st_mtime_ns, previous.st_size)
-                    )
+        output_frame = float(frame) if frame is not None else float(hou.frame())
+        expand_at_frame = getattr(getattr(hou, "text", None), "expandStringAtFrame", None)
+        if not callable(expand_at_frame):
+            expand_at_frame = getattr(hou, "expandStringAtFrame", None)
+        expanded_snapshot_path = (
+            expand_at_frame(snapshot_path, output_frame)
+            if callable(expand_at_frame)
+            else hou.expandString(snapshot_path)
+        )
+        output_dir = os.path.dirname(os.path.abspath(expanded_snapshot_path))
+        os.makedirs(output_dir, exist_ok=True)
+        previous = os.stat(expanded_snapshot_path) if os.path.isfile(expanded_snapshot_path) else None
+        usd_rop = None
+        try:
+            usd_rop = source.parent().createNode("usd_rop", node_name="snapshot_export")
+            usd_rop.setInput(0, source)
+            required = {
+                "lopoutput": snapshot_path,
+                "savestyle": "flattenstage" if flatten else "flattenimplicitlayers",
+                "trange": 1 if frame is not None else 0,
+            }
+            if frame is not None:
+                required.update({"f1": float(frame), "f2": float(frame), "f3": 1.0})
+            missing = [name for name, value in required.items() if not set_parm_if_exists(usd_rop, name, value)]
+            execute = usd_rop.parm("execute")
+            if missing or execute is None:
+                raise RuntimeError("USD ROP is missing parameters: {}".format(", ".join(missing or ["execute"])))
+            execute.pressButton()
+
+            current = os.stat(expanded_snapshot_path) if os.path.isfile(expanded_snapshot_path) else None
+            written = (
+                current is not None
+                and current.st_size > 0
+                and (
+                    previous is None
+                    or (current.st_mtime_ns, current.st_size) != (previous.st_mtime_ns, previous.st_size)
                 )
-                if not written:
-                    return skill_error(
-                        "Snapshot creation failed",
-                        "USD ROP did not write a non-empty snapshot",
-                        source=source.path(),
-                        snapshot_path=snapshot_path,
-                        expanded_snapshot_path=expanded_snapshot_path,
-                    )
-                return skill_success(
-                    "Created USD snapshot",
+            )
+            if not written:
+                return skill_error(
+                    "Snapshot creation failed",
+                    "USD ROP did not write a non-empty snapshot",
                     source=source.path(),
                     snapshot_path=snapshot_path,
                     expanded_snapshot_path=expanded_snapshot_path,
-                    written=True,
-                    frame=frame,
-                    flatten=flatten,
                 )
-            finally:
-                if usd_rop is not None:
-                    usd_rop.destroy()
-        else:
-            # Non-Solaris: export as .usd via ROP
             return skill_success(
-                "Snapshot hint",
-                source=node.path(),
-                hint="Non-Solaris source — use houdini-interchange export_usd to create a USD snapshot",
-                suggested_snapshot=snapshot_path,
+                "Created USD snapshot",
+                source=source.path(),
+                snapshot_path=snapshot_path,
+                expanded_snapshot_path=expanded_snapshot_path,
+                written=True,
+                frame=frame,
+                flatten=flatten,
             )
+        finally:
+            if usd_rop is not None:
+                usd_rop.destroy()
     except Exception as exc:
         return skill_exception(exc, message="Failed to create snapshot")
 

--- a/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
@@ -51,7 +51,9 @@ tools:
   - name: get_husk_job
     description: >-
       Poll a durable isolated Husk render. Returns state, elapsed time,
-      verified output files, bounded stdout/stderr tails, and worker ownership.
+      verified output files, bounded stdout/stderr tails, typed renderer
+      warnings/errors, render outcome, and worker ownership. A verified output
+      may still have a failed state when Husk reports procedural errors.
     source_file: scripts/get_husk_job.py
     execution: sync
     affinity: any

--- a/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
@@ -119,8 +119,9 @@ tools:
           type: integer
   - name: create_snapshot
     description: >-
-      Export the current Solaris stage (/stage) or LOP network as a USD snapshot
-      for husk command-line rendering. Uses Houdini's USD ROP internally.
+      Export the current Solaris stage (/stage), an external LOP network, or a
+      LOP node as a USD snapshot for husk command-line rendering. Uses Houdini's
+      USD ROP internally and returns typed redirects for non-LOP sources.
     source_file: scripts/create_snapshot.py
     execution: sync
     affinity: main

--- a/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-render/scripts/render_rop.py
@@ -34,6 +34,14 @@ def _expand_outputs(pattern: Optional[str]) -> list:
     return [pattern] if os.path.isfile(pattern) else []
 
 
+def _node_category_name(node) -> Optional[str]:
+    try:
+        name = node.type().category().name()
+    except Exception:  # noqa: BLE001
+        return None
+    return name if isinstance(name, str) else None
+
+
 def render_rop(
     rop_path: str,
     frame_range: Optional[List[float]] = None,
@@ -50,6 +58,25 @@ def render_rop(
         rop = get_node(hou, rop_path)
         rop_type = rop.type().name().split("::", 1)[0]
         is_solaris = rop_type == "usdrender_rop"
+        if _node_category_name(rop) == "Lop" and not is_solaris:
+            return skill_error(
+                "Solaris LOP requires USD and Husk rendering",
+                "UNSUPPORTED_LOP_RENDER",
+                prompt="Export the LOP stage to USD, then render that USD with Husk.",
+                possible_solutions=[
+                    "Call houdini_interchange__export_usd with this LOP node path.",
+                    "Pass the written USD file to houdini_husk__render_with_husk.",
+                ],
+                code="UNSUPPORTED_LOP_RENDER",
+                rop=node_summary(rop),
+                frame_range=frame_range,
+                dcc={
+                    "next_tools": [
+                        "houdini_interchange__export_usd",
+                        "houdini_husk__render_with_husk",
+                    ]
+                },
+            )
         if rop_type == "opengl" and not bool(hou.isUIAvailable()):
             return skill_error(
                 "OpenGL ROP requires interactive Houdini",

--- a/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-render/tools.yaml
@@ -213,6 +213,8 @@ tools:
       calls stay responsive. Plain calls return that render job_id directly;
       explicit MCP async metadata still returns a core job that must be resolved
       first. Pass background=false only for intentional foreground execution.
+      Solaris LOP nodes return a typed redirect to USD export and Husk instead
+      of being misclassified as ROPs.
     source_file: scripts/render_rop.py
     execution: sync
     affinity: main

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -148,6 +148,37 @@ def test_husk_worker_records_nonzero_exit_without_touching_host(tmp_path: Path) 
     assert status["error"] == "husk exited with code 7"
 
 
+def test_husk_worker_replaces_pending_outcome_when_render_times_out(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    write_status(
+        status_path,
+        {
+            "job_id": "timeout",
+            "job_kind": "husk_render",
+            "expected_outputs": [],
+            "output_glob": "",
+            "timeout_secs": 1,
+            "render_outcome": "pending",
+            "render_errors": [],
+            "warnings": [],
+        },
+    )
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=worker.subprocess.TimeoutExpired(["husk", "scene.usda"], timeout=1),
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "failed"
+    assert status["render_outcome"] == "failed"
+    assert status["render_errors"] == []
+    assert status["warnings"] == []
+
+
 def test_husk_worker_verifies_written_output(tmp_path: Path) -> None:
     worker = _load_script("_husk_worker.py")
     status_path = tmp_path / "status.json"
@@ -176,7 +207,97 @@ def test_husk_worker_verifies_written_output(tmp_path: Path) -> None:
 
     status = read_status(status_path)
     assert status["state"] == "completed"
+    assert status["render_outcome"] == "completed_clean"
+    assert status["render_errors"] == []
+    assert status["warnings"] == []
     assert status["written_files"] == [str(output)]
+    assert status["output_verification"]["state"] == "verified"
+
+
+def test_husk_worker_rejects_verified_output_with_procedural_render_errors(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    stderr_path = tmp_path / "stderr.log"
+    output = tmp_path / "beauty.0001.exr"
+    write_status(
+        status_path,
+        {
+            "job_id": "render-errors",
+            "job_kind": "husk_render",
+            "expected_outputs": [str(output)],
+            "output_glob": str(tmp_path / "beauty.*.exr"),
+            "stderr_path": str(stderr_path),
+            "timeout_secs": 30,
+        },
+    )
+
+    def render(*_args, **_kwargs):
+        output.write_bytes(b"degraded render")
+        stderr_path.write_text(
+            "hou.OperationFailed: Invalid node setup\n"
+            "Error: Missing point attribute pscale\n"
+            "Houdini procedural invocation failed for /World/Hair\n",
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=render,
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "failed"
+    assert status["render_outcome"] == "completed_with_render_errors"
+    assert status["render_errors"] == [
+        {"code": "HOUDINI_OPERATION_FAILED", "message": "hou.OperationFailed: Invalid node setup"},
+        {"code": "RENDERER_ERROR", "message": "Error: Missing point attribute pscale"},
+        {
+            "code": "PROCEDURAL_INVOCATION_FAILED",
+            "message": "Houdini procedural invocation failed for /World/Hair",
+        },
+    ]
+    assert status["warnings"] == []
+    assert status["written_files"] == [str(output)]
+    assert status["output_verification"]["state"] == "verified"
+
+
+def test_husk_worker_reports_renderer_warning_without_failing_written_output(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    stderr_path = tmp_path / "stderr.log"
+    output = tmp_path / "beauty.0001.exr"
+    write_status(
+        status_path,
+        {
+            "job_id": "render-warning",
+            "job_kind": "husk_render",
+            "expected_outputs": [str(output)],
+            "output_glob": str(output),
+            "stderr_path": str(stderr_path),
+            "timeout_secs": 30,
+        },
+    )
+
+    def render(*_args, **_kwargs):
+        output.write_bytes(b"render")
+        stderr_path.write_text("Warning: Falling back to one render device\n", encoding="utf-8")
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=render,
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "completed"
+    assert status["render_outcome"] == "completed_with_warnings"
+    assert status["render_errors"] == []
+    assert status["warnings"] == [{"code": "RENDERER_WARNING", "message": "Warning: Falling back to one render device"}]
     assert status["output_verification"]["state"] == "verified"
 
 
@@ -209,6 +330,9 @@ def test_husk_job_launch_is_nonblocking_and_pollable(tmp_path: Path) -> None:
 
     assert launch_elapsed < 1.0
     assert launched["state"] == "queued"
+    assert launched["render_outcome"] == "pending"
+    assert launched["render_errors"] == []
+    assert launched["warnings"] == []
     deadline = time.monotonic() + 10.0
     status = jobs.read_husk_job(launched["job_id"])
     while status["state"] not in {"completed", "failed", "cancelled", "interrupted"}:

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -341,3 +341,71 @@ def test_create_snapshot_fails_when_usd_rop_writes_nothing(tmp_path: Path) -> No
     assert result["success"] is False
     assert parent.rop.input is source
     assert parent.rop.destroyed is True
+
+
+def test_create_snapshot_accepts_lop_karma_outside_stage(tmp_path: Path) -> None:
+    snapshot = _load_script("create_snapshot.py")
+    output = tmp_path / "karma.usda"
+    parent = _SnapshotParent(write_output=True, expanded_output=output)
+    source = _SnapshotSource(parent)
+    source.path = lambda: "/obj/HAIR_V2_SOLARIS/KARMA_RENDER"
+    source.type = lambda: SimpleNamespace(
+        name=lambda: "karma",
+        category=lambda: SimpleNamespace(name=lambda: "Lop"),
+    )
+    hou = SimpleNamespace(
+        node=lambda _path: source,
+        frame=lambda: 2.0,
+        text=SimpleNamespace(expandStringAtFrame=lambda path, _frame: path),
+    )
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = snapshot.create_snapshot(source_path=source.path(), snapshot_path=str(output), frame=2)
+
+    assert result["success"] is True
+    assert parent.created_type == ("usd_rop", "snapshot_export")
+    assert parent.rop.input is source
+    assert result["context"]["source"] == source.path()
+    assert result["context"]["written"] is True
+
+
+def test_create_snapshot_resolves_displayed_lop_from_obj_lopnet(tmp_path: Path) -> None:
+    snapshot = _load_script("create_snapshot.py")
+    output = tmp_path / "lopnet.usda"
+    parent = _SnapshotParent(write_output=True, expanded_output=output)
+    source = _SnapshotSource(parent)
+    network = _SnapshotNetwork(source)
+    network.path = lambda: "/obj/HAIR_V2_SOLARIS"
+    network.type = lambda: SimpleNamespace(name=lambda: "lopnet")
+    hou = SimpleNamespace(
+        node=lambda _path: network,
+        frame=lambda: 1.0,
+        text=SimpleNamespace(expandStringAtFrame=lambda path, _frame: path),
+    )
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = snapshot.create_snapshot(source_path=network.path(), snapshot_path=str(output))
+
+    assert result["success"] is True
+    assert parent.rop.input is source
+    assert result["context"]["source"] == source.path()
+
+
+def test_create_snapshot_rejects_non_lop_with_typed_redirect(tmp_path: Path) -> None:
+    snapshot = _load_script("create_snapshot.py")
+    source = SimpleNamespace(
+        path=lambda: "/obj/geo1",
+        type=lambda: SimpleNamespace(
+            name=lambda: "geo",
+            category=lambda: SimpleNamespace(name=lambda: "Object"),
+        ),
+    )
+    hou = SimpleNamespace(node=lambda _path: source)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = snapshot.create_snapshot(source_path=source.path(), snapshot_path=str(tmp_path / "scene.usd"))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_SNAPSHOT_SOURCE"
+    assert result["context"]["code"] == "UNSUPPORTED_SNAPSHOT_SOURCE"
+    assert result["context"]["dcc"]["next_tools"] == ["houdini_interchange__export_usd"]

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -2658,6 +2658,26 @@ class TestRenderExecution:
         assert result["success"] is False
         rop.render.assert_not_called()
 
+    def test_render_rop_redirects_lop_karma_outside_stage(self) -> None:
+        mod = _load_script("houdini-render", "render_rop.py")
+        karma = _node("/obj/HAIR_V2_SOLARIS/KARMA_RENDER", "KARMA_RENDER", "karma")
+        karma.type.return_value.category.return_value.name.return_value = "Lop"
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = karma
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.render_rop(karma.path(), frame_range=[2, 2, 1], background=True)
+
+        assert result["success"] is False
+        assert result["error"] == "UNSUPPORTED_LOP_RENDER"
+        assert result["context"]["code"] == "UNSUPPORTED_LOP_RENDER"
+        assert result["context"]["rop"]["path"] == karma.path()
+        assert result["context"]["dcc"]["next_tools"] == [
+            "houdini_interchange__export_usd",
+            "houdini_husk__render_with_husk",
+        ]
+        karma.render.assert_not_called()
+
     def test_expand_outputs_accepts_single_value_parm_tuple(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-render", "render_rop.py")
         out = tmp_path / "beauty.0001.exr"


### PR DESCRIPTION
## Summary
- identify Solaris LOP nodes by Houdini node category instead of path
- return a stable USD-export and Husk-render redirect from the generic ROP helper
- snapshot direct LOP nodes and external `lopnet` display nodes, while failing closed for non-LOP sources

## Validation
- `python -m pytest -q` — 973 passed, 1 skipped
- packaging tests, Ruff, format, Python 3.7 syntax, and skill lint passed
- wheel/sdist and Twine checks passed
- win64, Linux, and macOS quickinstall assemble/verify passed

No live Houdini 22 session was available, so the external `lopnet` route is contract-tested with HOM fakes rather than a live Karma render.

Fixes #237