### PR TITLE
feat: add verified Houdini modeling verbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,12 @@ When adding or changing bundled skills, load the project skill:
 | Skill | Key tools |
 |-------|-----------|
 | `houdini-nodes` | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
-| `houdini-object-ops` | `rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform` |
+| `houdini-object-ops` | `set_pivot`, `rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform` |
 | `houdini-parameters` | `list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression` |
 | `houdini-node-graph` | `get_connections`, `connect_input`, `disconnect_input` |
 | `houdini-geometry` | `create_primitive`, `create_curve_guides`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
 | `houdini-groom` | `build_short_fur_groom` |
-| `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
+| `houdini-mesh-ops` | `loft_sections`, `lathe_profile`, `extrude_faces`, `bevel_edges`, `inset`, `bridge_edges`, `boolean_op`, `add_edge_loop`, `array_instances`, `mirror`, `auto_uv`, `uv_project`, `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material`, `build_materialx_pbr`, `validate_materialx_pbr` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |

--- a/README.md
+++ b/README.md
@@ -345,12 +345,12 @@ Full authoritative index with ready-made task chains: `src/dcc_mcp_houdini/skill
 | Skill | Tools |
 |-------|-------|
 | `houdini-nodes` | `create_node`, `set_node_parms`, `connect_nodes`, `cook_node`, `layout_children`, `delete_node` |
-| `houdini-object-ops` | `rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform` |
+| `houdini-object-ops` | `set_pivot`, `rename_node`, `duplicate_node`, `parent_node`, `set_node_flags`, `set_node_lock`, `get_transform`, `set_transform` |
 | `houdini-parameters` | `list_parms`, `get_parms`, `get_parm_templates`, `get_expression`, `set_parms`, `add_spare_parm`, `remove_spare_parm`, `set_expression`, `clear_expression` |
 | `houdini-node-graph` | `get_connections`, `connect_input`, `disconnect_input` |
 | `houdini-geometry` | `create_primitive`, `create_curve_guides`, `get_geometry_info`, `list_attributes`, `list_groups`, `get_cook_status` |
 | `houdini-groom` | `build_short_fur_groom` |
-| `houdini-mesh-ops` | `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
+| `houdini-mesh-ops` | `loft_sections`, `lathe_profile`, `extrude_faces`, `bevel_edges`, `inset`, `bridge_edges`, `boolean_op`, `add_edge_loop`, `array_instances`, `mirror`, `auto_uv`, `uv_project`, `transform_geometry`, `merge_geometry`, `blast_geometry`, `group_geometry`, `add_normals`, `triangulate_geometry`, `convert_geometry` |
 | `houdini-camera-light` | `list_cameras`, `create_camera`, `update_camera`, `frame_view`, `get_view_state`, `create_light`, `update_light` |
 | `houdini-materials` | `create_material`, `assign_material`, `build_materialx_pbr`, `validate_materialx_pbr` |
 | `houdini-lookdev` | `list_materials`, `list_assignments`, `get_material_parms`, `set_material_parms`, `get_shader_connections`, `connect_shader`, `disconnect_shader`, `reset_material`, `save_preset`, `list_presets`, `load_preset`, `delete_preset` |

--- a/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
+++ b/src/dcc_mcp_houdini/skills/SKILLS_INDEX.md
@@ -19,12 +19,12 @@ Progressive loading stages for `dcc-mcp-houdini`. Minimal mode loads **bootstrap
 | Inspect hip | `houdini_scene__get_scene_info` → `houdini_scene__list_obj_nodes` |
 | Scene lifecycle | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__open_scene` / `houdini_scene_edit__save_scene` |
 | Select & frame | `load_skill("houdini-scene-edit")` → `houdini_scene_edit__find_nodes` → `houdini_scene_edit__set_selection` → `houdini_scene_edit__get_bounding_box` |
-| Edit existing object | `load_skill("houdini-object-ops")` → `houdini_object_ops__get_transform` → `houdini_object_ops__set_transform` → `houdini_object_ops__set_node_flags` |
+| Edit existing object | `load_skill("houdini-object-ops")` → `houdini_object_ops__get_transform` → `houdini_object_ops__set_transform` / `set_pivot` → `houdini_object_ops__set_node_flags` |
 | Build SOP/OBJ network | `load_skill("houdini-nodes")` → `houdini_nodes__create_node` → `houdini_nodes__set_node_parms` → `houdini_nodes__connect_nodes` → choose `cook_node` (short monolithic), `cook_nodes_chunked` (bounded list), or `start_cook_job` + `get_cook_job` (long durable) |
 | Edit parameters & expressions | `load_skill("houdini-parameters")` → `houdini_parameters__list_parms` → `houdini_parameters__set_parms` / `houdini_parameters__set_expression` |
 | Inspect & rewire graph | `load_skill("houdini-node-graph")` → `houdini_node_graph__get_connections` → `houdini_node_graph__connect_input` / `houdini_node_graph__disconnect_input` |
 | Create & inspect geometry | `load_skill("houdini-geometry")` → `houdini_geometry__create_primitive` or bounded `houdini_geometry__create_curve_guides` → `houdini_geometry__get_geometry_info` → `houdini_geometry__list_attributes` / `houdini_geometry__list_groups` |
-| Edit a mesh procedurally | `load_skill("houdini-mesh-ops")` → `houdini_mesh_ops__transform_geometry` / `merge_geometry` / `blast_geometry` / `group_geometry` / `add_normals` / `triangulate_geometry` / `convert_geometry` → `houdini_geometry__get_cook_status` |
+| Model typed SOP geometry | `load_skill("houdini-mesh-ops")` → `loft_sections` / `lathe_profile` / `extrude_faces` / `bevel_edges` / `bridge_edges` / `boolean_op` / `add_edge_loop` / `array_instances` / `mirror` / `auto_uv` / `uv_project` → inspect returned readback → `houdini_geometry__get_cook_status` |
 | Create & debug VEX wrangles | `load_skill("houdini-vex")` → `houdini_vex__validate_vex_syntax` → `houdini_vex__create_wrangle` → `houdini_vex__cook_wrangle` → `houdini_vex__diagnose_wrangle` / `houdini_vex__get_vex_info` |
 | Set up cameras & lights | `load_skill("houdini-camera-light")` → `houdini_camera_light__create_camera` → `houdini_camera_light__create_light` → `houdini_camera_light__frame_view` |
 | Three-point studio lighting | `load_skill("houdini-light-rig")` → `create_three_point_light_rig` → `aim_light_at_object` → `set_light_rig_intensity` → `get_lighting_summary` |

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -35,7 +35,8 @@ All tools are `affinity: main` (they call `hou`).
   triangulate/convert tools; `blast_geometry` remains destructive.
 - **`modeling`** (default inactive): `loft_sections`, `lathe_profile`,
   `extrude_faces`, `bevel_edges`, `inset`, `bridge_edges`, `boolean_op`,
-  `add_edge_loop`, `array_instances` (bounded radial Copy to Points), `mirror`,
+  `add_edge_loop`, `array_instances` (bounded radial/tangent `orient` readback
+  before Copy to Points), `mirror`,
   `auto_uv`, and `uv_project`.
 
 ## Tracer-bullet flow

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: houdini-mesh-ops
 description: >-
-  Authoring skill — lightweight SOP mesh operations that append standard SOPs
-  downstream of an input: transform, merge, blast/delete, group create, normals,
-  triangulate, and convert. Each tool wires the new node into the network and
-  returns its path for chaining. Use with houdini-geometry for inspection.
+  Authoring skill — typed procedural modeling operations with bounded schemas,
+  native SOP parameter readback, and cooked geometry postconditions. Covers
+  loft, lathe, extrude, bevel, inset, bridge, Boolean, edge-loop, radial array,
+  mirror, UV, transform, merge, group, normal, triangulate, and convert flows.
 license: MIT
 compatibility: "dcc-mcp-houdini 0.1+, Houdini 20.5+, dcc-mcp-core 0.20.14+"
 allowed-tools: Bash Read Write Edit
@@ -13,33 +13,43 @@ metadata:
     dcc: houdini
     layer: domain
     stage: authoring
-    version: "1.0.0"
-    tags: [houdini, sop, mesh, transform, merge, blast, group, normal, convert, authoring]
-    search-hint: "transform merge blast delete group normals triangulate convert mesh sop edit"
+    version: "1.1.0"
+    tags: [houdini, sop, mesh, modeling, loft, lathe, extrude, bevel, bridge, boolean, array, uv]
+    search-hint: "typed houdini model loft lathe extrude bevel inset bridge boolean edge loop radial array mirror uv"
     tools: tools.yaml
+    groups: groups.yaml
 ---
 
 # houdini-mesh-ops
 
-Typed mesh-edit tools that build procedural SOP networks. Every tool creates a
-standard SOP downstream of the provided `input_path`, wires input 0, sets the
-display flag, and returns the new node path so calls chain naturally.
+Typed modeling tools that build procedural SOP networks. Mutating tools use
+bounded inputs and return parameter plus cooked-geometry readback. A tool fails
+closed and removes its partial SOP when required native parameters, cooking, or
+postconditions cannot be verified; there is no raw-script fallback.
 
 All tools are `affinity: main` (they call `hou`).
 
 ## Tool group
 
-- **`mesh-edit`:** `transform_geometry`, `merge_geometry`, `blast_geometry`
-  (destructive), `group_geometry`, `add_normals`, `triangulate_geometry`,
-  `convert_geometry`.
+- **`mesh-edit`** (default active): the existing transform/merge/group/normal/
+  triangulate/convert tools; `blast_geometry` remains destructive.
+- **`modeling`** (default inactive): `loft_sections`, `lathe_profile`,
+  `extrude_faces`, `bevel_edges`, `inset`, `bridge_edges`, `boolean_op`,
+  `add_edge_loop`, `array_instances` (bounded radial Copy to Points), `mirror`,
+  `auto_uv`, and `uv_project`.
 
 ## Tracer-bullet flow
 
 1. `houdini_geometry__create_primitive(parent_path="/obj/geo1", primitive="box")`
-2. `transform_geometry(input_path=".../box1", translate=[2,0,0])`
-3. `merge_geometry(input_paths=[".../xform1", ".../sphere1"])`
-4. `add_normals(input_path=".../merge1")`
-5. `houdini_geometry__get_cook_status(node_path=".../normal1")` → verify result
+2. `bevel_edges(input_path=".../box1", group="0-3", distance=0.05)`
+3. `array_instances(input_path=".../polybevel1", count=4, radius=3.5, axis="y")`
+4. `auto_uv(input_path=".../copytopoints1")`
+5. `houdini_geometry__get_cook_status(node_path=".../uvunwrap1")` → inspect again
 
 `blast_geometry` is flagged `destructive` because it removes geometry; pass
 `delete_non_selected=true` to invert the selection (keep the group).
+
+Use `houdini-object-ops.set_pivot` for OBJ pivots and
+`houdini-materials.assign_material` for material ownership. Houdini's procedural
+SOP graph has no safe one-to-one `delete_history` operation; use the existing
+explicit node-lock/export tools when a baked boundary is actually intended.

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/groups.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/groups.yaml
@@ -1,0 +1,28 @@
+groups:
+  - name: mesh-edit
+    description: Existing lightweight SOP edit operations.
+    default_active: true
+    tools:
+      - transform_geometry
+      - merge_geometry
+      - blast_geometry
+      - group_geometry
+      - add_normals
+      - triangulate_geometry
+      - convert_geometry
+  - name: modeling
+    description: Typed procedural SOP modeling operations with post-condition readback.
+    default_active: false
+    tools:
+      - array_instances
+      - lathe_profile
+      - add_edge_loop
+      - bridge_edges
+      - mirror
+      - auto_uv
+      - uv_project
+      - boolean_op
+      - loft_sections
+      - extrude_faces
+      - bevel_edges
+      - inset

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
@@ -14,20 +14,29 @@ def get_node(hou: Any, node_path: str) -> Any:
 
 
 def make_downstream_sop(input_node: Any, optype: str, name: Optional[str] = None) -> Any:
-    """Create *optype* in the input's parent, wired to the input's output 0."""
+    """Create and wire *optype*, transferring ownership only on success."""
     parent = input_node.parent()
     if parent is None:
         raise ValueError("Input node has no parent network: {}".format(input_node.path()))
-    new_node = parent.createNode(optype, node_name=name)
-    new_node.setInput(0, input_node)
-    if hasattr(new_node, "moveToGoodPosition"):
-        try:
-            new_node.moveToGoodPosition()
-        except Exception:  # noqa: BLE001
-            pass
-    if hasattr(new_node, "setDisplayFlag"):
-        new_node.setDisplayFlag(True)
-    return new_node
+    new_node = None
+    try:
+        new_node = parent.createNode(optype, node_name=name)
+        new_node.setInput(0, input_node)
+        if hasattr(new_node, "moveToGoodPosition"):
+            try:
+                new_node.moveToGoodPosition()
+            except Exception:  # noqa: BLE001
+                pass
+        if hasattr(new_node, "setDisplayFlag"):
+            new_node.setDisplayFlag(True)
+        return new_node
+    except BaseException:
+        if new_node is not None:
+            try:
+                new_node.destroy()
+            except BaseException:
+                pass
+        raise
 
 
 def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
@@ -4,6 +4,88 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+_PUBLIC_EXCEPTION_TYPES = frozenset(
+    (
+        "AttributeError",
+        "KeyError",
+        "LookupError",
+        "OSError",
+        "RuntimeError",
+        "TypeError",
+        "ValueError",
+    )
+)
+
+
+class SopNodeTransaction:
+    """Own created SOP nodes until the caller commits a complete receipt."""
+
+    def __init__(self) -> None:
+        self._owned = []
+        self._committed = False
+
+    def __enter__(self):
+        return self
+
+    def own(self, node: Any) -> Any:
+        """Adopt one successfully created node and return it to the caller."""
+        if self._committed:
+            raise RuntimeError("Cannot adopt a node after transaction commit")
+        if node is None:
+            raise RuntimeError("Cannot adopt an empty SOP node")
+        if any(existing is node for existing in self._owned):
+            raise RuntimeError("SOP node is already owned by this transaction")
+        self._owned.append(node)
+        return node
+
+    def commit(self) -> None:
+        """Transfer all owned nodes to the caller after its receipt is ready."""
+        if self._committed:
+            raise RuntimeError("SOP transaction is already committed")
+        self._committed = True
+
+    def rollback(self) -> None:
+        """Best-effort destroy all still-owned nodes exactly once."""
+        if not self._committed:
+            self._cleanup()
+
+    def _cleanup(self) -> None:
+        for node in reversed(self._owned):
+            try:
+                node.destroy()
+            except BaseException:
+                pass
+        self._owned = []
+
+    def __exit__(self, exc_type, _exc, _traceback) -> bool:
+        if exc_type is not None or not self._committed:
+            self._cleanup()
+        else:
+            self._owned = []
+        if exc_type is None and not self._committed:
+            raise RuntimeError("SOP transaction exited without a complete receipt")
+        return False
+
+
+def sop_node_transaction() -> SopNodeTransaction:
+    """Return a transaction that cleans adopted nodes on every failure path."""
+    return SopNodeTransaction()
+
+
+def sop_transaction_error(message: str, exc: Exception) -> dict:
+    """Return a stable public failure without exception text or traceback."""
+    from dcc_mcp_core.skill import skill_error  # noqa: PLC0415
+
+    exception_type = type(exc).__name__
+    if exception_type not in _PUBLIC_EXCEPTION_TYPES:
+        exception_type = "Exception"
+    return skill_error(
+        message,
+        "Houdini rejected the bounded SOP transaction",
+        error_code="houdini_sop_transaction_failed",
+        error_type=exception_type,
+    )
+
 
 def get_node(hou: Any, node_path: str) -> Any:
     """Return a Houdini node or raise a useful error."""

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/_mesh_common.py
@@ -45,6 +45,128 @@ def set_parm_if_exists(node: Any, name: str, value: Any) -> bool:
     return True
 
 
+def _template_label(parm: Any) -> str:
+    try:
+        return str(parm.parmTemplate().label())
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def find_scalar_parm(node: Any, candidates: tuple, labels: tuple = ()) -> Any:
+    """Find a scalar parm by stable internal name, then by exact UI label."""
+    for name in candidates:
+        parm = node.parm(name)
+        if parm is not None:
+            return parm
+    accepted = {_normalized_label(label) for label in labels}
+    if accepted and hasattr(node, "parms"):
+        matches = [parm for parm in node.parms() if _normalized_label(_template_label(parm)) in accepted]
+        if len(matches) == 1:
+            return matches[0]
+    raise RuntimeError("Required parameter is unavailable: {}".format("/".join(candidates)))
+
+
+def find_tuple_parm(node: Any, candidates: tuple, labels: tuple = ()) -> Any:
+    """Find a tuple parm by stable internal name, then by exact UI label."""
+    for name in candidates:
+        parm_tuple = node.parmTuple(name)
+        if parm_tuple is not None:
+            return parm_tuple
+    accepted = {_normalized_label(label) for label in labels}
+    if accepted and hasattr(node, "parmTuples"):
+        matches = [
+            parm_tuple for parm_tuple in node.parmTuples() if _normalized_label(_template_label(parm_tuple)) in accepted
+        ]
+        if len(matches) == 1:
+            return matches[0]
+    raise RuntimeError("Required tuple parameter is unavailable: {}".format("/".join(candidates)))
+
+
+def set_scalar_parm_verified(
+    node: Any,
+    candidates: tuple,
+    value: Any,
+    labels: tuple = (),
+) -> Any:
+    """Set a required scalar parm and return its verified value."""
+    parm = find_scalar_parm(node, candidates, labels)
+    parm.set(value)
+    actual = parm.eval()
+    if isinstance(value, bool):
+        matches = bool(actual) is value
+    elif isinstance(value, (int, float)):
+        matches = abs(float(actual) - float(value)) <= 1e-8
+    else:
+        matches = str(actual) == str(value)
+    if not matches:
+        raise RuntimeError("Parameter readback did not match: {}".format(candidates[0]))
+    return actual
+
+
+def set_tuple_parm_verified(
+    node: Any,
+    candidates: tuple,
+    values: tuple,
+    labels: tuple = (),
+) -> tuple:
+    """Set a required tuple parm and return its verified numeric values."""
+    parm_tuple = find_tuple_parm(node, candidates, labels)
+    requested = tuple(float(value) for value in values)
+    parm_tuple.set(requested)
+    actual = tuple(float(value) for value in parm_tuple.eval())
+    if len(actual) != len(requested) or any(
+        abs(actual[index] - requested[index]) > 1e-8 for index in range(len(requested))
+    ):
+        raise RuntimeError("Tuple parameter readback did not match: {}".format(candidates[0]))
+    return actual
+
+
+def _normalized_label(value: Any) -> str:
+    return "".join(character for character in str(value).lower() if character.isalnum())
+
+
+def set_menu_parm_candidates(
+    node: Any,
+    candidates: tuple,
+    accepted_labels: tuple,
+    parameter_labels: tuple = (),
+) -> str:
+    """Resolve a menu parameter and token by labels, then verify readback."""
+    parm = find_scalar_parm(node, candidates, parameter_labels)
+    if not hasattr(parm, "menuItems") or not hasattr(parm, "menuLabels"):
+        raise RuntimeError("Parameter is not a menu: {}".format(candidates[0]))
+    items = tuple(parm.menuItems())
+    labels = tuple(parm.menuLabels())
+    if len(items) != len(labels) or not items:
+        raise RuntimeError("Menu parameter has no stable items: {}".format(candidates[0]))
+    accepted = {_normalized_label(value) for value in accepted_labels}
+    matches = [item for item, label in zip(items, labels) if _normalized_label(label) in accepted]
+    if len(matches) != 1:
+        raise RuntimeError("Menu parameter {} did not expose exactly one accepted label".format(candidates[0]))
+    token = str(matches[0])
+    parm.set(token)
+    actual = None
+    if hasattr(parm, "evalAsString"):
+        try:
+            actual = str(parm.evalAsString())
+        except Exception:  # noqa: BLE001
+            pass
+    if actual != token:
+        raw = parm.eval()
+        if isinstance(raw, int) and not isinstance(raw, bool) and 0 <= raw < len(items):
+            actual = str(items[raw])
+        else:
+            actual = str(raw)
+    if actual != token:
+        raise RuntimeError("Menu parameter {} readback did not match".format(candidates[0]))
+    return token
+
+
+def set_menu_parm(node: Any, name: str, accepted_labels: tuple) -> str:
+    """Resolve one named menu parameter token by label and verify readback."""
+    return set_menu_parm_candidates(node, (name,), accepted_labels)
+
+
 def node_summary(node: Any) -> dict:
     """Return a small, JSON-safe node summary."""
     type_obj = node.type()
@@ -53,3 +175,45 @@ def node_summary(node: Any) -> dict:
         "name": node.name(),
         "type": type_obj.name() if hasattr(type_obj, "name") else str(type_obj),
     }
+
+
+def geometry_readback(node: Any) -> dict:
+    """Return bounded cooked-geometry evidence without enumerating components."""
+    geometry = node.geometry()
+    if geometry is None:
+        raise RuntimeError("SOP produced no geometry")
+    bounds = geometry.boundingBox()
+    return {
+        "point_count": int(geometry.pointCount()),
+        "primitive_count": int(geometry.primCount()),
+        "vertex_count": int(geometry.vertexCount()),
+        "bounds_min": [float(value) for value in bounds.minvec()],
+        "bounds_max": [float(value) for value in bounds.maxvec()],
+        "bounds_size": [float(value) for value in bounds.sizevec()],
+    }
+
+
+def geometry_changed(before: dict, after: dict) -> bool:
+    """Return whether bounded topology or bounds evidence changed."""
+    keys = ("point_count", "primitive_count", "vertex_count", "bounds_min", "bounds_max")
+    return any(before[key] != after[key] for key in keys)
+
+
+def cook_readback(node: Any, before: Optional[dict] = None, require_change: bool = True) -> dict:
+    """Cook a SOP and fail unless its bounded post-condition is observable."""
+    node.cook(force=True)
+    errors = [str(value) for value in (node.errors() or [])]
+    if errors:
+        raise RuntimeError("SOP cook failed: {}".format("; ".join(errors)))
+    after = geometry_readback(node)
+    if after["primitive_count"] <= 0:
+        raise RuntimeError("SOP geometry readback is empty")
+    if before is not None and require_change and not geometry_changed(before, after):
+        raise RuntimeError("SOP geometry readback reported no observable effect")
+    after["verified"] = True
+    if before is not None:
+        after["before"] = before
+    warnings = [str(value) for value in (node.warnings() or [])]
+    if warnings:
+        after["warnings"] = warnings
+    return after

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_edge_loop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_edge_loop.py
@@ -1,0 +1,76 @@
+"""Add a bounded PolySplit loop/path and verify cooked geometry."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_scalar_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def add_edge_loop(input_path: str, split_locations: str, node_name: Optional[str] = None) -> dict:
+    """Append PolySplit with an explicit bounded split-location expression."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty node path")
+    if (
+        not isinstance(split_locations, str)
+        or not split_locations.strip()
+        or len(split_locations) > 4096
+        or "\x00" in split_locations
+    ):
+        return skill_error(
+            "Invalid split locations",
+            "split_locations must be a non-empty Houdini selection string of at most 4096 characters",
+        )
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "polysplit", node_name)
+        set_scalar_parm_verified(
+            created,
+            ("splitloc", "splitlocations"),
+            split_locations,
+            ("Split Locations",),
+        )
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified PolySplit SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters={"split_locations": split_locations},
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified PolySplit SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return add_edge_loop(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_edge_loop.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_edge_loop.py
@@ -11,8 +11,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_scalar_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def add_edge_loop(input_path: str, split_locations: str, node_name: Optional[str] = None) -> dict:
@@ -37,32 +39,29 @@ def add_edge_loop(input_path: str, split_locations: str, node_name: Optional[str
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "polysplit", node_name)
-        set_scalar_parm_verified(
-            created,
-            ("splitloc", "splitlocations"),
-            split_locations,
-            ("Split Locations",),
-        )
-        readback = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified PolySplit SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters={"split_locations": split_locations},
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "polysplit", node_name))
+            set_scalar_parm_verified(
+                created,
+                ("splitloc", "splitlocations"),
+                split_locations,
+                ("Split Locations",),
+            )
+            readback = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified PolySplit SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters={"split_locations": split_locations},
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified PolySplit SOP")
+        return sop_transaction_error("Failed to create verified PolySplit SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_normals.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/add_normals.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from _mesh_common import (  # noqa: E402
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_parm_if_exists,
+    sop_node_transaction,
+    sop_transaction_error,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 # normal 'type' menu indices: 0=point, 1=vertex, 2=primitive, 3=detail.
 _NORMAL_TYPE = {"point": 0, "vertex": 1, "primitive": 2, "detail": 3}
@@ -22,20 +29,24 @@ def add_normals(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
+    created = None
     try:
         source = get_node(hou, input_path)
-        normal = make_downstream_sop(source, "normal", node_name)
-        type_index = _NORMAL_TYPE.get(attribute_class.lower())
-        if type_index is not None:
-            set_parm_if_exists(normal, "type", type_index)
-        return skill_success(
-            "Created normal SOP",
-            input_path=source.path(),
-            node=node_summary(normal),
-            attribute_class=attribute_class.lower(),
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "normal", node_name))
+            type_index = _NORMAL_TYPE.get(attribute_class.lower())
+            if type_index is not None:
+                set_parm_if_exists(created, "type", type_index)
+            result = skill_success(
+                "Created normal SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                attribute_class=attribute_class.lower(),
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create normal SOP")
+        return sop_transaction_error("Failed to create normal SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/array_instances.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/array_instances.py
@@ -15,7 +15,7 @@ from _mesh_common import (  # noqa: E402
     set_scalar_parm_verified,
     set_tuple_parm_verified,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 _ORIENTATION_LABELS = {
     "x": ("yz plane", "yz"),
@@ -23,12 +23,144 @@ _ORIENTATION_LABELS = {
     "z": ("xy plane", "xy"),
 }
 
+_AXIS_VECTORS = {
+    "x": (1.0, 0.0, 0.0),
+    "y": (0.0, 1.0, 0.0),
+    "z": (0.0, 0.0, 1.0),
+}
+
+_SOURCE_FORWARD_VECTORS = {
+    "+x": (1.0, 0.0, 0.0),
+    "-x": (-1.0, 0.0, 0.0),
+    "+y": (0.0, 1.0, 0.0),
+    "-y": (0.0, -1.0, 0.0),
+    "+z": (0.0, 0.0, 1.0),
+    "-z": (0.0, 0.0, -1.0),
+}
+
+
+def _orientation_vex(axis: str, direction_mode: str, source_forward: str) -> str:
+    ring_axis = _AXIS_VECTORS[axis]
+    forward = _SOURCE_FORWARD_VECTORS[source_forward]
+    target_expression = "normalize(cross(ring_axis, radial))" if direction_mode == "tangent" else "radial"
+    return """vector ring_axis = set({axis_x}, {axis_y}, {axis_z});
+vector source_forward = set({forward_x}, {forward_y}, {forward_z});
+vector radial = @P - dot(@P, ring_axis) * ring_axis;
+i@dcc_mcp_orientation_valid = 0;
+if (length2(radial) > 1e-12) {{
+    radial = normalize(radial);
+    vector target = {target};
+    if (length2(target) > 1e-12) {{
+        p@orient = quaternion(dihedral(source_forward, normalize(target)));
+        i@dcc_mcp_orientation_valid = 1;
+    }}
+}}
+""".format(
+        axis_x=ring_axis[0],
+        axis_y=ring_axis[1],
+        axis_z=ring_axis[2],
+        forward_x=forward[0],
+        forward_y=forward[1],
+        forward_z=forward[2],
+        target=target_expression,
+    )
+
+
+def _cross(left: tuple, right: tuple) -> tuple:
+    return (
+        left[1] * right[2] - left[2] * right[1],
+        left[2] * right[0] - left[0] * right[2],
+        left[0] * right[1] - left[1] * right[0],
+    )
+
+
+def _normalized(vector: tuple) -> tuple:
+    length = math.sqrt(sum(value * value for value in vector))
+    if length <= 1e-6:
+        raise RuntimeError("Generated point orientation contains a degenerate direction")
+    return tuple(value / length for value in vector)
+
+
+def _rotated_by_quaternion(vector: tuple, quaternion: tuple) -> tuple:
+    imaginary = quaternion[:3]
+    crossed = _cross(imaginary, vector)
+    nested = _cross(imaginary, crossed)
+    return tuple(vector[index] + 2.0 * quaternion[3] * crossed[index] + 2.0 * nested[index] for index in range(3))
+
+
+def _orientation_readback(
+    node,
+    expected_count: int,
+    axis: str,
+    direction_mode: str,
+    source_forward: str,
+) -> dict:
+    geometry = node.geometry()
+    point_count = int(geometry.pointCount())
+    if point_count != expected_count:
+        raise RuntimeError("Generated point count does not match requested array count")
+
+    orient_attribute = geometry.findPointAttrib("orient")
+    if orient_attribute is None or int(orient_attribute.size()) != 4:
+        raise RuntimeError("Generated points are missing a quaternion orient attribute")
+    raw_orientations = tuple(float(value) for value in geometry.pointFloatAttribValues("orient"))
+    if len(raw_orientations) != point_count * 4:
+        raise RuntimeError("Generated orient attribute has an invalid value count")
+    orientations = tuple(raw_orientations[index : index + 4] for index in range(0, len(raw_orientations), 4))
+    if any(
+        not all(math.isfinite(value) for value in quaternion)
+        or not 0.999 <= sum(value * value for value in quaternion) <= 1.001
+        for quaternion in orientations
+    ):
+        raise RuntimeError("Generated orient attribute contains invalid quaternions")
+
+    position_attribute = geometry.findPointAttrib("P")
+    if position_attribute is None or int(position_attribute.size()) != 3:
+        raise RuntimeError("Generated points are missing position readback")
+    raw_positions = tuple(float(value) for value in geometry.pointFloatAttribValues("P"))
+    if len(raw_positions) != point_count * 3:
+        raise RuntimeError("Generated point position has an invalid value count")
+    positions = tuple(raw_positions[index : index + 3] for index in range(0, len(raw_positions), 3))
+
+    ring_axis = _AXIS_VECTORS[axis]
+    forward = _SOURCE_FORWARD_VECTORS[source_forward]
+    for position, quaternion in zip(positions, orientations):
+        projection = sum(position[index] * ring_axis[index] for index in range(3))
+        radial = _normalized(tuple(position[index] - projection * ring_axis[index] for index in range(3)))
+        target = _normalized(_cross(ring_axis, radial)) if direction_mode == "tangent" else radial
+        actual = _normalized(_rotated_by_quaternion(forward, quaternion))
+        alignment = sum(actual[index] * target[index] for index in range(3))
+        if alignment < 0.999:
+            raise RuntimeError("Generated orient attribute does not match the requested direction")
+
+    valid_attribute = geometry.findPointAttrib("dcc_mcp_orientation_valid")
+    if valid_attribute is None or int(valid_attribute.size()) != 1:
+        raise RuntimeError("Generated points are missing orientation validity readback")
+    validity = tuple(int(value) for value in geometry.pointIntAttribValues("dcc_mcp_orientation_valid"))
+    if len(validity) != point_count or any(value != 1 for value in validity):
+        raise RuntimeError("Generated point orientation contains a degenerate direction")
+
+    distinct_count = len({tuple(round(value, 8) for value in item) for item in orientations})
+    if distinct_count < 2:
+        raise RuntimeError("Generated point orientations do not vary around the array")
+    return {
+        "attribute": "orient",
+        "distinct_count": distinct_count,
+        "point_count": point_count,
+        "tuple_size": 4,
+        "valid_count": sum(validity),
+        "verified": True,
+    }
+
 
 def array_instances(
     input_path: str,
     count: int,
     radius: float,
     axis: str = "y",
+    start_angle_degrees: float = 0.0,
+    direction_mode: str = "radial",
+    source_forward: str = "+x",
     node_name: Optional[str] = None,
     points_node_name: Optional[str] = None,
 ) -> dict:
@@ -44,6 +176,21 @@ def array_instances(
         return skill_error("Invalid array radius", "radius must be finite, positive, and at most 1000000")
     if axis not in _ORIENTATION_LABELS:
         return skill_error("Invalid array axis", "axis must be one of: x, y, z")
+    if isinstance(start_angle_degrees, bool) or not isinstance(start_angle_degrees, (int, float)):
+        return skill_error("Invalid start angle", "start_angle_degrees must be numeric")
+    resolved_start_angle = float(start_angle_degrees)
+    if not math.isfinite(resolved_start_angle) or abs(resolved_start_angle) > 360_000.0:
+        return skill_error(
+            "Invalid start angle",
+            "start_angle_degrees must be finite and within -360000 through 360000",
+        )
+    if direction_mode not in ("radial", "tangent"):
+        return skill_error("Invalid direction mode", "direction_mode must be radial or tangent")
+    if source_forward not in _SOURCE_FORWARD_VECTORS:
+        return skill_error(
+            "Invalid source forward",
+            "source_forward must be one of: +x, -x, +y, -y, +z, -z",
+        )
     for value, label in ((node_name, "node_name"), (points_node_name, "points_node_name")):
         if value is not None and (not isinstance(value, str) or not value):
             return skill_error("Invalid node name", "{} must be non-empty when provided".format(label))
@@ -54,6 +201,7 @@ def array_instances(
         return skill_error("Houdini not available", "hou could not be imported")
 
     points = None
+    orientation = None
     created = None
     try:
         source = get_node(hou, input_path)
@@ -76,28 +224,69 @@ def array_instances(
         )
         set_scalar_parm_verified(points, ("divs", "divisions"), count, ("Divisions",))
         set_tuple_parm_verified(points, ("rad", "radius"), (resolved_radius, resolved_radius), ("Radius",))
+        rotation = {
+            "x": (resolved_start_angle, 0.0, 0.0),
+            "y": (0.0, resolved_start_angle, 0.0),
+            "z": (0.0, 0.0, resolved_start_angle),
+        }[axis]
+        set_tuple_parm_verified(points, ("r", "rotate"), rotation, ("Rotate", "Rotation"))
         points_readback = cook_readback(points, require_change=False)
 
+        orientation = make_downstream_sop(points, "attribwrangle")
+        set_menu_parm_candidates(
+            orientation,
+            ("class", "runover"),
+            ("points", "point"),
+            ("Run Over",),
+        )
+        set_scalar_parm_verified(
+            orientation,
+            ("snippet", "vex"),
+            _orientation_vex(axis, direction_mode, source_forward),
+            ("VEXpression", "Snippet"),
+        )
+        orientation_readback = cook_readback(orientation, require_change=False)
+        orientation_receipt = _orientation_readback(
+            orientation,
+            count,
+            axis,
+            direction_mode,
+            source_forward,
+        )
+
         created = make_downstream_sop(source, "copytopoints", node_name)
-        created.setInput(1, points)
+        created.setInput(1, orientation)
         readback = cook_readback(created, before=before)
         readback["points"] = points_readback
+        readback["orientation_cook"] = orientation_readback
+        readback["orientation"] = orientation_receipt
         return skill_success(
             "Created and verified radial Copy to Points array",
             input_path=source.path(),
             node=node_summary(created),
             points_node=node_summary(points),
-            parameters={"axis": axis, "count": count, "radius": resolved_radius},
+            orientation_node=node_summary(orientation),
+            parameters={
+                "axis": axis,
+                "count": count,
+                "direction_mode": direction_mode,
+                "radius": resolved_radius,
+                "source_forward": source_forward,
+                "start_angle_degrees": resolved_start_angle,
+            },
             readback=readback,
         )
-    except Exception as exc:
-        for node in (created, points):
+    except Exception:  # noqa: BLE001
+        for node in (created, orientation, points):
             if node is not None:
                 try:
                     node.destroy()
                 except Exception:  # noqa: BLE001
                     pass
-        return skill_exception(exc, message="Failed to create verified radial instance array")
+        return skill_error(
+            "Failed to create verified radial instance array",
+            "Houdini rejected the bounded radial-array transaction",
+        )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/array_instances.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/array_instances.py
@@ -14,6 +14,8 @@ from _mesh_common import (  # noqa: E402
     set_menu_parm_candidates,
     set_scalar_parm_verified,
     set_tuple_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
@@ -203,13 +205,14 @@ def array_instances(
     points = None
     orientation = None
     created = None
+    transaction = sop_node_transaction()
     try:
         source = get_node(hou, input_path)
         parent = source.parent()
         if parent is None:
             raise ValueError("Input node has no parent SOP network")
         before = geometry_readback(source)
-        points = parent.createNode("circle", node_name=points_node_name)
+        points = transaction.own(parent.createNode("circle", node_name=points_node_name))
         set_menu_parm_candidates(
             points,
             ("type", "primitivetype"),
@@ -232,7 +235,7 @@ def array_instances(
         set_tuple_parm_verified(points, ("r", "rotate"), rotation, ("Rotate", "Rotation"))
         points_readback = cook_readback(points, require_change=False)
 
-        orientation = make_downstream_sop(points, "attribwrangle")
+        orientation = transaction.own(make_downstream_sop(points, "attribwrangle"))
         set_menu_parm_candidates(
             orientation,
             ("class", "runover"),
@@ -254,13 +257,13 @@ def array_instances(
             source_forward,
         )
 
-        created = make_downstream_sop(source, "copytopoints", node_name)
+        created = transaction.own(make_downstream_sop(source, "copytopoints", node_name))
         created.setInput(1, orientation)
         readback = cook_readback(created, before=before)
         readback["points"] = points_readback
         readback["orientation_cook"] = orientation_readback
         readback["orientation"] = orientation_receipt
-        return skill_success(
+        result = skill_success(
             "Created and verified radial Copy to Points array",
             input_path=source.path(),
             node=node_summary(created),
@@ -276,17 +279,13 @@ def array_instances(
             },
             readback=readback,
         )
-    except Exception:  # noqa: BLE001
-        for node in (created, orientation, points):
-            if node is not None:
-                try:
-                    node.destroy()
-                except Exception:  # noqa: BLE001
-                    pass
-        return skill_error(
-            "Failed to create verified radial instance array",
-            "Houdini rejected the bounded radial-array transaction",
-        )
+        transaction.commit()
+        return result
+    except BaseException as exc:
+        transaction.rollback()
+        if not isinstance(exc, Exception):
+            raise
+        return sop_transaction_error("Failed to create verified radial instance array", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/array_instances.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/array_instances.py
@@ -1,0 +1,111 @@
+"""Build a bounded radial instance array with Circle and Copy to Points."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_menu_parm_candidates,
+    set_scalar_parm_verified,
+    set_tuple_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_ORIENTATION_LABELS = {
+    "x": ("yz plane", "yz"),
+    "y": ("zx plane", "xz plane", "zx", "xz"),
+    "z": ("xy plane", "xy"),
+}
+
+
+def array_instances(
+    input_path: str,
+    count: int,
+    radius: float,
+    axis: str = "y",
+    node_name: Optional[str] = None,
+    points_node_name: Optional[str] = None,
+) -> dict:
+    """Instance one SOP on a generated radial point ring and verify output."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty node path")
+    if isinstance(count, bool) or not isinstance(count, int) or not 2 <= count <= 128:
+        return skill_error("Invalid array count", "count must be an integer from 2 through 128")
+    if isinstance(radius, bool) or not isinstance(radius, (int, float)):
+        return skill_error("Invalid array radius", "radius must be numeric")
+    resolved_radius = float(radius)
+    if not math.isfinite(resolved_radius) or not 0 < resolved_radius <= 1_000_000.0:
+        return skill_error("Invalid array radius", "radius must be finite, positive, and at most 1000000")
+    if axis not in _ORIENTATION_LABELS:
+        return skill_error("Invalid array axis", "axis must be one of: x, y, z")
+    for value, label in ((node_name, "node_name"), (points_node_name, "points_node_name")):
+        if value is not None and (not isinstance(value, str) or not value):
+            return skill_error("Invalid node name", "{} must be non-empty when provided".format(label))
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    points = None
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        parent = source.parent()
+        if parent is None:
+            raise ValueError("Input node has no parent SOP network")
+        before = geometry_readback(source)
+        points = parent.createNode("circle", node_name=points_node_name)
+        set_menu_parm_candidates(
+            points,
+            ("type", "primitivetype"),
+            ("polygon",),
+            ("Primitive Type",),
+        )
+        set_menu_parm_candidates(
+            points,
+            ("orient", "orientation"),
+            _ORIENTATION_LABELS[axis],
+            ("Orientation",),
+        )
+        set_scalar_parm_verified(points, ("divs", "divisions"), count, ("Divisions",))
+        set_tuple_parm_verified(points, ("rad", "radius"), (resolved_radius, resolved_radius), ("Radius",))
+        points_readback = cook_readback(points, require_change=False)
+
+        created = make_downstream_sop(source, "copytopoints", node_name)
+        created.setInput(1, points)
+        readback = cook_readback(created, before=before)
+        readback["points"] = points_readback
+        return skill_success(
+            "Created and verified radial Copy to Points array",
+            input_path=source.path(),
+            node=node_summary(created),
+            points_node=node_summary(points),
+            parameters={"axis": axis, "count": count, "radius": resolved_radius},
+            readback=readback,
+        )
+    except Exception as exc:
+        for node in (created, points):
+            if node is not None:
+                try:
+                    node.destroy()
+                except Exception:  # noqa: BLE001
+                    pass
+        return skill_exception(exc, message="Failed to create verified radial instance array")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return array_instances(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/auto_uv.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/auto_uv.py
@@ -1,0 +1,79 @@
+"""Generate UVs through a verified native UV Unwrap SOP."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_scalar_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_ATTRIBUTE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def auto_uv(
+    input_path: str,
+    group: Optional[str] = None,
+    uv_attribute: str = "uv",
+    node_name: Optional[str] = None,
+) -> dict:
+    """Append UV Unwrap and verify the requested vertex UV attribute exists."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty node path")
+    if group is not None and (not isinstance(group, str) or not group.strip()):
+        return skill_error("Invalid UV group", "group must be a non-empty selection when provided")
+    if not isinstance(uv_attribute, str) or not _ATTRIBUTE_NAME.fullmatch(uv_attribute):
+        return skill_error("Invalid UV attribute", "uv_attribute must be a valid Houdini attribute name")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "uvunwrap", node_name)
+        set_scalar_parm_verified(created, ("uvattrib",), uv_attribute, ("UV Attribute",))
+        if group is not None:
+            set_scalar_parm_verified(created, ("group",), group, ("Group",))
+        readback = cook_readback(created, before=before, require_change=False)
+        geometry = created.geometry()
+        if geometry.findVertexAttrib(uv_attribute) is None:
+            raise RuntimeError("UV Unwrap did not create vertex attribute: {}".format(uv_attribute))
+        readback["uv_attribute"] = uv_attribute
+        return skill_success(
+            "Created and verified UV Unwrap SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters={"group": group or "", "uv_attribute": uv_attribute},
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified UV Unwrap SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return auto_uv(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/auto_uv.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/auto_uv.py
@@ -12,8 +12,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_scalar_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 _ATTRIBUTE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -39,33 +41,30 @@ def auto_uv(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "uvunwrap", node_name)
-        set_scalar_parm_verified(created, ("uvattrib",), uv_attribute, ("UV Attribute",))
-        if group is not None:
-            set_scalar_parm_verified(created, ("group",), group, ("Group",))
-        readback = cook_readback(created, before=before, require_change=False)
-        geometry = created.geometry()
-        if geometry.findVertexAttrib(uv_attribute) is None:
-            raise RuntimeError("UV Unwrap did not create vertex attribute: {}".format(uv_attribute))
-        readback["uv_attribute"] = uv_attribute
-        return skill_success(
-            "Created and verified UV Unwrap SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters={"group": group or "", "uv_attribute": uv_attribute},
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "uvunwrap", node_name))
+            set_scalar_parm_verified(created, ("uvattrib",), uv_attribute, ("UV Attribute",))
+            if group is not None:
+                set_scalar_parm_verified(created, ("group",), group, ("Group",))
+            readback = cook_readback(created, before=before, require_change=False)
+            geometry = created.geometry()
+            if geometry.findVertexAttrib(uv_attribute) is None:
+                raise RuntimeError("UV Unwrap did not create the requested vertex attribute")
+            readback["uv_attribute"] = uv_attribute
+            result = skill_success(
+                "Created and verified UV Unwrap SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters={"group": group or "", "uv_attribute": uv_attribute},
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified UV Unwrap SOP")
+        return sop_transaction_error("Failed to create verified UV Unwrap SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bevel_edges.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bevel_edges.py
@@ -12,8 +12,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_scalar_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def bevel_edges(
@@ -43,34 +45,31 @@ def bevel_edges(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "polybevel", node_name)
-        requested = {"group": group, "distance": resolved_distance, "divisions": divisions}
-        actual = {
-            "group": str(set_scalar_parm_verified(created, ("group",), group)),
-            "distance": float(set_scalar_parm_verified(created, ("distance",), resolved_distance, ("Distance",))),
-            "divisions": int(set_scalar_parm_verified(created, ("divisions", "divs"), divisions, ("Divisions",))),
-        }
-        if actual != requested:
-            raise RuntimeError("PolyBevel parameter readback did not match the request")
-        readback = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified PolyBevel SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters=requested,
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "polybevel", node_name))
+            requested = {"group": group, "distance": resolved_distance, "divisions": divisions}
+            actual = {
+                "group": str(set_scalar_parm_verified(created, ("group",), group)),
+                "distance": float(set_scalar_parm_verified(created, ("distance",), resolved_distance, ("Distance",))),
+                "divisions": int(set_scalar_parm_verified(created, ("divisions", "divs"), divisions, ("Divisions",))),
+            }
+            if actual != requested:
+                raise RuntimeError("PolyBevel parameter readback did not match the request")
+            readback = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified PolyBevel SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters=requested,
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified PolyBevel SOP")
+        return sop_transaction_error("Failed to create verified PolyBevel SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bevel_edges.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bevel_edges.py
@@ -1,0 +1,84 @@
+"""Append a verified PolyBevel SOP for selected edges."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_scalar_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def bevel_edges(
+    input_path: str,
+    group: str,
+    distance: float,
+    divisions: int = 1,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Bevel selected edges and verify the resulting SOP."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty string")
+    if not isinstance(group, str) or not group.strip():
+        return skill_error("Invalid bevel group", "group must be a non-empty edge selection")
+    if isinstance(distance, bool) or not isinstance(distance, (int, float)):
+        return skill_error("Invalid bevel distance", "distance must be numeric")
+    resolved_distance = float(distance)
+    if not math.isfinite(resolved_distance) or not 0 < resolved_distance <= 1_000_000.0:
+        return skill_error("Invalid bevel distance", "distance must be finite, positive, and at most 1000000")
+    if isinstance(divisions, bool) or not isinstance(divisions, int) or not 1 <= divisions <= 64:
+        return skill_error("Invalid bevel divisions", "divisions must be an integer from 1 through 64")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "polybevel", node_name)
+        requested = {"group": group, "distance": resolved_distance, "divisions": divisions}
+        actual = {
+            "group": str(set_scalar_parm_verified(created, ("group",), group)),
+            "distance": float(set_scalar_parm_verified(created, ("distance",), resolved_distance, ("Distance",))),
+            "divisions": int(set_scalar_parm_verified(created, ("divisions", "divs"), divisions, ("Divisions",))),
+        }
+        if actual != requested:
+            raise RuntimeError("PolyBevel parameter readback did not match the request")
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified PolyBevel SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters=requested,
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified PolyBevel SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return bevel_edges(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/blast_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/blast_geometry.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from _mesh_common import (  # noqa: E402
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_parm_if_exists,
+    sop_node_transaction,
+    sop_transaction_error,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 # Blast 'grouptype' menu indices (Houdini 18.5+).
 _GROUP_TYPE = {
@@ -32,25 +39,29 @@ def blast_geometry(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
+    created = None
     try:
         source = get_node(hou, input_path)
-        blast = make_downstream_sop(source, "blast", node_name)
-        set_parm_if_exists(blast, "group", group)
-        type_index = _GROUP_TYPE.get(group_type.lower())
-        if type_index is not None:
-            set_parm_if_exists(blast, "grouptype", type_index)
-        # negate=1 keeps the selection and deletes everything else.
-        set_parm_if_exists(blast, "negate", 1 if delete_non_selected else 0)
-        return skill_success(
-            "Created blast SOP",
-            input_path=source.path(),
-            node=node_summary(blast),
-            group=group,
-            group_type=group_type.lower(),
-            delete_non_selected=bool(delete_non_selected),
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "blast", node_name))
+            set_parm_if_exists(created, "group", group)
+            type_index = _GROUP_TYPE.get(group_type.lower())
+            if type_index is not None:
+                set_parm_if_exists(created, "grouptype", type_index)
+            # negate=1 keeps the selection and deletes everything else.
+            set_parm_if_exists(created, "negate", 1 if delete_non_selected else 0)
+            result = skill_success(
+                "Created blast SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                group=group,
+                group_type=group_type.lower(),
+                delete_non_selected=bool(delete_non_selected),
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create blast SOP")
+        return sop_transaction_error("Failed to create blast SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/boolean_op.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/boolean_op.py
@@ -11,8 +11,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_menu_parm_candidates,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 _OPERATION_LABELS = {
     "union": ("union",),
@@ -47,36 +49,33 @@ def boolean_op(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         left = get_node(hou, input_a)
         right = get_node(hou, input_b)
         if left.parent() is None or right.parent() is not left.parent():
             raise ValueError("Boolean inputs must share one parent SOP network")
         before = geometry_readback(left)
-        created = make_downstream_sop(left, "boolean", node_name)
-        created.setInput(1, right)
-        token = set_menu_parm_candidates(
-            created,
-            ("booleanop", "operation"),
-            _OPERATION_LABELS[operation],
-            ("Operation",),
-        )
-        readback = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified Boolean SOP",
-            inputs=[left.path(), right.path()],
-            node=node_summary(created),
-            parameters={"operation": operation, "operation_token": token},
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(left, "boolean", node_name))
+            created.setInput(1, right)
+            token = set_menu_parm_candidates(
+                created,
+                ("booleanop", "operation"),
+                _OPERATION_LABELS[operation],
+                ("Operation",),
+            )
+            readback = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified Boolean SOP",
+                inputs=[left.path(), right.path()],
+                node=node_summary(created),
+                parameters={"operation": operation, "operation_token": token},
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified Boolean SOP")
+        return sop_transaction_error("Failed to create verified Boolean SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/boolean_op.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/boolean_op.py
@@ -1,0 +1,90 @@
+"""Combine two SOP streams through a verified native Boolean SOP."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_menu_parm_candidates,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_OPERATION_LABELS = {
+    "union": ("union",),
+    "intersect": ("intersect", "intersection"),
+    "subtract": ("a minus b", "a-b", "subtract", "a subtract b"),
+}
+
+
+def boolean_op(
+    input_a: str,
+    input_b: str,
+    operation: str,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Apply a typed Boolean operation and verify its cooked result."""
+    if not isinstance(input_a, str) or not input_a:
+        return skill_error("Invalid Boolean input", "input_a must be a non-empty node path")
+    if not isinstance(input_b, str) or not input_b:
+        return skill_error("Invalid Boolean input", "input_b must be a non-empty node path")
+    if input_a == input_b:
+        return skill_error("Invalid Boolean inputs", "input_a and input_b must be different nodes")
+    if operation not in _OPERATION_LABELS:
+        return skill_error(
+            "Unsupported Boolean operation",
+            "operation must be one of: intersect, subtract, union",
+        )
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        left = get_node(hou, input_a)
+        right = get_node(hou, input_b)
+        if left.parent() is None or right.parent() is not left.parent():
+            raise ValueError("Boolean inputs must share one parent SOP network")
+        before = geometry_readback(left)
+        created = make_downstream_sop(left, "boolean", node_name)
+        created.setInput(1, right)
+        token = set_menu_parm_candidates(
+            created,
+            ("booleanop", "operation"),
+            _OPERATION_LABELS[operation],
+            ("Operation",),
+        )
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified Boolean SOP",
+            inputs=[left.path(), right.path()],
+            node=node_summary(created),
+            parameters={"operation": operation, "operation_token": token},
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified Boolean SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return boolean_op(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bridge_edges.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bridge_edges.py
@@ -11,8 +11,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_scalar_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def bridge_edges(
@@ -41,33 +43,30 @@ def bridge_edges(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "polybridge", node_name)
-        set_scalar_parm_verified(created, ("srcgroup",), source_group)
-        set_scalar_parm_verified(created, ("dstgroup",), destination_group)
-        set_scalar_parm_verified(created, ("divisions", "divs"), divisions, ("Divisions",))
-        readback = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified PolyBridge SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters={
-                "destination_group": destination_group,
-                "divisions": divisions,
-                "source_group": source_group,
-            },
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "polybridge", node_name))
+            set_scalar_parm_verified(created, ("srcgroup",), source_group)
+            set_scalar_parm_verified(created, ("dstgroup",), destination_group)
+            set_scalar_parm_verified(created, ("divisions", "divs"), divisions, ("Divisions",))
+            readback = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified PolyBridge SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters={
+                    "destination_group": destination_group,
+                    "divisions": divisions,
+                    "source_group": source_group,
+                },
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified PolyBridge SOP")
+        return sop_transaction_error("Failed to create verified PolyBridge SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bridge_edges.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/bridge_edges.py
@@ -1,0 +1,81 @@
+"""Bridge two named edge/face groups through a verified PolyBridge SOP."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_scalar_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def bridge_edges(
+    input_path: str,
+    source_group: str,
+    destination_group: str,
+    divisions: int = 1,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Append PolyBridge and verify its group/division and cooked readback."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty node path")
+    if not isinstance(source_group, str) or not source_group.strip():
+        return skill_error("Invalid source group", "source_group must be a non-empty selection")
+    if not isinstance(destination_group, str) or not destination_group.strip():
+        return skill_error("Invalid destination group", "destination_group must be a non-empty selection")
+    if source_group == destination_group:
+        return skill_error("Invalid bridge groups", "source and destination groups must differ")
+    if isinstance(divisions, bool) or not isinstance(divisions, int) or not 1 <= divisions <= 64:
+        return skill_error("Invalid bridge divisions", "divisions must be an integer from 1 through 64")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "polybridge", node_name)
+        set_scalar_parm_verified(created, ("srcgroup",), source_group)
+        set_scalar_parm_verified(created, ("dstgroup",), destination_group)
+        set_scalar_parm_verified(created, ("divisions", "divs"), divisions, ("Divisions",))
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified PolyBridge SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters={
+                "destination_group": destination_group,
+                "divisions": divisions,
+                "source_group": source_group,
+            },
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified PolyBridge SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return bridge_edges(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/convert_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/convert_geometry.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from _mesh_common import (  # noqa: E402
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_parm_if_exists,
+    sop_node_transaction,
+    sop_transaction_error,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 # Friendly target type -> convert SOP 'totype' menu token.
 _TO_TYPE = {
@@ -37,18 +44,22 @@ def convert_geometry(
             "to_type must be one of: {}".format(", ".join(sorted(set(_TO_TYPE)))),
             requested=to_type,
         )
+    created = None
     try:
         source = get_node(hou, input_path)
-        convert = make_downstream_sop(source, "convert", node_name)
-        set_parm_if_exists(convert, "totype", token)
-        return skill_success(
-            "Created convert SOP",
-            input_path=source.path(),
-            node=node_summary(convert),
-            to_type=token,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "convert", node_name))
+            set_parm_if_exists(created, "totype", token)
+            result = skill_success(
+                "Created convert SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                to_type=token,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create convert SOP")
+        return sop_transaction_error("Failed to create convert SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/extrude_faces.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/extrude_faces.py
@@ -12,8 +12,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_scalar_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 _LIMIT = 1_000_000.0
 _TOLERANCE = 1e-8
@@ -59,47 +61,44 @@ def extrude_faces(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "polyextrude", node_name)
-        requested = {
-            "group": group or "",
-            "distance": resolved_distance,
-            "inset": resolved_inset,
-        }
-        actual = {
-            "group": str(set_scalar_parm_verified(created, ("group",), requested["group"])),
-            "distance": float(
-                set_scalar_parm_verified(
-                    created,
-                    ("dist", "distance"),
-                    resolved_distance,
-                    ("Distance",),
-                )
-            ),
-            "inset": float(set_scalar_parm_verified(created, ("inset",), resolved_inset, ("Inset",))),
-        }
-        if actual["group"] != requested["group"] or any(
-            abs(actual[key] - requested[key]) > _TOLERANCE for key in ("distance", "inset")
-        ):
-            raise RuntimeError("PolyExtrude parameter readback did not match the request")
-        after = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified PolyExtrude SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters=requested,
-            readback=after,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "polyextrude", node_name))
+            requested = {
+                "group": group or "",
+                "distance": resolved_distance,
+                "inset": resolved_inset,
+            }
+            actual = {
+                "group": str(set_scalar_parm_verified(created, ("group",), requested["group"])),
+                "distance": float(
+                    set_scalar_parm_verified(
+                        created,
+                        ("dist", "distance"),
+                        resolved_distance,
+                        ("Distance",),
+                    )
+                ),
+                "inset": float(set_scalar_parm_verified(created, ("inset",), resolved_inset, ("Inset",))),
+            }
+            if actual["group"] != requested["group"] or any(
+                abs(actual[key] - requested[key]) > _TOLERANCE for key in ("distance", "inset")
+            ):
+                raise RuntimeError("PolyExtrude parameter readback did not match the request")
+            after = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified PolyExtrude SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters=requested,
+                readback=after,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified PolyExtrude SOP")
+        return sop_transaction_error("Failed to create verified PolyExtrude SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/extrude_faces.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/extrude_faces.py
@@ -1,0 +1,113 @@
+"""Append a verified PolyExtrude SOP for a primitive selection."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_scalar_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_LIMIT = 1_000_000.0
+_TOLERANCE = 1e-8
+
+
+def _number(value: object, name: str):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None, skill_error("Invalid extrusion", "{} must be numeric".format(name))
+    result = float(value)
+    if not math.isfinite(result) or abs(result) > _LIMIT:
+        return None, skill_error(
+            "Invalid extrusion",
+            "{} must be finite and within +/-{}".format(name, int(_LIMIT)),
+        )
+    return result, None
+
+
+def extrude_faces(
+    input_path: str,
+    group: Optional[str] = None,
+    distance: float = 0.0,
+    inset: float = 0.0,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Extrude selected primitives and verify the cooked SOP readback."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty string")
+    if group is not None and (not isinstance(group, str) or not group.strip()):
+        return skill_error("Invalid group", "group must be a non-empty string when provided")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+    resolved_distance, error = _number(distance, "distance")
+    if error:
+        return error
+    resolved_inset, error = _number(inset, "inset")
+    if error:
+        return error
+    if abs(resolved_distance) <= _TOLERANCE and abs(resolved_inset) <= _TOLERANCE:
+        return skill_error("Extrusion has no effect", "distance or inset must be non-zero")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "polyextrude", node_name)
+        requested = {
+            "group": group or "",
+            "distance": resolved_distance,
+            "inset": resolved_inset,
+        }
+        actual = {
+            "group": str(set_scalar_parm_verified(created, ("group",), requested["group"])),
+            "distance": float(
+                set_scalar_parm_verified(
+                    created,
+                    ("dist", "distance"),
+                    resolved_distance,
+                    ("Distance",),
+                )
+            ),
+            "inset": float(set_scalar_parm_verified(created, ("inset",), resolved_inset, ("Inset",))),
+        }
+        if actual["group"] != requested["group"] or any(
+            abs(actual[key] - requested[key]) > _TOLERANCE for key in ("distance", "inset")
+        ):
+            raise RuntimeError("PolyExtrude parameter readback did not match the request")
+        after = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified PolyExtrude SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters=requested,
+            readback=after,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified PolyExtrude SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return extrude_faces(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/group_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/group_geometry.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from _mesh_common import (  # noqa: E402
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_parm_if_exists,
+    sop_node_transaction,
+    sop_transaction_error,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 # groupcreate 'grouptype' menu indices.
 _GROUP_TYPE = {
@@ -30,26 +37,30 @@ def group_geometry(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
+    created = None
     try:
         source = get_node(hou, input_path)
-        group_node = make_downstream_sop(source, "groupcreate", node_name)
-        set_parm_if_exists(group_node, "groupname", group_name)
-        type_index = _GROUP_TYPE.get(group_type.lower())
-        if type_index is not None:
-            set_parm_if_exists(group_node, "grouptype", type_index)
-        if pattern:
-            # Enable base-group pattern selection when supported.
-            set_parm_if_exists(group_node, "groupbase", 1)
-            set_parm_if_exists(group_node, "basegroup", pattern)
-        return skill_success(
-            "Created group SOP",
-            input_path=source.path(),
-            node=node_summary(group_node),
-            group_name=group_name,
-            group_type=group_type.lower(),
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "groupcreate", node_name))
+            set_parm_if_exists(created, "groupname", group_name)
+            type_index = _GROUP_TYPE.get(group_type.lower())
+            if type_index is not None:
+                set_parm_if_exists(created, "grouptype", type_index)
+            if pattern:
+                # Enable base-group pattern selection when supported.
+                set_parm_if_exists(created, "groupbase", 1)
+                set_parm_if_exists(created, "basegroup", pattern)
+            result = skill_success(
+                "Created group SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                group_name=group_name,
+                group_type=group_type.lower(),
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create group SOP")
+        return sop_transaction_error("Failed to create group SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/inset.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/inset.py
@@ -1,0 +1,35 @@
+"""Inset selected primitives through the verified PolyExtrude path."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dcc_mcp_core.skill import skill_entry
+from extrude_faces import extrude_faces  # noqa: E402
+
+
+def inset(
+    input_path: str,
+    amount: float,
+    group: Optional[str] = None,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Inset selected primitives without exposing raw HOM execution."""
+    return extrude_faces(
+        input_path=input_path,
+        group=group,
+        distance=0.0,
+        inset=amount,
+        node_name=node_name,
+    )
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return inset(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/lathe_profile.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/lathe_profile.py
@@ -13,8 +13,10 @@ from _mesh_common import (  # noqa: E402
     node_summary,
     set_scalar_parm_verified,
     set_tuple_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 _AXES = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
 
@@ -54,34 +56,31 @@ def lathe_profile(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, profile)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "revolve", node_name)
-        origin_values = set_tuple_parm_verified(created, ("origin",), tuple(resolved_origin), ("Origin",))
-        direction_values = set_tuple_parm_verified(created, ("dir",), _AXES[axis], ("Axis Direction",))
-        set_scalar_parm_verified(created, ("divs",), segments, ("Divisions",))
-        readback = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified Revolve SOP",
-            profile=source.path(),
-            node=node_summary(created),
-            parameters={
-                "axis": axis,
-                "axis_direction": list(direction_values),
-                "origin": list(origin_values),
-                "segments": segments,
-            },
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "revolve", node_name))
+            origin_values = set_tuple_parm_verified(created, ("origin",), tuple(resolved_origin), ("Origin",))
+            direction_values = set_tuple_parm_verified(created, ("dir",), _AXES[axis], ("Axis Direction",))
+            set_scalar_parm_verified(created, ("divs",), segments, ("Divisions",))
+            readback = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified Revolve SOP",
+                profile=source.path(),
+                node=node_summary(created),
+                parameters={
+                    "axis": axis,
+                    "axis_direction": list(direction_values),
+                    "origin": list(origin_values),
+                    "segments": segments,
+                },
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified Revolve SOP")
+        return sop_transaction_error("Failed to create verified Revolve SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/lathe_profile.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/lathe_profile.py
@@ -1,0 +1,95 @@
+"""Revolve a profile through a verified native Revolve SOP."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_scalar_parm_verified,
+    set_tuple_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_AXES = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
+
+
+def lathe_profile(
+    profile: str,
+    axis: str = "y",
+    origin: Optional[List[float]] = None,
+    segments: int = 32,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Revolve one curve/profile SOP and verify parameter and geometry readback."""
+    if not isinstance(profile, str) or not profile:
+        return skill_error("Invalid lathe profile", "profile must be a non-empty node path")
+    if axis not in _AXES:
+        return skill_error("Invalid lathe axis", "axis must be one of: x, y, z")
+    resolved_origin = origin if origin is not None else [0.0, 0.0, 0.0]
+    if (
+        not isinstance(resolved_origin, (list, tuple))
+        or len(resolved_origin) != 3
+        or any(
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or abs(float(value)) > 1_000_000.0
+            for value in resolved_origin
+        )
+    ):
+        return skill_error("Invalid lathe origin", "origin must contain three bounded finite numbers")
+    if isinstance(segments, bool) or not isinstance(segments, int) or not 3 <= segments <= 256:
+        return skill_error("Invalid lathe segments", "segments must be an integer from 3 through 256")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, profile)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "revolve", node_name)
+        origin_values = set_tuple_parm_verified(created, ("origin",), tuple(resolved_origin), ("Origin",))
+        direction_values = set_tuple_parm_verified(created, ("dir",), _AXES[axis], ("Axis Direction",))
+        set_scalar_parm_verified(created, ("divs",), segments, ("Divisions",))
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified Revolve SOP",
+            profile=source.path(),
+            node=node_summary(created),
+            parameters={
+                "axis": axis,
+                "axis_direction": list(direction_values),
+                "origin": list(origin_values),
+                "segments": segments,
+            },
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified Revolve SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return lathe_profile(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/loft_sections.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/loft_sections.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from _mesh_common import cook_readback, geometry_readback, get_node, node_summary  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def loft_sections(sections: List[str], node_name: Optional[str] = None) -> dict:
@@ -24,7 +24,7 @@ def loft_sections(sections: List[str], node_name: Optional[str] = None) -> dict:
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
+    created = []
     try:
         sources = [get_node(hou, path) for path in sections]
         parent = sources[0].parent()
@@ -33,27 +33,40 @@ def loft_sections(sections: List[str], node_name: Optional[str] = None) -> dict:
         if any(source.parent() is not parent for source in sources[1:]):
             raise ValueError("All loft sections must share one parent SOP network")
         before = geometry_readback(sources[0])
-        created = parent.createNode("skin", node_name=node_name)
+        merge = parent.createNode("merge")
+        created.append(merge)
         for index, source in enumerate(sources):
-            created.setInput(index, source)
-        if hasattr(created, "moveToGoodPosition"):
-            created.moveToGoodPosition()
-        if hasattr(created, "setDisplayFlag"):
-            created.setDisplayFlag(True)
-        readback = cook_readback(created, before=before)
+            merge.setInput(index, source)
+        if hasattr(merge, "moveToGoodPosition"):
+            merge.moveToGoodPosition()
+        merge_readback = cook_readback(merge, require_change=False)
+
+        skin = parent.createNode("skin", node_name=node_name)
+        created.append(skin)
+        skin.setInput(0, merge)
+        if hasattr(skin, "moveToGoodPosition"):
+            skin.moveToGoodPosition()
+        if hasattr(skin, "setDisplayFlag"):
+            skin.setDisplayFlag(True)
+        readback = cook_readback(skin, before=before)
+        readback["merge"] = merge_readback
         return skill_success(
             "Created and verified Skin SOP loft",
             sections=[source.path() for source in sources],
-            node=node_summary(created),
+            merge_node=node_summary(merge),
+            node=node_summary(skin),
             readback=readback,
         )
-    except Exception as exc:
-        if created is not None:
+    except Exception:  # noqa: BLE001
+        for node in reversed(created):
             try:
-                created.destroy()
+                node.destroy()
             except Exception:  # noqa: BLE001
                 pass
-        return skill_exception(exc, message="Failed to create verified Skin SOP loft")
+        return skill_error(
+            "Failed to create verified Skin SOP loft",
+            "Houdini rejected the bounded loft transaction",
+        )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/loft_sections.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/loft_sections.py
@@ -1,0 +1,67 @@
+"""Loft ordered cross-section SOPs through a verified Skin SOP."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from _mesh_common import cook_readback, geometry_readback, get_node, node_summary  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def loft_sections(sections: List[str], node_name: Optional[str] = None) -> dict:
+    """Connect ordered section SOPs to Skin and verify cooked output."""
+    if not isinstance(sections, list) or not 2 <= len(sections) <= 64:
+        return skill_error("Invalid loft sections", "sections must contain 2 through 64 node paths")
+    if any(not isinstance(path, str) or not path for path in sections):
+        return skill_error("Invalid loft sections", "every section must be a non-empty node path")
+    if len(set(sections)) != len(sections):
+        return skill_error("Invalid loft sections", "section node paths must be unique")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        sources = [get_node(hou, path) for path in sections]
+        parent = sources[0].parent()
+        if parent is None:
+            raise ValueError("First loft section has no parent SOP network")
+        if any(source.parent() is not parent for source in sources[1:]):
+            raise ValueError("All loft sections must share one parent SOP network")
+        before = geometry_readback(sources[0])
+        created = parent.createNode("skin", node_name=node_name)
+        for index, source in enumerate(sources):
+            created.setInput(index, source)
+        if hasattr(created, "moveToGoodPosition"):
+            created.moveToGoodPosition()
+        if hasattr(created, "setDisplayFlag"):
+            created.setDisplayFlag(True)
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified Skin SOP loft",
+            sections=[source.path() for source in sources],
+            node=node_summary(created),
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified Skin SOP loft")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return loft_sections(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/mirror.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/mirror.py
@@ -1,0 +1,97 @@
+"""Mirror geometry through a verified native Mirror SOP."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_tuple_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def _vector(value: object, name: str):
+    if (
+        not isinstance(value, (list, tuple))
+        or len(value) != 3
+        or any(
+            isinstance(component, bool)
+            or not isinstance(component, (int, float))
+            or not math.isfinite(float(component))
+            or abs(float(component)) > 1_000_000.0
+            for component in value
+        )
+    ):
+        return None, skill_error("Invalid mirror vector", "{} must contain three bounded finite numbers".format(name))
+    return tuple(float(component) for component in value), None
+
+
+def mirror(
+    input_path: str,
+    origin: Optional[List[float]] = None,
+    direction: Optional[List[float]] = None,
+    node_name: Optional[str] = None,
+) -> dict:
+    """Append Mirror, set its plane, and verify cooked geometry."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty node path")
+    resolved_origin, error = _vector(origin or [0.0, 0.0, 0.0], "origin")
+    if error:
+        return error
+    resolved_direction, error = _vector(direction or [1.0, 0.0, 0.0], "direction")
+    if error:
+        return error
+    if sum(component * component for component in resolved_direction) <= 1e-16:
+        return skill_error("Invalid mirror direction", "direction must be non-zero")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "mirror", node_name)
+        actual_origin = set_tuple_parm_verified(created, ("origin",), resolved_origin, ("Origin",))
+        actual_direction = set_tuple_parm_verified(
+            created,
+            ("dir",),
+            resolved_direction,
+            ("Direction",),
+        )
+        readback = cook_readback(created, before=before)
+        return skill_success(
+            "Created and verified Mirror SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters={"direction": list(actual_direction), "origin": list(actual_origin)},
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified Mirror SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return mirror(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/mirror.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/mirror.py
@@ -12,8 +12,10 @@ from _mesh_common import (  # noqa: E402
     make_downstream_sop,
     node_summary,
     set_tuple_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def _vector(value: object, name: str):
@@ -57,33 +59,30 @@ def mirror(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "mirror", node_name)
-        actual_origin = set_tuple_parm_verified(created, ("origin",), resolved_origin, ("Origin",))
-        actual_direction = set_tuple_parm_verified(
-            created,
-            ("dir",),
-            resolved_direction,
-            ("Direction",),
-        )
-        readback = cook_readback(created, before=before)
-        return skill_success(
-            "Created and verified Mirror SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters={"direction": list(actual_direction), "origin": list(actual_origin)},
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "mirror", node_name))
+            actual_origin = set_tuple_parm_verified(created, ("origin",), resolved_origin, ("Origin",))
+            actual_direction = set_tuple_parm_verified(
+                created,
+                ("dir",),
+                resolved_direction,
+                ("Direction",),
+            )
+            readback = cook_readback(created, before=before)
+            result = skill_success(
+                "Created and verified Mirror SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters={"direction": list(actual_direction), "origin": list(actual_origin)},
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified Mirror SOP")
+        return sop_transaction_error("Failed to create verified Mirror SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/transform_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/transform_geometry.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from _mesh_common import (  # noqa: E402
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_parm_if_exists,
+    sop_node_transaction,
+    sop_transaction_error,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def transform_geometry(
@@ -21,24 +28,28 @@ def transform_geometry(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
+    created = None
     try:
         source = get_node(hou, input_path)
-        xform = make_downstream_sop(source, "xform", node_name)
-        applied = {}
-        if translate is not None and set_parm_if_exists(xform, "t", translate):
-            applied["t"] = list(translate)
-        if rotate is not None and set_parm_if_exists(xform, "r", rotate):
-            applied["r"] = list(rotate)
-        if scale is not None and set_parm_if_exists(xform, "s", scale):
-            applied["s"] = list(scale)
-        return skill_success(
-            "Created transform SOP",
-            input_path=source.path(),
-            node=node_summary(xform),
-            applied=applied,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "xform", node_name))
+            applied = {}
+            if translate is not None and set_parm_if_exists(created, "t", translate):
+                applied["t"] = list(translate)
+            if rotate is not None and set_parm_if_exists(created, "r", rotate):
+                applied["r"] = list(rotate)
+            if scale is not None and set_parm_if_exists(created, "s", scale):
+                applied["s"] = list(scale)
+            result = skill_success(
+                "Created transform SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                applied=applied,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create transform SOP")
+        return sop_transaction_error("Failed to create transform SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/triangulate_geometry.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/triangulate_geometry.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Optional
 
-from _mesh_common import get_node, make_downstream_sop, node_summary, set_parm_if_exists  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from _mesh_common import (  # noqa: E402
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_parm_if_exists,
+    sop_node_transaction,
+    sop_transaction_error,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 
 def triangulate_geometry(input_path: str, node_name: Optional[str] = None) -> dict:
@@ -15,19 +22,23 @@ def triangulate_geometry(input_path: str, node_name: Optional[str] = None) -> di
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
+    created = None
     try:
         source = get_node(hou, input_path)
-        divide = make_downstream_sop(source, "divide", node_name)
-        # Convex polygons into triangles (max 3 sides).
-        set_parm_if_exists(divide, "convex", 1)
-        set_parm_if_exists(divide, "numsides", 3)
-        return skill_success(
-            "Created triangulate (divide) SOP",
-            input_path=source.path(),
-            node=node_summary(divide),
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "divide", node_name))
+            # Convex polygons into triangles (max 3 sides).
+            set_parm_if_exists(created, "convex", 1)
+            set_parm_if_exists(created, "numsides", 3)
+            result = skill_success(
+                "Created triangulate (divide) SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        return skill_exception(exc, message="Failed to create triangulate SOP")
+        return sop_transaction_error("Failed to create triangulate SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/uv_project.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/uv_project.py
@@ -1,0 +1,94 @@
+"""Project UVs through a verified native UV Project SOP."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from _mesh_common import (  # noqa: E402
+    cook_readback,
+    geometry_readback,
+    get_node,
+    make_downstream_sop,
+    node_summary,
+    set_menu_parm,
+    set_scalar_parm_verified,
+)
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_ATTRIBUTE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROJECTION_LABELS = {
+    "planar": ("orthographic", "planar"),
+    "cylindrical": ("cylindrical", "cylinder"),
+    "spherical": ("spherical", "sphere"),
+}
+
+
+def uv_project(
+    input_path: str,
+    projection: str = "planar",
+    group: Optional[str] = None,
+    uv_attribute: str = "uv",
+    node_name: Optional[str] = None,
+) -> dict:
+    """Append UV Project and verify the requested vertex UV attribute exists."""
+    if not isinstance(input_path, str) or not input_path:
+        return skill_error("Invalid input", "input_path must be a non-empty node path")
+    if projection not in _PROJECTION_LABELS:
+        return skill_error("Invalid UV projection", "projection must be planar, cylindrical, or spherical")
+    if group is not None and (not isinstance(group, str) or not group.strip()):
+        return skill_error("Invalid UV group", "group must be a non-empty selection when provided")
+    if not isinstance(uv_attribute, str) or not _ATTRIBUTE_NAME.fullmatch(uv_attribute):
+        return skill_error("Invalid UV attribute", "uv_attribute must be a valid Houdini attribute name")
+    if node_name is not None and (not isinstance(node_name, str) or not node_name):
+        return skill_error("Invalid node name", "node_name must be a non-empty string when provided")
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    created = None
+    try:
+        source = get_node(hou, input_path)
+        before = geometry_readback(source)
+        created = make_downstream_sop(source, "uvproject", node_name)
+        set_scalar_parm_verified(created, ("uvattrib",), uv_attribute, ("UV Attribute",))
+        if group is not None:
+            set_scalar_parm_verified(created, ("group",), group, ("Group",))
+        token = set_menu_parm(created, "projection", _PROJECTION_LABELS[projection])
+        readback = cook_readback(created, before=before, require_change=False)
+        geometry = created.geometry()
+        if geometry.findVertexAttrib(uv_attribute) is None:
+            raise RuntimeError("UV Project did not create vertex attribute: {}".format(uv_attribute))
+        readback["uv_attribute"] = uv_attribute
+        return skill_success(
+            "Created and verified UV Project SOP",
+            input_path=source.path(),
+            node=node_summary(created),
+            parameters={
+                "group": group or "",
+                "projection": projection,
+                "projection_token": token,
+                "uv_attribute": uv_attribute,
+            },
+            readback=readback,
+        )
+    except Exception as exc:
+        if created is not None:
+            try:
+                created.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to create verified UV Project SOP")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return uv_project(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/uv_project.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/uv_project.py
@@ -13,8 +13,10 @@ from _mesh_common import (  # noqa: E402
     node_summary,
     set_menu_parm,
     set_scalar_parm_verified,
+    sop_node_transaction,
+    sop_transaction_error,
 )
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
 _ATTRIBUTE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _PROJECTION_LABELS = {
@@ -48,39 +50,36 @@ def uv_project(
     except ImportError:
         return skill_error("Houdini not available", "hou could not be imported")
 
-    created = None
     try:
         source = get_node(hou, input_path)
         before = geometry_readback(source)
-        created = make_downstream_sop(source, "uvproject", node_name)
-        set_scalar_parm_verified(created, ("uvattrib",), uv_attribute, ("UV Attribute",))
-        if group is not None:
-            set_scalar_parm_verified(created, ("group",), group, ("Group",))
-        token = set_menu_parm(created, "projection", _PROJECTION_LABELS[projection])
-        readback = cook_readback(created, before=before, require_change=False)
-        geometry = created.geometry()
-        if geometry.findVertexAttrib(uv_attribute) is None:
-            raise RuntimeError("UV Project did not create vertex attribute: {}".format(uv_attribute))
-        readback["uv_attribute"] = uv_attribute
-        return skill_success(
-            "Created and verified UV Project SOP",
-            input_path=source.path(),
-            node=node_summary(created),
-            parameters={
-                "group": group or "",
-                "projection": projection,
-                "projection_token": token,
-                "uv_attribute": uv_attribute,
-            },
-            readback=readback,
-        )
+        with sop_node_transaction() as transaction:
+            created = transaction.own(make_downstream_sop(source, "uvproject", node_name))
+            set_scalar_parm_verified(created, ("uvattrib",), uv_attribute, ("UV Attribute",))
+            if group is not None:
+                set_scalar_parm_verified(created, ("group",), group, ("Group",))
+            token = set_menu_parm(created, "projection", _PROJECTION_LABELS[projection])
+            readback = cook_readback(created, before=before, require_change=False)
+            geometry = created.geometry()
+            if geometry.findVertexAttrib(uv_attribute) is None:
+                raise RuntimeError("UV Project did not create the requested vertex attribute")
+            readback["uv_attribute"] = uv_attribute
+            result = skill_success(
+                "Created and verified UV Project SOP",
+                input_path=source.path(),
+                node=node_summary(created),
+                parameters={
+                    "group": group or "",
+                    "projection": projection,
+                    "projection_token": token,
+                    "uv_attribute": uv_attribute,
+                },
+                readback=readback,
+            )
+            transaction.commit()
+        return result
     except Exception as exc:
-        if created is not None:
-            try:
-                created.destroy()
-            except Exception:  # noqa: BLE001
-                pass
-        return skill_exception(exc, message="Failed to create verified UV Project SOP")
+        return sop_transaction_error("Failed to create verified UV Project SOP", exc)
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/tools.yaml
@@ -1,4 +1,467 @@
 tools:
+  - name: array_instances
+    description: >-
+      Create a bounded radial point ring and instance an input SOP with native
+      Circle and Copy to Points SOPs, with parameter and cooked readback.
+    source_file: scripts/array_instances.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path, count, radius]
+      properties:
+        input_path: {type: string, minLength: 1}
+        count: {type: integer, minimum: 2, maximum: 128}
+        radius: {type: number, exclusiveMinimum: 0, maximum: 1000000}
+        axis: {type: string, enum: [x, y, z], default: y}
+        node_name: {type: string, minLength: 1}
+        points_node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, points_node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        points_node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: uv_project
+    description: >-
+      Project vertex UVs with a native UV Project SOP and verify that the
+      requested UV attribute exists on the cooked result.
+    source_file: scripts/uv_project.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path]
+      properties:
+        input_path: {type: string, minLength: 1}
+        projection: {type: string, enum: [planar, cylindrical, spherical], default: planar}
+        group: {type: string, minLength: 1}
+        uv_attribute: {type: string, pattern: "^[A-Za-z_][A-Za-z0-9_]*$", default: uv}
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__list_attributes]
+  - name: auto_uv
+    description: >-
+      Generate vertex UVs with a native UV Unwrap SOP and verify that the
+      requested UV attribute exists on the cooked result.
+    source_file: scripts/auto_uv.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path]
+      properties:
+        input_path: {type: string, minLength: 1}
+        group: {type: string, minLength: 1}
+        uv_attribute: {type: string, pattern: "^[A-Za-z_][A-Za-z0-9_]*$", default: uv}
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__list_attributes]
+  - name: mirror
+    description: >-
+      Mirror a polygon SOP across an explicit plane and verify parameter plus
+      cooked geometry readback.
+    source_file: scripts/mirror.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path]
+      properties:
+        input_path: {type: string, minLength: 1}
+        origin:
+          type: array
+          items: {type: number, minimum: -1000000, maximum: 1000000}
+          minItems: 3
+          maxItems: 3
+        direction:
+          type: array
+          items: {type: number, minimum: -1000000, maximum: 1000000}
+          minItems: 3
+          maxItems: 3
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: bridge_edges
+    description: >-
+      Bridge two explicit edge or face selections with a native PolyBridge SOP
+      and verify the requested parameters plus cooked output.
+    source_file: scripts/bridge_edges.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path, source_group, destination_group]
+      properties:
+        input_path: {type: string, minLength: 1}
+        source_group: {type: string, minLength: 1}
+        destination_group: {type: string, minLength: 1}
+        divisions: {type: integer, minimum: 1, maximum: 64, default: 1}
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: add_edge_loop
+    description: >-
+      Apply an explicit bounded PolySplit location string and verify the cooked
+      topology before success.
+    source_file: scripts/add_edge_loop.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path, split_locations]
+      properties:
+        input_path: {type: string, minLength: 1}
+        split_locations: {type: string, minLength: 1, maxLength: 4096}
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: lathe_profile
+    description: >-
+      Revolve a profile SOP around a typed axis with bounded segments and
+      verified parameter plus cooked geometry readback.
+    source_file: scripts/lathe_profile.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [profile]
+      properties:
+        profile: {type: string, minLength: 1}
+        axis: {type: string, enum: [x, y, z], default: y}
+        origin:
+          type: array
+          items: {type: number, minimum: -1000000, maximum: 1000000}
+          minItems: 3
+          maxItems: 3
+        segments: {type: integer, minimum: 3, maximum: 256, default: 32}
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [profile, node, parameters, readback]
+      properties:
+        profile: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: boolean_op
+    description: >-
+      Combine two polygon SOP streams using a native Boolean SOP. The operation
+      is resolved from Houdini's menu labels and verified before success.
+    source_file: scripts/boolean_op.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_a, input_b, operation]
+      properties:
+        input_a: {type: string, minLength: 1}
+        input_b: {type: string, minLength: 1}
+        operation: {type: string, enum: [union, intersect, subtract]}
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [inputs, node, parameters, readback]
+      properties:
+        inputs: {type: array, items: {type: string}}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: loft_sections
+    description: >-
+      Loft two to sixty-four ordered section SOPs with a Skin SOP, requiring a
+      shared parent network and returning cooked geometry readback.
+    source_file: scripts/loft_sections.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [sections]
+      properties:
+        sections:
+          type: array
+          items: {type: string, minLength: 1}
+          minItems: 2
+          maxItems: 64
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [sections, node, readback]
+      properties:
+        sections: {type: array, items: {type: string}}
+        node: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: inset
+    description: >-
+      Inset a bounded primitive selection through the verified PolyExtrude
+      path, with no raw scripting fallback.
+    source_file: scripts/inset.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path, amount]
+      properties:
+        input_path: {type: string, minLength: 1}
+        group: {type: string, minLength: 1}
+        amount:
+          type: number
+          minimum: -1000000
+          maximum: 1000000
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: bevel_edges
+    description: >-
+      Append a PolyBevel SOP for a bounded edge selection and verify the
+      requested bevel parameters plus cooked geometry before reporting success.
+    source_file: scripts/bevel_edges.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path, group, distance]
+      properties:
+        input_path: {type: string, minLength: 1}
+        group:
+          type: string
+          minLength: 1
+          description: Edge group name or bounded edge selection pattern.
+        distance:
+          type: number
+          exclusiveMinimum: 0
+          maximum: 1000000
+        divisions:
+          type: integer
+          minimum: 1
+          maximum: 64
+          default: 1
+        node_name: {type: string, minLength: 1}
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback: {type: object}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
+  - name: extrude_faces
+    description: >-
+      Append a PolyExtrude SOP for a bounded primitive selection and return
+      parameter plus cooked-geometry readback; fail if Houdini reports no effect.
+    source_file: scripts/extrude_faces.py
+    execution: sync
+    affinity: main
+    group: modeling
+    read_only: false
+    destructive: false
+    idempotent: false
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: false
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [input_path]
+      properties:
+        input_path:
+          type: string
+          minLength: 1
+          description: Upstream polygon SOP node path.
+        group:
+          type: string
+          description: Optional primitive group name or bounded selection pattern.
+        distance:
+          type: number
+          minimum: -1000000
+          maximum: 1000000
+          default: 0.0
+        inset:
+          type: number
+          minimum: -1000000
+          maximum: 1000000
+          default: 0.0
+        node_name:
+          type: string
+          minLength: 1
+    output_schema:
+      type: object
+      required: [input_path, node, parameters, readback]
+      properties:
+        input_path: {type: string}
+        node: {type: object}
+        parameters: {type: object}
+        readback:
+          type: object
+          required: [verified, point_count, primitive_count, vertex_count]
+          properties:
+            verified: {type: boolean}
+            point_count: {type: integer, minimum: 0}
+            primitive_count: {type: integer, minimum: 0}
+            vertex_count: {type: integer, minimum: 0}
+    next-tools:
+      on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
   - name: transform_geometry
     description: >-
       Append a Transform (xform) SOP downstream of an input SOP and set

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/tools.yaml
@@ -1,8 +1,9 @@
 tools:
   - name: array_instances
     description: >-
-      Create a bounded radial point ring and instance an input SOP with native
-      Circle and Copy to Points SOPs, with parameter and cooked readback.
+      Create a bounded radial point ring, orient every point radially or
+      tangentially from a declared source-forward axis, and instance an input
+      SOP with native Circle, Attribute Wrangle, and Copy to Points SOPs.
     source_file: scripts/array_instances.py
     execution: sync
     affinity: main
@@ -23,15 +24,19 @@ tools:
         count: {type: integer, minimum: 2, maximum: 128}
         radius: {type: number, exclusiveMinimum: 0, maximum: 1000000}
         axis: {type: string, enum: [x, y, z], default: y}
+        start_angle_degrees: {type: number, minimum: -360000, maximum: 360000, default: 0}
+        direction_mode: {type: string, enum: [radial, tangent], default: radial}
+        source_forward: {type: string, enum: ["+x", "-x", "+y", "-y", "+z", "-z"], default: "+x"}
         node_name: {type: string, minLength: 1}
         points_node_name: {type: string, minLength: 1}
     output_schema:
       type: object
-      required: [input_path, node, points_node, parameters, readback]
+      required: [input_path, node, points_node, orientation_node, parameters, readback]
       properties:
         input_path: {type: string}
         node: {type: object}
         points_node: {type: object}
+        orientation_node: {type: object}
         parameters: {type: object}
         readback: {type: object}
     next-tools:
@@ -290,8 +295,8 @@ tools:
       on-failure: [houdini_geometry__get_cook_status, houdini_geometry__get_geometry_info]
   - name: loft_sections
     description: >-
-      Loft two to sixty-four ordered section SOPs with a Skin SOP, requiring a
-      shared parent network and returning cooked geometry readback.
+      Merge two to sixty-four ordered section SOPs into Skin input zero for a
+      linear loft, requiring a shared parent network and cooked readback.
     source_file: scripts/loft_sections.py
     execution: sync
     affinity: main
@@ -316,9 +321,10 @@ tools:
         node_name: {type: string, minLength: 1}
     output_schema:
       type: object
-      required: [sections, node, readback]
+      required: [sections, merge_node, node, readback]
       properties:
         sections: {type: array, items: {type: string}}
+        merge_node: {type: object}
         node: {type: object}
         readback: {type: object}
     next-tools:

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/SKILL.md
@@ -3,7 +3,7 @@ name: houdini-object-ops
 description: >-
   Authoring skill — object-level Houdini mutations: rename, duplicate, reparent,
   set display/render/template/bypass flags, hard-lock/unlock, and read/set
-  translate-rotate-scale transforms. Use these typed tools instead of arbitrary
+  pivot and translate-rotate-scale transforms. Use these typed tools instead of arbitrary
   Python for editing existing nodes. Not for creating nodes (use houdini-nodes)
   or scene lifecycle/selection (use houdini-scene-edit).
 license: MIT
@@ -14,9 +14,9 @@ metadata:
     dcc: houdini
     layer: domain
     stage: authoring
-    version: "1.0.0"
-    tags: [houdini, object, transform, rename, parent, flags, authoring]
-    search-hint: "rename node, duplicate node, reparent, move node, set flags, lock node, get transform, set transform, translate rotate scale"
+    version: "1.1.0"
+    tags: [houdini, object, transform, pivot, rename, parent, flags, authoring]
+    search-hint: "rename node, duplicate node, reparent, move node, set flags, lock node, get transform, set transform, set pivot, translate rotate scale"
     tools: tools.yaml
 ---
 
@@ -30,13 +30,13 @@ editing nodes that already exist.
 
 - **`object-edit`:** `rename_node`, `duplicate_node`, `parent_node`,
   `set_node_flags`, `set_node_lock`.
-- **`object-transform`:** `get_transform`, `set_transform` (operate on OBJ-level
-  `t`/`r`/`s` parm tuples).
+- **`object-transform`:** `get_transform`, `set_transform`, `set_pivot` (operate
+  on OBJ-level `t`/`r`/`s` and `p` parm tuples with exact pivot readback).
 
 ## Suggested flow
 
 1. Find/select with `houdini-scene-edit` (`find_nodes` → `set_selection`)
-2. `get_transform` → `set_transform` to position an object
+2. `get_transform` → `set_transform` / `set_pivot` to position an object
 3. `set_node_flags` / `set_node_lock` to control display and freeze state
 
 For creating new nodes use `houdini-nodes`. On failure, load `houdini-scripting`

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_pivot.py
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/scripts/set_pivot.py
@@ -1,0 +1,71 @@
+"""Set and verify the local pivot of a Houdini OBJ node."""
+
+from __future__ import annotations
+
+import math
+from typing import List
+
+from _object_common import get_node  # noqa: E402
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+
+def set_pivot(node_path: str, position: List[float]) -> dict:
+    """Set the ``p`` parm tuple and return exact readback."""
+    if not isinstance(node_path, str) or not node_path:
+        return skill_error("Invalid node", "node_path must be a non-empty string")
+    if (
+        not isinstance(position, (list, tuple))
+        or len(position) != 3
+        or any(
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or abs(float(value)) > 1_000_000.0
+            for value in position
+        )
+    ):
+        return skill_error("Invalid pivot", "position must contain three bounded finite numbers")
+    requested = tuple(float(value) for value in position)
+
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+
+    parm_tuple = None
+    previous = None
+    try:
+        node = get_node(hou, node_path)
+        parm_tuple = node.parmTuple("p")
+        if parm_tuple is None:
+            raise ValueError("Node has no local pivot parameter tuple: {}".format(node.path()))
+        previous = tuple(float(value) for value in parm_tuple.eval())
+        parm_tuple.set(requested)
+        actual = tuple(float(value) for value in parm_tuple.eval())
+        if len(actual) != 3 or any(abs(actual[index] - requested[index]) > 1e-8 for index in range(3)):
+            raise RuntimeError("Pivot parameter readback did not match the request")
+        values = list(actual)
+        return skill_success(
+            "Set and verified pivot",
+            node_path=node.path(),
+            position=values,
+            readback={"pivot": values, "verified": True},
+        )
+    except Exception as exc:
+        if parm_tuple is not None and previous is not None:
+            try:
+                parm_tuple.set(previous)
+            except Exception:  # noqa: BLE001
+                pass
+        return skill_exception(exc, message="Failed to set and verify pivot")
+
+
+@skill_entry
+def main(**kwargs) -> dict:
+    return set_pivot(**kwargs)
+
+
+if __name__ == "__main__":
+    from dcc_mcp_core.skill import run_main
+
+    run_main(main)

--- a/src/dcc_mcp_houdini/skills/houdini-object-ops/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-object-ops/tools.yaml
@@ -1,4 +1,37 @@
 tools:
+  - name: set_pivot
+    description: >-
+      Set the local pivot tuple of an OBJ node and verify exact parameter
+      readback, restoring the previous value if verification fails.
+    source_file: scripts/set_pivot.py
+    execution: sync
+    affinity: main
+    group: object-transform
+    read_only: false
+    destructive: false
+    idempotent: true
+    annotations:
+      read_only_hint: false
+      destructive_hint: false
+      idempotent_hint: true
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_path, position]
+      properties:
+        node_path: {type: string, minLength: 1}
+        position:
+          type: array
+          items: {type: number, minimum: -1000000, maximum: 1000000}
+          minItems: 3
+          maxItems: 3
+    output_schema:
+      type: object
+      required: [node_path, position, readback]
+      properties:
+        node_path: {type: string}
+        position: {type: array, items: {type: number}}
+        readback: {type: object}
   - name: rename_node
     description: >-
       Rename a node, optionally enforcing a unique name within its parent.

--- a/tests/test_mesh_sop_transactions.py
+++ b/tests/test_mesh_sop_transactions.py
@@ -1,0 +1,203 @@
+"""Strict ownership and public-error contracts for downstream SOP callers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+from skill_loader import skill_script_import_context
+
+_SCRIPT_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills" / "houdini-mesh-ops" / "scripts"
+_PRIVATE_TOKENS = (
+    "PRIVATE_POST_TRANSFER_PARAMETER_FAILURE",
+    "C:\\Users\\private\\shot.hip",
+    "relative/private/report.json",
+)
+
+
+def _load_script(script_name: str) -> ModuleType:
+    path = _SCRIPT_ROOT / script_name
+    spec = importlib.util.spec_from_file_location("transaction_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _wire_downstream(optype: str):
+    parent = MagicMock()
+    parent.path.return_value = "/obj/geo1"
+    created = MagicMock()
+    created.path.return_value = "/obj/geo1/{}1".format(optype)
+    created.name.return_value = "{}1".format(optype)
+    created.type.return_value.name.return_value = optype
+    created.parmTuple.return_value = None
+    created.parm.return_value = MagicMock()
+    parent.createNode.return_value = created
+    source = MagicMock()
+    source.path.return_value = "/obj/geo1/source"
+    source.parent.return_value = parent
+    hou = MagicMock()
+    hou.node.return_value = source
+    return hou, created
+
+
+def _assert_safe_failure(result: dict) -> None:
+    assert result["success"] is False
+    payload = json.dumps(result, sort_keys=True)
+    assert "traceback" not in payload.lower()
+    for token in _PRIVATE_TOKENS:
+        assert token not in payload
+    assert result["context"]["error_code"] == "houdini_sop_transaction_failed"
+    assert result["context"]["error_type"] == "RuntimeError"
+
+
+_POST_TRANSFER_CASES = (
+    ("add_normals.py", "add_normals", "normal", {"input_path": "/obj/geo1/source"}, "set_parm_if_exists"),
+    (
+        "blast_geometry.py",
+        "blast_geometry",
+        "blast",
+        {"input_path": "/obj/geo1/source", "group": "0-5"},
+        "set_parm_if_exists",
+    ),
+    (
+        "convert_geometry.py",
+        "convert_geometry",
+        "convert",
+        {"input_path": "/obj/geo1/source"},
+        "skill_success",
+    ),
+    (
+        "group_geometry.py",
+        "group_geometry",
+        "groupcreate",
+        {"input_path": "/obj/geo1/source", "group_name": "top"},
+        "node_summary",
+    ),
+    (
+        "transform_geometry.py",
+        "transform_geometry",
+        "xform",
+        {"input_path": "/obj/geo1/source", "translate": [1.0, 2.0, 3.0]},
+        "set_parm_if_exists",
+    ),
+    (
+        "triangulate_geometry.py",
+        "triangulate_geometry",
+        "divide",
+        {"input_path": "/obj/geo1/source"},
+        "node_summary",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("script_name", "function_name", "optype", "kwargs", "failure_target"),
+    _POST_TRANSFER_CASES,
+)
+def test_legacy_downstream_callers_rollback_and_redact_every_post_transfer_failure(
+    script_name: str,
+    function_name: str,
+    optype: str,
+    kwargs: dict,
+    failure_target: str,
+) -> None:
+    module = _load_script(script_name)
+    hou, created = _wire_downstream(optype)
+    failure = RuntimeError(" ".join(_PRIVATE_TOKENS))
+
+    with patch.dict(sys.modules, {"hou": hou}), patch.object(module, failure_target, side_effect=failure):
+        result = getattr(module, function_name)(**kwargs)
+
+    _assert_safe_failure(result)
+    created.destroy.assert_called_once_with()
+
+
+@pytest.mark.parametrize("failure_type", (KeyboardInterrupt, SystemExit))
+def test_transform_cleanup_preserves_exact_base_exception_identity(failure_type) -> None:
+    module = _load_script("transform_geometry.py")
+    hou, created = _wire_downstream("xform")
+    original = failure_type(" ".join(_PRIVATE_TOKENS))
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        with patch.object(module, "set_parm_if_exists", side_effect=original):
+            with pytest.raises(failure_type) as captured:
+                module.transform_geometry("/obj/geo1/source", translate=[1.0, 2.0, 3.0])
+
+    assert captured.value is original
+    created.destroy.assert_called_once_with()
+
+
+def test_transform_cleanup_base_exception_does_not_replace_or_leak_original_failure() -> None:
+    module = _load_script("transform_geometry.py")
+    hou, created = _wire_downstream("xform")
+    created.destroy.side_effect = SystemExit("PRIVATE_CLEANUP_FAILURE C:\\private\\cleanup.hip")
+    failure = RuntimeError(" ".join(_PRIVATE_TOKENS))
+
+    with patch.dict(sys.modules, {"hou": hou}), patch.object(
+        module,
+        "set_parm_if_exists",
+        side_effect=failure,
+    ):
+        result = module.transform_geometry("/obj/geo1/source", translate=[1.0, 2.0, 3.0])
+
+    _assert_safe_failure(result)
+    assert "PRIVATE_CLEANUP_FAILURE" not in json.dumps(result, sort_keys=True)
+    created.destroy.assert_called_once_with()
+
+
+def test_verified_caller_cook_failure_is_exactly_once_and_public_safe() -> None:
+    module = _load_script("add_edge_loop.py")
+    hou, created = _wire_downstream("polysplit")
+    failure = RuntimeError(" ".join(_PRIVATE_TOKENS))
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        with patch.object(module, "geometry_readback", return_value={"point_count": 8}):
+            with patch.object(module, "set_scalar_parm_verified", return_value="0e0.5"):
+                with patch.object(module, "cook_readback", side_effect=failure):
+                    result = module.add_edge_loop("/obj/geo1/source", "0e0.5")
+
+    _assert_safe_failure(result)
+    created.destroy.assert_called_once_with()
+
+
+def test_every_downstream_helper_result_is_adopted_by_the_shared_transaction() -> None:
+    callers = tuple(
+        path
+        for path in _SCRIPT_ROOT.glob("*.py")
+        if path.name != "_mesh_common.py" and "make_downstream_sop(" in path.read_text(encoding="utf-8")
+    )
+
+    assert len(callers) == 16
+    assert sum(path.read_text(encoding="utf-8").count("make_downstream_sop(") for path in callers) == 17
+    for path in callers:
+        source = path.read_text(encoding="utf-8")
+        assert source.count("make_downstream_sop(") == source.count("transaction.own(make_downstream_sop(")
+
+
+@pytest.mark.parametrize(
+    ("script_name", "function_name", "optype", "kwargs"),
+    tuple(case[:4] for case in _POST_TRANSFER_CASES),
+)
+def test_legacy_downstream_success_transfers_node_ownership(
+    script_name: str,
+    function_name: str,
+    optype: str,
+    kwargs: dict,
+) -> None:
+    module = _load_script(script_name)
+    hou, created = _wire_downstream(optype)
+
+    with patch.dict(sys.modules, {"hou": hou}):
+        result = getattr(module, function_name)(**kwargs)
+
+    assert result["success"] is True, result
+    created.destroy.assert_not_called()

--- a/tests/test_typed_modeling_verbs.py
+++ b/tests/test_typed_modeling_verbs.py
@@ -1,0 +1,673 @@
+"""Public-contract tests for Houdini's typed modeling vocabulary."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import yaml
+from skill_loader import skill_script_import_context
+
+_SKILL_ROOT = Path(__file__).parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-mesh-ops"
+
+
+def _load_skill_script(skill: str, name: str) -> ModuleType:
+    path = _SKILL_ROOT.parent / skill / "scripts" / name
+    spec = importlib.util.spec_from_file_location("typed_modeling_{}".format(path.stem), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_script(name: str) -> ModuleType:
+    return _load_skill_script("houdini-mesh-ops", name)
+
+
+class _Type:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
+class _Parm:
+    def __init__(self, menu_items=None, menu_labels=None) -> None:
+        self.value = None
+        self._menu_items = tuple(menu_items or ())
+        self._menu_labels = tuple(menu_labels or ())
+
+    def set(self, value) -> None:
+        self.value = value
+
+    def eval(self):
+        return self.value
+
+    def evalAsString(self) -> str:
+        return str(self.value)
+
+    def menuItems(self):
+        return self._menu_items
+
+    def menuLabels(self):
+        return self._menu_labels
+
+
+class _ParmTuple:
+    def __init__(self, value=(0.0, 0.0, 0.0)) -> None:
+        self.value = tuple(value)
+
+    def set(self, value) -> None:
+        self.value = tuple(value)
+
+    def eval(self):
+        return self.value
+
+
+class _Bounds:
+    def __init__(self, minimum, maximum) -> None:
+        self._minimum = minimum
+        self._maximum = maximum
+
+    def minvec(self):
+        return self._minimum
+
+    def maxvec(self):
+        return self._maximum
+
+    def sizevec(self):
+        return tuple(self._maximum[index] - self._minimum[index] for index in range(3))
+
+
+class _Geometry:
+    def __init__(
+        self,
+        points: int,
+        primitives: int,
+        vertices: int,
+        minimum,
+        maximum,
+        attributes=(),
+    ) -> None:
+        self._points = points
+        self._primitives = primitives
+        self._vertices = vertices
+        self._bounds = _Bounds(minimum, maximum)
+        self._attributes = set(attributes)
+
+    def pointCount(self) -> int:
+        return self._points
+
+    def primCount(self) -> int:
+        return self._primitives
+
+    def vertexCount(self) -> int:
+        return self._vertices
+
+    def boundingBox(self) -> _Bounds:
+        return self._bounds
+
+    def findVertexAttrib(self, name: str):
+        return object() if name in self._attributes else None
+
+
+class _Node:
+    def __init__(self, path: str, type_name: str, geometry: _Geometry) -> None:
+        self._path = path
+        self._type = _Type(type_name)
+        self._geometry = geometry
+        self._parent = None
+        self._inputs = {}
+        self._parms = {}
+        self._parm_tuples = {}
+        self.created = []
+        self.destroyed = False
+
+    def path(self) -> str:
+        return self._path
+
+    def name(self) -> str:
+        return self._path.rsplit("/", 1)[-1]
+
+    def type(self) -> _Type:
+        return self._type
+
+    def geometry(self) -> _Geometry:
+        return self._geometry
+
+    def parent(self):
+        return self._parent
+
+    def createNode(self, type_name: str, node_name=None):
+        path = "{}/{}".format(self._path, node_name or "{}1".format(type_name))
+        node = _Node(
+            path,
+            type_name,
+            _Geometry(16, 10, 40, (-1.0, -1.0, -1.0), (1.0, 1.25, 1.0)),
+        )
+        node._parent = self
+        self.created.append(node)
+        return node
+
+    def setInput(self, index: int, node) -> None:
+        self._inputs[index] = node
+
+    def inputs(self):
+        return tuple(self._inputs[index] for index in sorted(self._inputs))
+
+    def parm(self, name: str):
+        return self._parms.setdefault(name, _Parm())
+
+    def parmTuple(self, _name: str):
+        return self._parm_tuples.setdefault(_name, _ParmTuple())
+
+    def cook(self, force: bool = False) -> None:
+        assert force is True
+
+    def errors(self):
+        return []
+
+    def warnings(self):
+        return []
+
+    def setDisplayFlag(self, _value: bool) -> None:
+        return None
+
+    def moveToGoodPosition(self) -> None:
+        return None
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+def test_extrude_faces_is_typed_and_reads_back_the_created_sop() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    groups = yaml.safe_load((_SKILL_ROOT / "groups.yaml").read_text(encoding="utf-8"))["groups"]
+    by_group = {group["name"]: group for group in groups}
+    assert by_group["mesh-edit"]["default_active"] is True
+    assert by_group["modeling"]["default_active"] is False
+    assert set(by_group["modeling"]["tools"]) == {item["name"] for item in tools if item["group"] == "modeling"}
+    contract = next(item for item in tools if item["name"] == "extrude_faces")
+    assert contract["execution"] == "sync"
+    assert contract["affinity"] == "main"
+    assert contract["group"] == "modeling"
+    assert contract["input_schema"]["additionalProperties"] is False
+
+    module = _load_script("extrude_faces.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/box1",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    source._parent = parent
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(
+            input_path=source.path(),
+            group="0",
+            distance=0.25,
+            node_name="rim_extrude",
+        )
+
+    assert result["success"] is True, result
+    assert result["context"]["node"] == {
+        "path": "/obj/geo1/rim_extrude",
+        "name": "rim_extrude",
+        "type": "polyextrude",
+    }
+    assert result["context"]["parameters"] == {
+        "distance": 0.25,
+        "group": "0",
+        "inset": 0.0,
+    }
+    assert result["context"]["readback"]["primitive_count"] == 10
+    assert result["context"]["readback"]["verified"] is True
+    assert parent.created[0].inputs() == (source,)
+
+
+def test_bevel_edges_is_bounded_and_reads_back_the_created_sop() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "bevel_edges")
+    assert contract["input_schema"]["properties"]["divisions"]["maximum"] == 64
+
+    module = _load_script("bevel_edges.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/box1",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    source._parent = parent
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(
+            input_path=source.path(),
+            group="0-3",
+            distance=0.05,
+            divisions=3,
+            node_name="rim_bevel",
+        )
+
+    assert result["success"] is True, result
+    assert result["context"]["node"]["type"] == "polybevel"
+    assert result["context"]["parameters"] == {
+        "distance": 0.05,
+        "divisions": 3,
+        "group": "0-3",
+    }
+    assert result["context"]["readback"]["verified"] is True
+
+
+def test_inset_reuses_verified_polyextrude_without_raw_execution() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "inset")
+    assert contract["source_file"] == "scripts/inset.py"
+    assert contract["input_schema"]["additionalProperties"] is False
+
+    module = _load_script("inset.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/box1",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    source._parent = parent
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(input_path=source.path(), group="0", amount=0.1)
+
+    assert result["success"] is True, result
+    assert result["context"]["node"]["type"] == "polyextrude"
+    assert result["context"]["parameters"] == {
+        "distance": 0.0,
+        "group": "0",
+        "inset": 0.1,
+    }
+    assert result["context"]["readback"]["verified"] is True
+
+
+def test_loft_sections_wires_bounded_same_network_inputs_and_reads_back() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "loft_sections")
+    sections_schema = contract["input_schema"]["properties"]["sections"]
+    assert sections_schema["minItems"] == 2
+    assert sections_schema["maxItems"] == 64
+
+    module = _load_script("loft_sections.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    sections = [
+        _Node(
+            "/obj/geo1/section{}".format(index),
+            "circle",
+            _Geometry(8, 1, 8, (-1.0, float(index), -1.0), (1.0, float(index), 1.0)),
+        )
+        for index in range(3)
+    ]
+    for section in sections:
+        section._parent = parent
+    by_path = {section.path(): section for section in sections}
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return by_path.get(path)
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(
+            sections=[section.path() for section in sections],
+            node_name="fuselage_loft",
+        )
+
+    assert result["success"] is True, result
+    assert result["context"]["node"]["type"] == "skin"
+    assert result["context"]["node"]["path"] == "/obj/geo1/fuselage_loft"
+    assert parent.created[0].inputs() == tuple(sections)
+    assert result["context"]["readback"]["verified"] is True
+
+
+def test_boolean_op_resolves_native_menu_and_verifies_two_input_result() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "boolean_op")
+    assert contract["input_schema"]["properties"]["operation"]["enum"] == [
+        "union",
+        "intersect",
+        "subtract",
+    ]
+
+    module = _load_script("boolean_op.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    left = _Node(
+        "/obj/geo1/body",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    right = _Node(
+        "/obj/geo1/cutter",
+        "tube",
+        _Geometry(16, 18, 64, (-0.25, -2.0, -0.25), (0.25, 2.0, 0.25)),
+    )
+    left._parent = parent
+    right._parent = parent
+    by_path = {left.path(): left, right.path(): right}
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return by_path.get(path)
+
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        node._parms["booleanop"] = _Parm(
+            menu_items=("0", "1", "2"),
+            menu_labels=("Union", "Intersect", "A Minus B"),
+        )
+        return node
+
+    parent.createNode = create_node
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(
+            input_a=left.path(),
+            input_b=right.path(),
+            operation="subtract",
+            node_name="launcher_cutout",
+        )
+
+    assert result["success"] is True, result
+    assert result["context"]["node"]["type"] == "boolean"
+    assert result["context"]["parameters"] == {
+        "operation": "subtract",
+        "operation_token": "2",
+    }
+    assert parent.created[0].inputs() == (left, right)
+    assert result["context"]["readback"]["verified"] is True
+
+
+def test_lathe_profile_sets_axis_and_divisions_with_readback() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "lathe_profile")
+    assert contract["input_schema"]["properties"]["segments"]["maximum"] == 256
+
+    module = _load_script("lathe_profile.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    profile = _Node(
+        "/obj/geo1/profile",
+        "curve",
+        _Geometry(5, 1, 5, (0.5, -1.0, 0.0), (1.0, 1.0, 0.0)),
+    )
+    profile._parent = parent
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return profile if path == profile.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(
+            profile=profile.path(),
+            axis="y",
+            origin=[0.0, 0.0, 0.0],
+            segments=48,
+            node_name="rotor_hub",
+        )
+
+    assert result["success"] is True, result
+    assert result["context"]["node"]["type"] == "revolve"
+    assert result["context"]["parameters"] == {
+        "axis": "y",
+        "axis_direction": [0.0, 1.0, 0.0],
+        "origin": [0.0, 0.0, 0.0],
+        "segments": 48,
+    }
+    assert result["context"]["readback"]["verified"] is True
+
+
+def test_edge_loop_and_bridge_are_bounded_verified_sop_operations() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    edge_contract = next(item for item in tools if item["name"] == "add_edge_loop")
+    bridge_contract = next(item for item in tools if item["name"] == "bridge_edges")
+    assert edge_contract["input_schema"]["properties"]["split_locations"]["maxLength"] == 4096
+    assert bridge_contract["input_schema"]["properties"]["divisions"]["maximum"] == 64
+
+    edge_module = _load_script("add_edge_loop.py")
+    bridge_module = _load_script("bridge_edges.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/body",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    source._parent = parent
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        edge_result = edge_module.main(
+            input_path=source.path(),
+            split_locations="0e0:0.5",
+            node_name="support_loop",
+        )
+        bridge_result = bridge_module.main(
+            input_path=source.path(),
+            source_group="left_rim",
+            destination_group="right_rim",
+            divisions=4,
+            node_name="rim_bridge",
+        )
+
+    assert edge_result["success"] is True, edge_result
+    assert edge_result["context"]["node"]["type"] == "polysplit"
+    assert edge_result["context"]["parameters"]["split_locations"] == "0e0:0.5"
+    assert bridge_result["success"] is True, bridge_result
+    assert bridge_result["context"]["node"]["type"] == "polybridge"
+    assert bridge_result["context"]["parameters"] == {
+        "destination_group": "right_rim",
+        "divisions": 4,
+        "source_group": "left_rim",
+    }
+
+
+def test_mirror_and_uv_tools_return_native_postcondition_readback() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    names = {item["name"] for item in tools}
+    assert {"mirror", "auto_uv", "uv_project"} <= names
+
+    mirror_module = _load_script("mirror.py")
+    auto_uv_module = _load_script("auto_uv.py")
+    project_module = _load_script("uv_project.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/pylon",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    source._parent = parent
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        if type_name in {"uvunwrap", "uvproject"}:
+            node._geometry = _Geometry(
+                16,
+                10,
+                40,
+                (-1.0, -1.0, -1.0),
+                (1.0, 1.25, 1.0),
+                attributes=("uv",),
+            )
+        if type_name == "uvproject":
+            node._parms["projection"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("Orthographic", "Cylindrical", "Spherical"),
+            )
+        return node
+
+    parent.createNode = create_node
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        mirror_result = mirror_module.main(
+            input_path=source.path(),
+            origin=[0.0, 0.0, 0.0],
+            direction=[1.0, 0.0, 0.0],
+        )
+        auto_result = auto_uv_module.main(input_path=source.path(), uv_attribute="uv")
+        project_result = project_module.main(
+            input_path=source.path(),
+            projection="cylindrical",
+            uv_attribute="uv",
+        )
+
+    assert mirror_result["success"] is True, mirror_result
+    assert mirror_result["context"]["node"]["type"] == "mirror"
+    assert mirror_result["context"]["parameters"]["direction"] == [1.0, 0.0, 0.0]
+    assert auto_result["success"] is True, auto_result
+    assert auto_result["context"]["readback"]["uv_attribute"] == "uv"
+    assert project_result["success"] is True, project_result
+    assert project_result["context"]["parameters"]["projection"] == "cylindrical"
+    assert project_result["context"]["readback"]["uv_attribute"] == "uv"
+
+
+def test_array_instances_builds_verified_radial_copy_to_points() -> None:
+    tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "array_instances")
+    assert contract["input_schema"]["properties"]["count"] == {
+        "type": "integer",
+        "minimum": 2,
+        "maximum": 128,
+    }
+
+    module = _load_script("array_instances.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/rotor_blade",
+        "box",
+        _Geometry(8, 6, 24, (0.0, -0.1, -0.5), (4.0, 0.1, 0.5)),
+    )
+    source._parent = parent
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        if type_name == "circle":
+            node._parms["type"] = _Parm(
+                menu_items=("0", "1"),
+                menu_labels=("Polygon", "NURBS Curve"),
+            )
+            node._parms["orient"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("XY Plane", "YZ Plane", "ZX Plane"),
+            )
+        return node
+
+    parent.createNode = create_node
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(
+            input_path=source.path(),
+            count=4,
+            radius=3.5,
+            axis="y",
+            node_name="main_rotor_array",
+        )
+
+    assert result["success"] is True, result
+    assert result["context"]["node"]["type"] == "copytopoints"
+    assert result["context"]["points_node"]["type"] == "circle"
+    assert result["context"]["parameters"] == {
+        "axis": "y",
+        "count": 4,
+        "radius": 3.5,
+    }
+    circle, copy = parent.created
+    assert copy.inputs() == (source, circle)
+    assert result["context"]["readback"]["verified"] is True
+
+
+def test_boolean_op_fails_closed_and_removes_partial_node_without_native_menu() -> None:
+    module = _load_script("boolean_op.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    left = _Node(
+        "/obj/geo1/body",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    right = _Node(
+        "/obj/geo1/cutter",
+        "tube",
+        _Geometry(16, 18, 64, (-0.25, -2.0, -0.25), (0.25, 2.0, 0.25)),
+    )
+    left._parent = parent
+    right._parent = parent
+    by_path = {left.path(): left, right.path(): right}
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return by_path.get(path)
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(input_a=left.path(), input_b=right.path(), operation="subtract")
+
+    assert result["success"] is False
+    assert "menu" in result["message"].lower() or "menu" in str(result).lower()
+    assert parent.created[0].destroyed is True
+
+
+def test_set_pivot_is_owned_by_object_ops_and_returns_exact_readback() -> None:
+    object_skill = _SKILL_ROOT.parent / "houdini-object-ops"
+    tools = yaml.safe_load((object_skill / "tools.yaml").read_text(encoding="utf-8"))["tools"]
+    contract = next(item for item in tools if item["name"] == "set_pivot")
+    assert contract["input_schema"]["additionalProperties"] is False
+    assert contract["input_schema"]["properties"]["position"]["maxItems"] == 3
+
+    module = _load_skill_script("houdini-object-ops", "set_pivot.py")
+    node = _Node("/obj/main_rotor", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return node if path == node.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(node_path=node.path(), position=[0.0, 2.5, 0.0])
+
+    assert result["success"] is True, result
+    assert result["context"]["node_path"] == node.path()
+    assert result["context"]["position"] == [0.0, 2.5, 0.0]
+    assert result["context"]["readback"] == {"pivot": [0.0, 2.5, 0.0], "verified": True}

--- a/tests/test_typed_modeling_verbs.py
+++ b/tests/test_typed_modeling_verbs.py
@@ -1081,7 +1081,11 @@ def test_boolean_op_fails_closed_and_removes_partial_node_without_native_menu() 
         result = module.main(input_a=left.path(), input_b=right.path(), operation="subtract")
 
     assert result["success"] is False
-    assert "menu" in result["message"].lower() or "menu" in str(result).lower()
+    assert result["context"] == {
+        "error_code": "houdini_sop_transaction_failed",
+        "error_type": "RuntimeError",
+    }
+    assert "traceback" not in str(result).lower()
     assert parent.created[0].destroyed is True
 
 

--- a/tests/test_typed_modeling_verbs.py
+++ b/tests/test_typed_modeling_verbs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import patch
 
+import pytest
 import yaml
 from skill_loader import skill_script_import_context
 
@@ -85,6 +86,14 @@ class _Bounds:
         return tuple(self._maximum[index] - self._minimum[index] for index in range(3))
 
 
+class _Attrib:
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
 class _Geometry:
     def __init__(
         self,
@@ -94,12 +103,16 @@ class _Geometry:
         minimum,
         maximum,
         attributes=(),
+        point_float_attributes=None,
+        point_int_attributes=None,
     ) -> None:
         self._points = points
         self._primitives = primitives
         self._vertices = vertices
         self._bounds = _Bounds(minimum, maximum)
         self._attributes = set(attributes)
+        self._point_float_attributes = dict(point_float_attributes or {})
+        self._point_int_attributes = dict(point_int_attributes or {})
 
     def pointCount(self) -> int:
         return self._points
@@ -116,9 +129,23 @@ class _Geometry:
     def findVertexAttrib(self, name: str):
         return object() if name in self._attributes else None
 
+    def findPointAttrib(self, name: str):
+        values = self._point_float_attributes.get(name)
+        if values:
+            return _Attrib(len(values[0]))
+        if name in self._point_int_attributes:
+            return _Attrib(1)
+        return None
+
+    def pointFloatAttribValues(self, name: str):
+        return tuple(component for value in self._point_float_attributes[name] for component in value)
+
+    def pointIntAttribValues(self, name: str):
+        return tuple(self._point_int_attributes[name])
+
 
 class _Node:
-    def __init__(self, path: str, type_name: str, geometry: _Geometry) -> None:
+    def __init__(self, path: str, type_name: str, geometry: _Geometry, max_inputs=None) -> None:
         self._path = path
         self._type = _Type(type_name)
         self._geometry = geometry
@@ -128,6 +155,8 @@ class _Node:
         self._parm_tuples = {}
         self.created = []
         self.destroyed = False
+        self._max_inputs = max_inputs
+        self._fail_input_index = None
 
     def path(self) -> str:
         return self._path
@@ -156,6 +185,10 @@ class _Node:
         return node
 
     def setInput(self, index: int, node) -> None:
+        if self._max_inputs is not None and index >= self._max_inputs:
+            raise RuntimeError("Input {} is not available on {}".format(index, self._type.name()))
+        if index == self._fail_input_index:
+            raise RuntimeError("PRIVATE_CONNECTION_DETAIL")
         self._inputs[index] = node
 
     def inputs(self):
@@ -328,6 +361,15 @@ def test_loft_sections_wires_bounded_same_network_inputs_and_reads_back() -> Non
     for section in sections:
         section._parent = parent
     by_path = {section.path(): section for section in sections}
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        if type_name == "skin":
+            node._max_inputs = 2
+        return node
+
+    parent.createNode = create_node
 
     class _Hou:
         @staticmethod
@@ -343,8 +385,71 @@ def test_loft_sections_wires_bounded_same_network_inputs_and_reads_back() -> Non
     assert result["success"] is True, result
     assert result["context"]["node"]["type"] == "skin"
     assert result["context"]["node"]["path"] == "/obj/geo1/fuselage_loft"
-    assert parent.created[0].inputs() == tuple(sections)
+    merge, skin = parent.created
+    assert merge.type().name() == "merge"
+    assert merge.inputs() == tuple(sections)
+    assert skin.inputs() == (merge,)
+    assert result["context"]["merge_node"]["path"] == merge.path()
     assert result["context"]["readback"]["verified"] is True
+
+
+@pytest.mark.parametrize(
+    ("failure_stage", "expected_created"),
+    (
+        ("merge_create", 0),
+        ("merge_connect", 1),
+        ("skin_create", 1),
+        ("skin_connect", 2),
+    ),
+)
+def test_loft_sections_rolls_back_the_whole_linear_loft_on_failure(
+    failure_stage: str,
+    expected_created: int,
+) -> None:
+    module = _load_script("loft_sections.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    sections = [
+        _Node(
+            "/obj/geo1/section{}".format(index),
+            "circle",
+            _Geometry(8, 1, 8, (-1.0, float(index), -1.0), (1.0, float(index), 1.0)),
+        )
+        for index in range(3)
+    ]
+    for section in sections:
+        section._parent = parent
+    by_path = {section.path(): section for section in sections}
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        if failure_stage == "merge_create" and type_name == "merge":
+            raise RuntimeError("PRIVATE_CREATE_DETAIL")
+        if failure_stage == "skin_create" and type_name == "skin":
+            raise RuntimeError("PRIVATE_CREATE_DETAIL")
+        node = original_create(type_name, node_name)
+        if type_name == "merge" and failure_stage == "merge_connect":
+            node._fail_input_index = 1
+        if type_name == "skin":
+            node._max_inputs = 2
+            if failure_stage == "skin_connect":
+                node._fail_input_index = 0
+        return node
+
+    parent.createNode = create_node
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return by_path.get(path)
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(sections=[section.path() for section in sections])
+
+    assert result["success"] is False
+    assert result["message"] == "Failed to create verified Skin SOP loft"
+    assert "PRIVATE_" not in str(result)
+    assert len(parent.created) == expected_created
+    assert all(node.destroyed for node in parent.created)
 
 
 def test_boolean_op_resolves_native_menu_and_verifies_two_input_result() -> None:
@@ -566,6 +671,18 @@ def test_array_instances_builds_verified_radial_copy_to_points() -> None:
         "minimum": 2,
         "maximum": 128,
     }
+    assert contract["input_schema"]["properties"]["direction_mode"]["enum"] == [
+        "radial",
+        "tangent",
+    ]
+    assert contract["input_schema"]["properties"]["source_forward"]["enum"] == [
+        "+x",
+        "-x",
+        "+y",
+        "-y",
+        "+z",
+        "-z",
+    ]
 
     module = _load_script("array_instances.py")
     parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
@@ -580,6 +697,7 @@ def test_array_instances_builds_verified_radial_copy_to_points() -> None:
     def create_node(type_name: str, node_name=None):
         node = original_create(type_name, node_name)
         if type_name == "circle":
+            node._geometry = _Geometry(4, 1, 4, (-3.5, 0.0, -3.5), (3.5, 0.0, 3.5))
             node._parms["type"] = _Parm(
                 menu_items=("0", "1"),
                 menu_labels=("Polygon", "NURBS Curve"),
@@ -588,6 +706,44 @@ def test_array_instances_builds_verified_radial_copy_to_points() -> None:
                 menu_items=("0", "1", "2"),
                 menu_labels=("XY Plane", "YZ Plane", "ZX Plane"),
             )
+        if type_name == "attribwrangle":
+            orientation_geometry = _Geometry(
+                4,
+                1,
+                4,
+                (-3.5, 0.0, -3.5),
+                (3.5, 0.0, 3.5),
+                point_float_attributes={
+                    "P": (
+                        (0.0, 0.0, 3.5),
+                        (3.5, 0.0, 0.0),
+                        (0.0, 0.0, -3.5),
+                        (-3.5, 0.0, 0.0),
+                    ),
+                    "orient": (
+                        (0.0, 0.0, 0.0, 1.0),
+                        (0.0, 0.70710678, 0.0, 0.70710678),
+                        (0.0, 1.0, 0.0, 0.0),
+                        (0.0, -0.70710678, 0.0, 0.70710678),
+                    ),
+                },
+                point_int_attributes={"dcc_mcp_orientation_valid": (1, 1, 1, 1)},
+            )
+            node._parms["class"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("Points", "Primitives", "Detail"),
+            )
+
+            def verified_geometry():
+                snippet = node.parm("snippet").eval()
+                assert "vector ring_axis = set(0.0, 1.0, 0.0);" in snippet
+                assert "vector source_forward = set(1.0, 0.0, 0.0);" in snippet
+                assert "normalize(cross(ring_axis, radial))" in snippet
+                assert "p@orient = quaternion(dihedral" in snippet
+                assert "i@dcc_mcp_orientation_valid = 1" in snippet
+                return orientation_geometry
+
+            node.geometry = verified_geometry
         return node
 
     parent.createNode = create_node
@@ -603,20 +759,201 @@ def test_array_instances_builds_verified_radial_copy_to_points() -> None:
             count=4,
             radius=3.5,
             axis="y",
+            start_angle_degrees=30.0,
+            direction_mode="tangent",
+            source_forward="+x",
             node_name="main_rotor_array",
         )
 
     assert result["success"] is True, result
     assert result["context"]["node"]["type"] == "copytopoints"
     assert result["context"]["points_node"]["type"] == "circle"
+    assert result["context"]["orientation_node"]["type"] == "attribwrangle"
     assert result["context"]["parameters"] == {
         "axis": "y",
         "count": 4,
+        "direction_mode": "tangent",
         "radius": 3.5,
+        "source_forward": "+x",
+        "start_angle_degrees": 30.0,
     }
-    circle, copy = parent.created
-    assert copy.inputs() == (source, circle)
+    circle, orientation, copy = parent.created
+    assert circle.parmTuple("r").eval() == (0.0, 30.0, 0.0)
+    assert orientation.inputs() == (circle,)
+    assert copy.inputs() == (source, orientation)
+    assert result["context"]["readback"]["orientation"] == {
+        "attribute": "orient",
+        "distinct_count": 4,
+        "point_count": 4,
+        "tuple_size": 4,
+        "valid_count": 4,
+        "verified": True,
+    }
     assert result["context"]["readback"]["verified"] is True
+
+
+@pytest.mark.parametrize(
+    (
+        "axis",
+        "direction_mode",
+        "source_forward",
+        "axis_literal",
+        "forward_literal",
+        "target_literal",
+    ),
+    (
+        (
+            "x",
+            "radial",
+            "-z",
+            "set(1.0, 0.0, 0.0)",
+            "set(0.0, 0.0, -1.0)",
+            "vector target = radial;",
+        ),
+        (
+            "z",
+            "tangent",
+            "+y",
+            "set(0.0, 0.0, 1.0)",
+            "set(0.0, 1.0, 0.0)",
+            "vector target = normalize(cross(ring_axis, radial));",
+        ),
+    ),
+)
+def test_array_instances_emits_axis_and_source_forward_orientation_contract(
+    axis: str,
+    direction_mode: str,
+    source_forward: str,
+    axis_literal: str,
+    forward_literal: str,
+    target_literal: str,
+) -> None:
+    module = _load_script("array_instances.py")
+
+    snippet = module._orientation_vex(axis, direction_mode, source_forward)
+
+    assert "vector ring_axis = {};".format(axis_literal) in snippet
+    assert "vector source_forward = {};".format(forward_literal) in snippet
+    assert target_literal in snippet
+    assert "length2(radial) > 1e-12" in snippet
+    assert "i@dcc_mcp_orientation_valid = 0" in snippet
+
+
+def test_array_instances_rejects_missing_orientation_readback_and_rolls_back() -> None:
+    module = _load_script("array_instances.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/rotor_blade",
+        "box",
+        _Geometry(8, 6, 24, (0.0, -0.1, -0.5), (4.0, 0.1, 0.5)),
+    )
+    source._parent = parent
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        if type_name == "circle":
+            node._geometry = _Geometry(4, 1, 4, (-2.0, 0.0, -2.0), (2.0, 0.0, 2.0))
+            node._parms["type"] = _Parm(
+                menu_items=("0", "1"),
+                menu_labels=("Polygon", "NURBS Curve"),
+            )
+            node._parms["orient"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("XY Plane", "YZ Plane", "ZX Plane"),
+            )
+        if type_name == "attribwrangle":
+            node._geometry = _Geometry(4, 1, 4, (-2.0, 0.0, -2.0), (2.0, 0.0, 2.0))
+            node._parms["class"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("Points", "Primitives", "Detail"),
+            )
+        return node
+
+    parent.createNode = create_node
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(input_path=source.path(), count=4, radius=2.0, axis="y")
+
+    assert result["success"] is False
+    assert result["message"] == "Failed to create verified radial instance array"
+    assert len(parent.created) == 2
+    assert all(node.destroyed for node in parent.created)
+
+
+def test_array_instances_rolls_back_ring_orientation_and_copy_on_connection_failure() -> None:
+    module = _load_script("array_instances.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/rotor_blade",
+        "box",
+        _Geometry(8, 6, 24, (0.0, -0.1, -0.5), (4.0, 0.1, 0.5)),
+    )
+    source._parent = parent
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        if type_name == "circle":
+            node._geometry = _Geometry(4, 1, 4, (-2.0, 0.0, -2.0), (2.0, 0.0, 2.0))
+            node._parms["type"] = _Parm(
+                menu_items=("0", "1"),
+                menu_labels=("Polygon", "NURBS Curve"),
+            )
+            node._parms["orient"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("XY Plane", "YZ Plane", "ZX Plane"),
+            )
+        if type_name == "attribwrangle":
+            node._geometry = _Geometry(
+                4,
+                1,
+                4,
+                (-2.0, 0.0, -2.0),
+                (2.0, 0.0, 2.0),
+                point_float_attributes={
+                    "P": (
+                        (2.0, 0.0, 0.0),
+                        (0.0, 0.0, -2.0),
+                        (-2.0, 0.0, 0.0),
+                        (0.0, 0.0, 2.0),
+                    ),
+                    "orient": (
+                        (0.0, 0.0, 0.0, 1.0),
+                        (0.0, 0.70710678, 0.0, 0.70710678),
+                        (0.0, 1.0, 0.0, 0.0),
+                        (0.0, -0.70710678, 0.0, 0.70710678),
+                    ),
+                },
+                point_int_attributes={"dcc_mcp_orientation_valid": (1, 1, 1, 1)},
+            )
+            node._parms["class"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("Points", "Primitives", "Detail"),
+            )
+        if type_name == "copytopoints":
+            node._fail_input_index = 1
+        return node
+
+    parent.createNode = create_node
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(input_path=source.path(), count=4, radius=2.0, axis="y")
+
+    assert result["success"] is False
+    assert result["message"] == "Failed to create verified radial instance array"
+    assert len(parent.created) == 3
+    assert all(node.destroyed for node in parent.created)
 
 
 def test_boolean_op_fails_closed_and_removes_partial_node_without_native_menu() -> None:

--- a/tests/test_typed_modeling_verbs.py
+++ b/tests/test_typed_modeling_verbs.py
@@ -155,6 +155,7 @@ class _Node:
         self._parm_tuples = {}
         self.created = []
         self.destroyed = False
+        self.destroy_calls = 0
         self._max_inputs = max_inputs
         self._fail_input_index = None
 
@@ -216,6 +217,7 @@ class _Node:
         return None
 
     def destroy(self) -> None:
+        self.destroy_calls += 1
         self.destroyed = True
 
 
@@ -886,7 +888,65 @@ def test_array_instances_rejects_missing_orientation_readback_and_rolls_back() -
     assert all(node.destroyed for node in parent.created)
 
 
-def test_array_instances_rolls_back_ring_orientation_and_copy_on_connection_failure() -> None:
+@pytest.mark.parametrize("failure_stage", ("input_zero", "display_flag"))
+def test_array_instances_rolls_back_unreturned_wrangle_on_pre_return_failure(
+    failure_stage: str,
+) -> None:
+    module = _load_script("array_instances.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/rotor_blade",
+        "box",
+        _Geometry(8, 6, 24, (0.0, -0.1, -0.5), (4.0, 0.1, 0.5)),
+    )
+    source._parent = parent
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+        if type_name == "circle":
+            node._geometry = _Geometry(4, 1, 4, (-2.0, 0.0, -2.0), (2.0, 0.0, 2.0))
+            node._parms["type"] = _Parm(
+                menu_items=("0", "1"),
+                menu_labels=("Polygon", "NURBS Curve"),
+            )
+            node._parms["orient"] = _Parm(
+                menu_items=("0", "1", "2"),
+                menu_labels=("XY Plane", "YZ Plane", "ZX Plane"),
+            )
+        if type_name == "attribwrangle":
+            if failure_stage == "input_zero":
+                node._fail_input_index = 0
+            else:
+
+                def fail_display(_value: bool) -> None:
+                    raise RuntimeError("PRIVATE_DISPLAY_DETAIL")
+
+                node.setDisplayFlag = fail_display
+        return node
+
+    parent.createNode = create_node
+
+    class _Hou:
+        @staticmethod
+        def node(path: str):
+            return source if path == source.path() else None
+
+    with patch.dict(sys.modules, {"hou": _Hou()}):
+        result = module.main(input_path=source.path(), count=4, radius=2.0, axis="y")
+
+    assert result["success"] is False
+    assert result["message"] == "Failed to create verified radial instance array"
+    assert "PRIVATE_" not in str(result)
+    assert len(parent.created) == 2
+    assert all(node.destroyed for node in parent.created)
+    assert [node.destroy_calls for node in parent.created] == [1, 1]
+
+
+@pytest.mark.parametrize("copy_input_index", (0, 1))
+def test_array_instances_rolls_back_ring_orientation_and_copy_on_connection_failure(
+    copy_input_index: int,
+) -> None:
     module = _load_script("array_instances.py")
     parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
     source = _Node(
@@ -937,7 +997,7 @@ def test_array_instances_rolls_back_ring_orientation_and_copy_on_connection_fail
                 menu_labels=("Points", "Primitives", "Detail"),
             )
         if type_name == "copytopoints":
-            node._fail_input_index = 1
+            node._fail_input_index = copy_input_index
         return node
 
     parent.createNode = create_node
@@ -954,6 +1014,45 @@ def test_array_instances_rolls_back_ring_orientation_and_copy_on_connection_fail
     assert result["message"] == "Failed to create verified radial instance array"
     assert len(parent.created) == 3
     assert all(node.destroyed for node in parent.created)
+    assert [node.destroy_calls for node in parent.created] == [1, 1, 1]
+
+
+def test_make_downstream_sop_preserves_display_failure_when_cleanup_raises_base_exception() -> None:
+    module = _load_script("_mesh_common.py")
+    parent = _Node("/obj/geo1", "geo", _Geometry(0, 0, 0, (0, 0, 0), (0, 0, 0)))
+    source = _Node(
+        "/obj/geo1/source",
+        "box",
+        _Geometry(8, 6, 24, (-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
+    )
+    source._parent = parent
+    original_failure = KeyboardInterrupt("PRIVATE_DISPLAY_DETAIL")
+    cleanup_failure = SystemExit("PRIVATE_CLEANUP_DETAIL")
+    original_create = parent.createNode
+
+    def create_node(type_name: str, node_name=None):
+        node = original_create(type_name, node_name)
+
+        def fail_display(_value: bool) -> None:
+            raise original_failure
+
+        def fail_cleanup() -> None:
+            node.destroy_calls += 1
+            raise cleanup_failure
+
+        node.setDisplayFlag = fail_display
+        node.destroy = fail_cleanup
+        return node
+
+    parent.createNode = create_node
+
+    with pytest.raises(KeyboardInterrupt) as captured:
+        module.make_downstream_sop(source, "attribwrangle")
+
+    assert captured.value is original_failure
+    assert len(parent.created) == 1
+    assert parent.created[0].inputs() == (source,)
+    assert parent.created[0].destroy_calls == 1
 
 
 def test_boolean_op_fails_closed_and_removes_partial_node_without_native_menu() -> None:


### PR DESCRIPTION
## Summary
- add 12 bounded modeling tools and an inactive-by-default modeling group
- route ordered loft sections through Merge into Skin input 0 with whole-transaction rollback
- generate and read back per-point radial or tangent orient values before Copy to Points
- retain downstream SOP ownership through parameter, cook, readback, and receipt construction across all 17 helper call sites
- return stable public transaction failures without exception text, traceback, or private paths

## Verification
- loft/orientation Red: strict Skin ports and missing orientation readback produced 7 failures / 10 passes
- helper pre-return Red: Wrangle and Copy to Points input 0 rollback both failed
- caller ownership Red on the prior head: 10 failed / 6 passed across post-transfer failures, cleanup, BaseException identity, and public redaction
- focused modeling and transaction contracts passed 62 / 62
- full suite passed 1,125 tests with 1 skipped and 3 deselected
- Ruff check/format, Python 3.7 syntax, and dcc-mcp-cli 0.20.20 Skill lint passed for 35 skills
- wheel/sdist build, Twine, and win64/Linux/macOS quickinstall matrices passed

## Boundary
No live or licensed Houdini host, user scene, or real Houdini step was used. Local evidence is Mock-HOM and packaging-contract validation; the repository Hython workflow is separate and may skip when its licensed runtime is unavailable.

Core recipe/readback follow-ups remain tracked in dcc-mcp-core#2259 and dcc-mcp-core#2260.

Refs #266
