### PR TITLE
fix: surface Husk procedural render errors

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -42,7 +42,9 @@ hython worker so Karma cannot occupy Houdini's UI thread.
 3. `set_husk_options(node_path="/stage/karmarenderproduct1", options={"threads": 8, "verbose": true})`
 4. `create_checkpoint(usd_file="/tmp/scene_snapshot.usd", checkpoint_path="/tmp/checkpoint_001.usd")`
 5. `render_with_husk(usd_file="/tmp/scene_snapshot.usd", output_path="/tmp/render/beauty.$F4.exr", renderer="karma", resolution=[1920, 1080], frame_range=[1, 120])` → `job_id`
-6. `get_husk_job(job_id="...")` until `state` is terminal → `written_files`, `elapsed_secs`
+6. `get_husk_job(job_id="...")` until `state` is terminal → inspect
+   `render_outcome`, `render_errors`, `warnings`, `written_files`, and
+   `output_verification`; verified partial files do not override procedural errors.
 
 `use_hython_fallback=true` is rejected because in-process rendering can freeze
 the Houdini event loop. Export a USD snapshot and use the isolated native Husk

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_jobs.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_jobs.py
@@ -35,6 +35,9 @@ def launch_husk_job(
             "expected_outputs": list(expected_outputs),
             "output_glob": output_glob,
             "timeout_secs": int(timeout_secs),
+            "render_outcome": "pending",
+            "render_errors": [],
+            "warnings": [],
         }
     )
     worker_path = Path(__file__).resolve().parent / "_husk_worker.py"

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -12,6 +13,17 @@ import traceback
 from pathlib import Path
 
 from dcc_mcp_houdini._status_io import read_status, write_status
+
+_STDERR_SCAN_BYTES = 64 * 1024
+_MAX_DIAGNOSTICS = 32
+_MAX_DIAGNOSTIC_CHARS = 1000
+_PROCEDURAL_FAILURE = re.compile(
+    r"(?:\bprocedural\b.*\b(?:error|failed|failure|unable)\b|"
+    r"\b(?:error|failed|failure|unable)\b.*\bprocedural\b)",
+    re.IGNORECASE,
+)
+_RENDERER_ERROR = re.compile(r"(?:^|\s)Error:\s*", re.IGNORECASE)
+_RENDERER_WARNING = re.compile(r"(?:^|\s)Warning:\s*", re.IGNORECASE)
 
 
 def _written_files(status: dict) -> list:
@@ -21,10 +33,53 @@ def _written_files(status: dict) -> list:
     return written
 
 
+def _bounded_stderr(path_value) -> str:
+    if not path_value:
+        return ""
+    try:
+        with Path(str(path_value)).open("rb") as stream:
+            stream.seek(0, os.SEEK_END)
+            stream.seek(max(0, stream.tell() - _STDERR_SCAN_BYTES))
+            payload = stream.read(_STDERR_SCAN_BYTES)
+    except OSError:
+        return ""
+    return payload.decode("utf-8", errors="replace")
+
+
+def _render_diagnostics(stderr: str):
+    render_errors = []
+    warnings = []
+    for raw_line in stderr.splitlines():
+        message = " ".join(raw_line.split())[:_MAX_DIAGNOSTIC_CHARS]
+        if not message:
+            continue
+        if "hou.OperationFailed" in message:
+            target = render_errors
+            code = "HOUDINI_OPERATION_FAILED"
+        elif _PROCEDURAL_FAILURE.search(message):
+            target = render_errors
+            code = "PROCEDURAL_INVOCATION_FAILED"
+        elif _RENDERER_ERROR.search(message):
+            target = render_errors
+            code = "RENDERER_ERROR"
+        elif _RENDERER_WARNING.search(message):
+            target = warnings
+            code = "RENDERER_WARNING"
+        else:
+            continue
+        diagnostic = {"code": code, "message": message}
+        if diagnostic not in target and len(target) < _MAX_DIAGNOSTICS:
+            target.append(diagnostic)
+    return render_errors, warnings
+
+
 def main() -> None:
     status_path = Path(sys.argv[1])
     command = json.loads(sys.argv[2])
     status = read_status(status_path)
+    status.setdefault("render_outcome", "pending")
+    status.setdefault("render_errors", [])
+    status.setdefault("warnings", [])
     started = time.time()
     status.update({"state": "running", "started_at": started, "worker_pid": os.getpid()})
     write_status(status_path, status)
@@ -36,10 +91,26 @@ def main() -> None:
             check=False,
         )
         written_files = _written_files(status)
+        render_errors, warnings = _render_diagnostics(_bounded_stderr(status.get("stderr_path")))
+        if process.returncode != 0:
+            state = "failed"
+            render_outcome = "failed"
+        elif render_errors:
+            state = "failed"
+            render_outcome = "completed_with_render_errors"
+        elif warnings:
+            state = "completed"
+            render_outcome = "completed_with_warnings"
+        else:
+            state = "completed"
+            render_outcome = "completed_clean"
         status.update(
             {
-                "state": "completed" if process.returncode == 0 else "failed",
+                "state": state,
+                "render_outcome": render_outcome,
                 "returncode": process.returncode,
+                "render_errors": render_errors,
+                "warnings": warnings,
                 "written_files": written_files,
                 "output_verification": {
                     "state": "verified" if written_files else "not_observed",
@@ -50,10 +121,13 @@ def main() -> None:
         )
         if process.returncode != 0:
             status["error"] = "husk exited with code {}".format(process.returncode)
+        elif render_errors:
+            status["error"] = "Husk reported procedural or renderer errors"
     except subprocess.TimeoutExpired:
         status.update(
             {
                 "state": "failed",
+                "render_outcome": "failed",
                 "error": "Husk render exceeded the configured timeout",
                 "written_files": _written_files(status),
             }
@@ -62,6 +136,7 @@ def main() -> None:
         status.update(
             {
                 "state": "failed",
+                "render_outcome": "failed",
                 "error": str(exc),
                 "traceback": traceback.format_exc(),
                 "written_files": _written_files(status),

--- a/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/tools.yaml
@@ -51,7 +51,9 @@ tools:
   - name: get_husk_job
     description: >-
       Poll a durable isolated Husk render. Returns state, elapsed time,
-      verified output files, bounded stdout/stderr tails, and worker ownership.
+      verified output files, bounded stdout/stderr tails, typed renderer
+      warnings/errors, render outcome, and worker ownership. A verified output
+      may still have a failed state when Husk reports procedural errors.
     source_file: scripts/get_husk_job.py
     execution: sync
     affinity: any

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -148,6 +148,37 @@ def test_husk_worker_records_nonzero_exit_without_touching_host(tmp_path: Path) 
     assert status["error"] == "husk exited with code 7"
 
 
+def test_husk_worker_replaces_pending_outcome_when_render_times_out(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    write_status(
+        status_path,
+        {
+            "job_id": "timeout",
+            "job_kind": "husk_render",
+            "expected_outputs": [],
+            "output_glob": "",
+            "timeout_secs": 1,
+            "render_outcome": "pending",
+            "render_errors": [],
+            "warnings": [],
+        },
+    )
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=worker.subprocess.TimeoutExpired(["husk", "scene.usda"], timeout=1),
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "failed"
+    assert status["render_outcome"] == "failed"
+    assert status["render_errors"] == []
+    assert status["warnings"] == []
+
+
 def test_husk_worker_verifies_written_output(tmp_path: Path) -> None:
     worker = _load_script("_husk_worker.py")
     status_path = tmp_path / "status.json"
@@ -176,7 +207,97 @@ def test_husk_worker_verifies_written_output(tmp_path: Path) -> None:
 
     status = read_status(status_path)
     assert status["state"] == "completed"
+    assert status["render_outcome"] == "completed_clean"
+    assert status["render_errors"] == []
+    assert status["warnings"] == []
     assert status["written_files"] == [str(output)]
+    assert status["output_verification"]["state"] == "verified"
+
+
+def test_husk_worker_rejects_verified_output_with_procedural_render_errors(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    stderr_path = tmp_path / "stderr.log"
+    output = tmp_path / "beauty.0001.exr"
+    write_status(
+        status_path,
+        {
+            "job_id": "render-errors",
+            "job_kind": "husk_render",
+            "expected_outputs": [str(output)],
+            "output_glob": str(tmp_path / "beauty.*.exr"),
+            "stderr_path": str(stderr_path),
+            "timeout_secs": 30,
+        },
+    )
+
+    def render(*_args, **_kwargs):
+        output.write_bytes(b"degraded render")
+        stderr_path.write_text(
+            "hou.OperationFailed: Invalid node setup\n"
+            "Error: Missing point attribute pscale\n"
+            "Houdini procedural invocation failed for /World/Hair\n",
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=render,
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "failed"
+    assert status["render_outcome"] == "completed_with_render_errors"
+    assert status["render_errors"] == [
+        {"code": "HOUDINI_OPERATION_FAILED", "message": "hou.OperationFailed: Invalid node setup"},
+        {"code": "RENDERER_ERROR", "message": "Error: Missing point attribute pscale"},
+        {
+            "code": "PROCEDURAL_INVOCATION_FAILED",
+            "message": "Houdini procedural invocation failed for /World/Hair",
+        },
+    ]
+    assert status["warnings"] == []
+    assert status["written_files"] == [str(output)]
+    assert status["output_verification"]["state"] == "verified"
+
+
+def test_husk_worker_reports_renderer_warning_without_failing_written_output(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    status_path = tmp_path / "status.json"
+    stderr_path = tmp_path / "stderr.log"
+    output = tmp_path / "beauty.0001.exr"
+    write_status(
+        status_path,
+        {
+            "job_id": "render-warning",
+            "job_kind": "husk_render",
+            "expected_outputs": [str(output)],
+            "output_glob": str(output),
+            "stderr_path": str(stderr_path),
+            "timeout_secs": 30,
+        },
+    )
+
+    def render(*_args, **_kwargs):
+        output.write_bytes(b"render")
+        stderr_path.write_text("Warning: Falling back to one render device\n", encoding="utf-8")
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(sys, "argv", ["_husk_worker.py", str(status_path), '["husk", "scene.usda"]']), patch.object(
+        worker.subprocess,
+        "run",
+        side_effect=render,
+    ):
+        worker.main()
+
+    status = read_status(status_path)
+    assert status["state"] == "completed"
+    assert status["render_outcome"] == "completed_with_warnings"
+    assert status["render_errors"] == []
+    assert status["warnings"] == [{"code": "RENDERER_WARNING", "message": "Warning: Falling back to one render device"}]
     assert status["output_verification"]["state"] == "verified"
 
 
@@ -209,6 +330,9 @@ def test_husk_job_launch_is_nonblocking_and_pollable(tmp_path: Path) -> None:
 
     assert launch_elapsed < 1.0
     assert launched["state"] == "queued"
+    assert launched["render_outcome"] == "pending"
+    assert launched["render_errors"] == []
+    assert launched["warnings"] == []
     deadline = time.monotonic() + 10.0
     status = jobs.read_husk_job(launched["job_id"])
     while status["state"] not in {"completed", "failed", "cancelled", "interrupted"}:


### PR DESCRIPTION
## Summary
- classify bounded Husk stderr into typed renderer errors and warnings
- fail a render with procedural errors even when Husk exits zero and writes verified output
- preserve written-file evidence and expose explicit pending, clean, warning, error, and failed outcomes

## Verification
- `python -m pytest` (976 passed, 1 skipped, 3 deselected)
- `python -m ruff check src/ tests/ tools/ packaging/`
- `python -m ruff format --check src/ tests/ tools/ packaging/`
- `python tools/lint_skills.py --require-cli --warnings-as-errors`
- `python tools/check_py37_syntax.py src tests tools packaging`
- `python -m build` and `python -m twine check`
- quickinstall build and verification for win64, linux, and macos

Live Houdini/Husk validation was not run because no local runtime is available.

Depends on #269
Fixes #238