### PR TITLE
fix: prevent release asset overwrites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-please, build, quickinstall]
     if: needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '')
+    concurrency:
+      group: release-assets-${{ github.repository }}-${{ needs.release-please.outputs.tag_name }}
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -329,6 +332,17 @@ jobs:
           if match is None or manifest != expected or match.group(1) != expected:
               raise SystemExit("Checked-out package version does not match the release target.")
           PY
+      - name: Stage release asset guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          guard_path="$RUNNER_TEMP/check_release_assets.py"
+          if ! git show "${GITHUB_SHA}:tools/check_release_assets.py" > "$guard_path"; then
+            rm -f "$guard_path"
+            echo "Release asset guard source is unavailable." >&2
+            exit 1
+          fi
+          chmod 0500 "$guard_path"
       - name: Download dist artifacts
         uses: actions/download-artifact@v8
         with:
@@ -340,10 +354,25 @@ jobs:
           path: dist_houdini/
           pattern: houdini-quickinstall-*
           merge-multiple: true
+      - name: Guard immutable release assets
+        env:
+          GH_HOST: github.com
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_TAG: ${{ needs.release-please.outputs.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python "$RUNNER_TEMP/check_release_assets.py" \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$EXPECTED_TAG" \
+            --pattern "dist/*" \
+            --pattern "dist_houdini/*.zip"
       - name: Attach assets to release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
+          overwrite_files: false
+          fail_on_unmatched_files: true
           files: |
             dist/*
             dist_houdini/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,7 @@ jobs:
             --pattern "dist/*" \
             --pattern "dist_houdini/*.zip"
       - name: Attach assets to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           overwrite_files: false

--- a/tests/test_release_asset_guard.py
+++ b/tests/test_release_asset_guard.py
@@ -1,0 +1,169 @@
+"""Executable tests for immutable GitHub release asset uploads."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "check_release_assets.py"
+
+
+class _FakeGh:
+    def __init__(self, *responses: Tuple[int, str, str]) -> None:
+        self.responses = list(responses)
+        self.calls: List[Tuple[List[str], Dict[str, Any]]] = []
+
+    def __call__(self, command: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        self.calls.append((command, kwargs))
+        returncode, stdout, stderr = self.responses.pop(0)
+        return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr=stderr)
+
+
+def _load_guard() -> Any:
+    assert SCRIPT.is_file(), "release asset guard script is missing"
+    spec = importlib.util.spec_from_file_location("release_asset_guard", str(SCRIPT))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(
+    tmp_path: Path,
+    fake: _FakeGh,
+    patterns: Optional[List[str]] = None,
+    environ: Optional[Dict[str, str]] = None,
+) -> int:
+    module = _load_guard()
+    arguments = ["--repository", "dcc-mcp/dcc-mcp-houdini", "--tag", "v1.2.3"]
+    for pattern in patterns or ["dist/*"]:
+        arguments.extend(["--pattern", pattern])
+    environment = {"GH_TOKEN": "PRIVATE_TOKEN_71aa", "GH_HOST": "private.invalid"}
+    if environ:
+        environment.update(environ)
+    return module.main(arguments, environ=environment, cwd=tmp_path, runner=fake)
+
+
+def test_missing_artifact_pattern_fails_before_github_io(tmp_path: Path, capsys: Any) -> None:
+    fake = _FakeGh()
+
+    assert _run(tmp_path, fake) == 1
+    assert fake.calls == []
+    assert capsys.readouterr().err == "release asset guard failed: artifact_pattern_unmatched\n"
+
+
+def test_duplicate_local_basenames_fail_before_github_io(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "quick").mkdir()
+    (tmp_path / "dist" / "same.zip").write_bytes(b"wheel")
+    (tmp_path / "quick" / "same.zip").write_bytes(b"quickinstall")
+    fake = _FakeGh()
+
+    assert _run(tmp_path, fake, ["dist/*", "quick/*"]) == 1
+    assert fake.calls == []
+    assert capsys.readouterr().err == "release asset guard failed: duplicate_artifact_basename\n"
+
+
+def test_missing_release_allows_new_unicode_assets_and_forces_github_host(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "dcc_houdini_资产.zip").write_bytes(b"asset")
+    fake = _FakeGh((0, json.dumps([[]]), ""))
+
+    assert _run(tmp_path, fake) == 0
+    assert capsys.readouterr().err == ""
+    assert len(fake.calls) == 1
+    command, kwargs = fake.calls[0]
+    assert command == [
+        "gh",
+        "api",
+        "--hostname",
+        "github.com",
+        "--paginate",
+        "--slurp",
+        "repos/dcc-mcp/dcc-mcp-houdini/releases?per_page=100",
+    ]
+    assert kwargs["env"]["GH_HOST"] == "github.com"
+    assert kwargs["env"]["GH_TOKEN"] == "PRIVATE_TOKEN_71aa"
+
+
+def test_paginated_exact_collision_fails_without_leaking_hostile_values(tmp_path: Path, capsys: Any) -> None:
+    hostile_name = "私密-REVIEW_SECRET_7f0a.zip"
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / hostile_name).write_bytes(b"asset")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 1, "tag_name": "v0.9.0"}], [{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "unrelated.whl"}], [{"name": hostile_name}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 1
+    error = capsys.readouterr().err
+    assert error == "release asset guard failed: asset_name_collision\n"
+    assert hostile_name not in error
+    assert "PRIVATE_TOKEN_71aa" not in error
+    assert str(tmp_path) not in error
+    assert fake.calls[1][0][-1] == "repos/dcc-mcp/dcc-mcp-houdini/releases/77/assets?per_page=100"
+
+
+def test_unrelated_existing_assets_allow_upload(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "new.whl").write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "old.whl"}, {"name": "旧.zip"}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_github_api_failure_is_fail_closed_and_redacted(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "new.whl").write_bytes(b"wheel")
+    fake = _FakeGh((1, "", "PRIVATE_TOKEN_71aa /private/release/path"))
+
+    assert _run(tmp_path, fake) == 1
+    error = capsys.readouterr().err
+    assert error == "release asset guard failed: github_api_unavailable\n"
+    assert "PRIVATE_TOKEN_71aa" not in error
+    assert "/private/release/path" not in error
+
+
+def test_empty_pattern_and_malformed_api_payload_fail_closed(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "new.whl").write_bytes(b"wheel")
+
+    assert _run(tmp_path, _FakeGh(), [""]) == 1
+    assert capsys.readouterr().err == "release asset guard failed: invalid_artifact_pattern\n"
+
+    fake = _FakeGh((0, "{not-json", ""))
+    assert _run(tmp_path, fake) == 1
+    assert capsys.readouterr().err == "release asset guard failed: github_api_invalid_response\n"
+
+
+def test_script_cli_rejects_missing_glob_with_stable_error(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repository",
+            "dcc-mcp/dcc-mcp-houdini",
+            "--tag",
+            "v1.2.3",
+            "--pattern",
+            "dist/*",
+        ],
+        cwd=str(tmp_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert completed.stderr == "release asset guard failed: artifact_pattern_unmatched\n"

--- a/tests/test_release_asset_guard.py
+++ b/tests/test_release_asset_guard.py
@@ -69,6 +69,17 @@ def test_duplicate_local_basenames_fail_before_github_io(tmp_path: Path, capsys:
     assert capsys.readouterr().err == "release asset guard failed: duplicate_artifact_basename\n"
 
 
+def test_local_raw_and_aligned_identity_overlap_fails_before_github_io(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "artifact name.whl").write_bytes(b"first")
+    (tmp_path / "dist" / "artifact.name.whl").write_bytes(b"second")
+    fake = _FakeGh((0, json.dumps([[]]), ""))
+
+    assert _run(tmp_path, fake) == 1
+    assert fake.calls == []
+    assert capsys.readouterr().err == "release asset guard failed: duplicate_artifact_identity\n"
+
+
 def test_missing_release_allows_new_unicode_assets_and_forces_github_host(tmp_path: Path, capsys: Any) -> None:
     (tmp_path / "dist").mkdir()
     (tmp_path / "dist" / "dcc_houdini_资产.zip").write_bytes(b"asset")
@@ -109,12 +120,75 @@ def test_paginated_exact_collision_fails_without_leaking_hostile_values(tmp_path
     assert fake.calls[1][0][-1] == "repos/dcc-mcp/dcc-mcp-houdini/releases/77/assets?per_page=100"
 
 
+def test_remote_aligned_name_collision_is_rejected(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "artifact name.whl").write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "artifact.name.whl", "label": None}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 1
+    assert capsys.readouterr().err == "release asset guard failed: asset_name_collision\n"
+
+
+def test_alignment_replaces_each_ascii_space_without_changing_unicode(tmp_path: Path, capsys: Any) -> None:
+    local_name = "资产  build.whl"
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / local_name).write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "资产..build.whl"}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 1
+    error = capsys.readouterr().err
+    assert error == "release asset guard failed: asset_name_collision\n"
+    assert local_name not in error
+
+
+def test_remote_label_collision_is_rejected_when_github_rewrote_the_name(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "artifact.whl").write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "rewritten.whl", "label": "artifact.whl"}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 1
+    assert capsys.readouterr().err == "release asset guard failed: asset_name_collision\n"
+
+
+def test_remote_label_is_not_over_normalized(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "artifact name.whl").write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "unrelated.whl", "label": "artifact.name.whl"}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 0
+    assert capsys.readouterr().err == ""
+
+
 def test_unrelated_existing_assets_allow_upload(tmp_path: Path, capsys: Any) -> None:
     (tmp_path / "dist").mkdir()
     (tmp_path / "dist" / "new.whl").write_bytes(b"wheel")
     fake = _FakeGh(
         (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
         (0, json.dumps([[{"name": "old.whl"}, {"name": "旧.zip"}]]), ""),
+    )
+
+    assert _run(tmp_path, fake) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_already_dotted_local_name_does_not_collide_with_itself(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "already.dotted.whl").write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "unrelated.whl", "label": None}]]), ""),
     )
 
     assert _run(tmp_path, fake) == 0
@@ -141,6 +215,18 @@ def test_empty_pattern_and_malformed_api_payload_fail_closed(tmp_path: Path, cap
     assert capsys.readouterr().err == "release asset guard failed: invalid_artifact_pattern\n"
 
     fake = _FakeGh((0, "{not-json", ""))
+    assert _run(tmp_path, fake) == 1
+    assert capsys.readouterr().err == "release asset guard failed: github_api_invalid_response\n"
+
+
+def test_non_string_remote_label_fails_closed(tmp_path: Path, capsys: Any) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "artifact.whl").write_bytes(b"wheel")
+    fake = _FakeGh(
+        (0, json.dumps([[{"id": 77, "tag_name": "v1.2.3"}]]), ""),
+        (0, json.dumps([[{"name": "unrelated.whl", "label": 7}]]), ""),
+    )
+
     assert _run(tmp_path, fake) == 1
     assert capsys.readouterr().err == "release asset guard failed: github_api_invalid_response\n"
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -158,3 +158,36 @@ def test_publish_uses_oidc_only_and_jobs_keep_least_privilege() -> None:
     assert "password" not in publishers[0].get("with", {})
     attach_step = [step for step in attach["steps"] if step.get("uses", "").startswith("softprops/action-gh-release@")]
     assert attach_step[0]["with"]["tag_name"] == "${{ needs.release-please.outputs.tag_name }}"
+
+
+def test_release_assets_are_guarded_before_immutable_upload() -> None:
+    workflow = _release_workflow()
+    attach_job = workflow["jobs"]["attach-release-assets"]
+    steps = attach_job["steps"]
+
+    assert attach_job["concurrency"] == {
+        "group": "release-assets-${{ github.repository }}-${{ needs.release-please.outputs.tag_name }}",
+        "cancel-in-progress": "false",
+    }
+
+    stage = [step for step in steps if step.get("name") == "Stage release asset guard"]
+    guard = [step for step in steps if step.get("name") == "Guard immutable release assets"]
+    upload = [step for step in steps if step.get("uses", "").startswith("softprops/action-gh-release@")]
+    assert len(stage) == len(guard) == len(upload) == 1
+    assert steps.index(stage[0]) < steps.index(guard[0]) < steps.index(upload[0])
+
+    assert 'git show "${GITHUB_SHA}:tools/check_release_assets.py"' in stage[0]["run"]
+    assert "$RUNNER_TEMP/check_release_assets.py" in stage[0]["run"]
+    assert guard[0]["env"] == {
+        "GH_HOST": "github.com",
+        "GH_TOKEN": "${{ github.token }}",
+        "EXPECTED_TAG": "${{ needs.release-please.outputs.tag_name }}",
+    }
+    guard_run = guard[0]["run"]
+    assert 'python "$RUNNER_TEMP/check_release_assets.py"' in guard_run
+    assert '--repository "$GITHUB_REPOSITORY"' in guard_run
+    assert '--tag "$EXPECTED_TAG"' in guard_run
+    assert '--pattern "dist/*"' in guard_run
+    assert '--pattern "dist_houdini/*.zip"' in guard_run
+    assert upload[0]["with"]["overwrite_files"] == "false"
+    assert upload[0]["with"]["fail_on_unmatched_files"] == "true"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -175,6 +175,7 @@ def test_release_assets_are_guarded_before_immutable_upload() -> None:
     upload = [step for step in steps if step.get("uses", "").startswith("softprops/action-gh-release@")]
     assert len(stage) == len(guard) == len(upload) == 1
     assert steps.index(stage[0]) < steps.index(guard[0]) < steps.index(upload[0])
+    assert upload[0]["uses"] == "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228"
 
     assert 'git show "${GITHUB_SHA}:tools/check_release_assets.py"' in stage[0]["run"]
     assert "$RUNNER_TEMP/check_release_assets.py" in stage[0]["run"]

--- a/tools/check_release_assets.py
+++ b/tools/check_release_assets.py
@@ -1,0 +1,178 @@
+"""Fail closed before attaching immutable GitHub release assets."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple
+
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_TAG = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")
+_GH_TIMEOUT_SECONDS = 30
+
+
+class GuardError(Exception):
+    """Stable public failure raised by the release asset guard."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _parse_args(arguments: Sequence[str]) -> Tuple[str, str, List[str]]:
+    repository: Optional[str] = None
+    tag: Optional[str] = None
+    patterns: List[str] = []
+    index = 0
+    while index < len(arguments):
+        option = arguments[index]
+        if option not in ("--repository", "--tag", "--pattern") or index + 1 >= len(arguments):
+            raise GuardError("invalid_arguments")
+        value = arguments[index + 1]
+        if option == "--repository" and repository is None:
+            repository = value
+        elif option == "--tag" and tag is None:
+            tag = value
+        elif option == "--pattern":
+            patterns.append(value)
+        else:
+            raise GuardError("invalid_arguments")
+        index += 2
+
+    if repository is None or _REPOSITORY.fullmatch(repository) is None:
+        raise GuardError("invalid_repository")
+    if tag is None or _TAG.fullmatch(tag) is None:
+        raise GuardError("invalid_tag")
+    if not patterns:
+        raise GuardError("invalid_artifact_pattern")
+    return repository, tag, patterns
+
+
+def _validate_pattern(pattern: str) -> None:
+    portable = pattern.replace("\\", "/")
+    parts = PurePosixPath(portable).parts
+    if not pattern or portable.startswith("/") or _WINDOWS_DRIVE.match(portable) or ".." in parts:
+        raise GuardError("invalid_artifact_pattern")
+
+
+def _artifact_basenames(patterns: Sequence[str], cwd: Path) -> Set[str]:
+    basenames: List[str] = []
+    for pattern in patterns:
+        _validate_pattern(pattern)
+        matched = sorted(Path(value) for value in glob.glob(str(cwd / pattern)))
+        if not matched:
+            raise GuardError("artifact_pattern_unmatched")
+        if any(path.is_symlink() or not path.is_file() for path in matched):
+            raise GuardError("artifact_not_regular")
+        basenames.extend(path.name for path in matched)
+
+    if len(basenames) != len(set(basenames)):
+        raise GuardError("duplicate_artifact_basename")
+    return set(basenames)
+
+
+def _github_pages(
+    endpoint: str,
+    environ: Mapping[str, str],
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> List[List[Dict[str, Any]]]:
+    child_env = dict(environ)
+    child_env["GH_HOST"] = "github.com"
+    command = [
+        "gh",
+        "api",
+        "--hostname",
+        "github.com",
+        "--paginate",
+        "--slurp",
+        endpoint,
+    ]
+    try:
+        completed = runner(
+            command,
+            env=child_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=_GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise GuardError("github_api_unavailable") from None
+    if completed.returncode != 0:
+        raise GuardError("github_api_unavailable")
+    try:
+        pages = json.loads(completed.stdout)
+    except (TypeError, ValueError):
+        raise GuardError("github_api_invalid_response") from None
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise GuardError("github_api_invalid_response")
+    if any(not isinstance(item, dict) for page in pages for item in page):
+        raise GuardError("github_api_invalid_response")
+    return pages
+
+
+def _existing_asset_names(
+    repository: str,
+    tag: str,
+    environ: Mapping[str, str],
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> Set[str]:
+    release_pages = _github_pages("repos/{}/releases?per_page=100".format(repository), environ, runner)
+    matching = [item for page in release_pages for item in page if item.get("tag_name") == tag]
+    if not matching:
+        return set()
+    if len(matching) != 1:
+        raise GuardError("github_api_invalid_response")
+    release_id = matching[0].get("id")
+    if isinstance(release_id, bool) or not isinstance(release_id, int) or release_id <= 0:
+        raise GuardError("github_api_invalid_response")
+
+    asset_pages = _github_pages(
+        "repos/{}/releases/{}/assets?per_page=100".format(repository, release_id), environ, runner
+    )
+    names: Set[str] = set()
+    for page in asset_pages:
+        for asset in page:
+            name = asset.get("name")
+            if not isinstance(name, str) or not name:
+                raise GuardError("github_api_invalid_response")
+            names.add(name)
+    return names
+
+
+def main(
+    arguments: Optional[Sequence[str]] = None,
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+    cwd: Optional[Path] = None,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> int:
+    """Validate local artifacts and refuse exact-name release collisions."""
+
+    try:
+        repository, tag, patterns = _parse_args(list(arguments if arguments is not None else sys.argv[1:]))
+        environment = dict(environ if environ is not None else os.environ)
+        artifact_names = _artifact_basenames(patterns, cwd if cwd is not None else Path.cwd())
+        if not environment.get("GH_TOKEN"):
+            raise GuardError("github_token_missing")
+        existing_names = _existing_asset_names(repository, tag, environment, runner)
+        if artifact_names.intersection(existing_names):
+            raise GuardError("asset_name_collision")
+    except GuardError as exc:
+        sys.stderr.write("release asset guard failed: {}\n".format(exc.code))
+        return 1
+    except Exception:
+        sys.stderr.write("release asset guard failed: internal_error\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_release_assets.py
+++ b/tools/check_release_assets.py
@@ -77,6 +77,24 @@ def _artifact_basenames(patterns: Sequence[str], cwd: Path) -> Set[str]:
     return set(basenames)
 
 
+def _align_asset_name(asset_name: str) -> str:
+    """Mirror action-gh-release@3d0d9888's exact ASCII-space alignment."""
+
+    return asset_name.replace(" ", ".")
+
+
+def _upload_match_names(asset_names: Set[str]) -> Set[str]:
+    """Return non-overlapping raw/aligned names matched by action-gh-release."""
+
+    identities: Set[str] = set()
+    for asset_name in sorted(asset_names):
+        current = {asset_name, _align_asset_name(asset_name)}
+        if identities.intersection(current):
+            raise GuardError("duplicate_artifact_identity")
+        identities.update(current)
+    return identities
+
+
 def _github_pages(
     endpoint: str,
     environ: Mapping[str, str],
@@ -118,16 +136,16 @@ def _github_pages(
     return pages
 
 
-def _existing_asset_names(
+def _existing_asset_identities(
     repository: str,
     tag: str,
     environ: Mapping[str, str],
     runner: Callable[..., subprocess.CompletedProcess],
-) -> Set[str]:
+) -> Tuple[Set[str], Set[str]]:
     release_pages = _github_pages("repos/{}/releases?per_page=100".format(repository), environ, runner)
     matching = [item for page in release_pages for item in page if item.get("tag_name") == tag]
     if not matching:
-        return set()
+        return set(), set()
     if len(matching) != 1:
         raise GuardError("github_api_invalid_response")
     release_id = matching[0].get("id")
@@ -138,13 +156,19 @@ def _existing_asset_names(
         "repos/{}/releases/{}/assets?per_page=100".format(repository, release_id), environ, runner
     )
     names: Set[str] = set()
+    labels: Set[str] = set()
     for page in asset_pages:
         for asset in page:
             name = asset.get("name")
             if not isinstance(name, str) or not name:
                 raise GuardError("github_api_invalid_response")
+            label = asset.get("label")
+            if label is not None and not isinstance(label, str):
+                raise GuardError("github_api_invalid_response")
             names.add(name)
-    return names
+            if label is not None:
+                labels.add(label)
+    return names, labels
 
 
 def main(
@@ -160,10 +184,11 @@ def main(
         repository, tag, patterns = _parse_args(list(arguments if arguments is not None else sys.argv[1:]))
         environment = dict(environ if environ is not None else os.environ)
         artifact_names = _artifact_basenames(patterns, cwd if cwd is not None else Path.cwd())
+        upload_match_names = _upload_match_names(artifact_names)
         if not environment.get("GH_TOKEN"):
             raise GuardError("github_token_missing")
-        existing_names = _existing_asset_names(repository, tag, environment, runner)
-        if artifact_names.intersection(existing_names):
+        existing_names, existing_labels = _existing_asset_identities(repository, tag, environment, runner)
+        if upload_match_names.intersection(existing_names) or artifact_names.intersection(existing_labels):
             raise GuardError("asset_name_collision")
     except GuardError as exc:
         sys.stderr.write("release asset guard failed: {}\n".format(exc.code))


### PR DESCRIPTION
## Summary

- reject missing, duplicate, or colliding release assets using the uploader's raw, space-aligned, and label identities
- bind paginated GitHub checks to github.com, the exact repository, and the resolved tag
- pin the uploader matcher, serialize same-tag uploads, disable overwrite, and require every upload glob to match
- keep manual backfills protected by staging the guard from the workflow commit

## Verification

- `1141 passed, 1 skipped, 3 deselected`
- release guard and parsed workflow contracts: `25 passed`
- Ruff check/format, Python 3.7 syntax, actionlint, and Skill lint with dcc-mcp-cli 0.20.20
- wheel/sdist build and Twine check
- win64, Linux, and macOS quickinstall build and version verification

No licensed Houdini session was used; the licensed-host conditional test remained skipped.

Closes #278