### PR TITLE
test: support Core structured error details

### DIFF
--- a/tests/skill_error_assertions.py
+++ b/tests/skill_error_assertions.py
@@ -1,0 +1,19 @@
+"""Assertions that span the Core 0.19 and 0.20 Skill error envelopes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def skill_error_detail(result: Mapping[str, Any]) -> str:
+    """Return bounded exception detail without changing the runtime contract."""
+    metadata = result.get("_meta")
+    if isinstance(metadata, Mapping):
+        error_metadata = metadata.get("dcc.error")
+        if isinstance(error_metadata, Mapping):
+            message = error_metadata.get("message")
+            if isinstance(message, str) and message:
+                return message
+    error = result.get("error")
+    return str(error) if error is not None else ""

--- a/tests/test_groom_skills.py
+++ b/tests/test_groom_skills.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from skill_error_assertions import skill_error_detail
+
 
 def _load_script():
     path = (
@@ -207,7 +209,7 @@ def test_build_short_fur_groom_rejects_surface_topology_mismatch() -> None:
         )
 
     assert result["success"] is False
-    assert "matching rest/deformed skin topology" in result["error"]
+    assert "matching rest/deformed skin topology" in skill_error_detail(result)
     geo.createNode.assert_not_called()
 
 

--- a/tests/test_hda_contract_tools.py
+++ b/tests/test_hda_contract_tools.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from skill_error_assertions import skill_error_detail
 from skill_loader import skill_script_import_context
 
 _SCRIPTS = Path(__file__).parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-hda" / "scripts"
@@ -180,7 +181,7 @@ def test_author_hda_interface_rejects_script_fields() -> None:
         )
 
     assert result["success"] is False
-    assert "not allowed" in str(result["error"])
+    assert "not allowed" in skill_error_detail(result)
 
 
 def test_author_hda_interface_accepts_one_sided_numeric_ranges() -> None:
@@ -283,7 +284,7 @@ def test_publish_hda_library_requires_explicit_overwrite(tmp_path: Path) -> None
         )
 
     assert result["success"] is False
-    assert "already exists" in str(result["error"])
+    assert "already exists" in skill_error_detail(result)
     source_definition.updateFromNode.assert_not_called()
     source_definition.copyToHDAFile.assert_not_called()
 

--- a/tests/test_hda_lifecycle.py
+++ b/tests/test_hda_lifecycle.py
@@ -10,6 +10,7 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+from skill_error_assertions import skill_error_detail
 from skill_loader import skill_script_import_context
 
 _SCRIPTS = Path(__file__).parents[1] / "src" / "dcc_mcp_houdini" / "skills" / "houdini-hda" / "scripts"
@@ -239,7 +240,7 @@ def test_save_node_as_hda_refuses_existing_library_without_explicit_overwrite(tm
         )
 
     assert result["success"] is False
-    assert "already exists" in result["error"].lower()
+    assert "already exists" in skill_error_detail(result).lower()
     assert hashlib.sha256(hda_path.read_bytes()).hexdigest() == before_sha256
     node.createDigitalAsset.assert_not_called()
 

--- a/tests/test_skill_error_assertions.py
+++ b/tests/test_skill_error_assertions.py
@@ -1,0 +1,30 @@
+"""Compatibility regressions for structured Skill exception assertions."""
+
+from __future__ import annotations
+
+from skill_error_assertions import skill_error_detail
+
+
+def test_skill_error_detail_reads_legacy_error_repr() -> None:
+    result = {
+        "success": False,
+        "error": "ValueError('matching topology required')",
+        "context": {"error_type": "ValueError"},
+    }
+
+    assert skill_error_detail(result) == "ValueError('matching topology required')"
+
+
+def test_skill_error_detail_prefers_core_020_metadata_message() -> None:
+    result = {
+        "success": False,
+        "error": "ValueError",
+        "_meta": {
+            "dcc.error": {
+                "type": "ValueError",
+                "message": "matching topology required",
+            }
+        },
+    }
+
+    assert skill_error_detail(result) == "matching topology required"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 import yaml
+from skill_error_assertions import skill_error_detail
 from skill_loader import skill_script_import_context
 
 _SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
@@ -821,7 +822,7 @@ class TestGsplatRelightingSkills:
             )
 
         assert result["success"] is False
-        assert "resolution parameters" in result["error"]
+        assert "resolution parameters" in skill_error_detail(result)
         raster.destroy.assert_called_once_with()
         sop_import.destroy.assert_called_once_with()
 


### PR DESCRIPTION
## Summary

- read bounded exception messages from the Core 0.20 structured error metadata
- keep assertion compatibility with the Core 0.19 legacy error field
- cover both envelope shapes with regression tests

## Validation

- Core 0.19.91: 971 passed, 1 skipped, 3 deselected
- Core 0.20.11: 971 passed, 1 skipped, 3 deselected
- Ruff check and format
- Python 3.7 syntax check
- Skill lint

Fixes #274