### PR TITLE
fix: make Houdini texture assignment fail closed

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -72,10 +72,15 @@ presets).
   library path when sharing across projects; choose lookdev presets for
   quick per-user snapshots.
 - **Texture mapping:** `assign_texture` uses built-in texture controls on
-  `principledshader` nodes, updates string file parameters on `mtlximage` and
-  `arnold::image`, or creates the matching image node for an exact input on
-  `mtlxstandard_surface` and `arnold::standard_surface`. Other node types and
-  missing parameters fail closed without fallback wiring.
+  `principledshader` nodes, updates only the typed file-path parameters on
+  `mtlximage` and `arnold::image`, or creates the matching image node for an
+  exact input on `mtlxstandard_surface` and `arnold::standard_surface`. The
+  texture must remain one regular, non-linked local file through every guarded
+  mutation and readback. Owned image nodes are bound to material, node, input,
+  and Houdini session identity; stale or duplicate ownership fails closed.
+  Every touched parameter, input, and newly created node is rolled back if
+  mutation or post-mutation verification fails. Other node types and missing
+  parameters fail closed without fallback wiring.
 - **OCIO:** `list_color_spaces` reads from Houdini's active OCIO config;
   `set_color_management` sets the `OCIO` environment variable and triggers a
   Houdini refresh when possible.

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -71,9 +71,11 @@ presets).
   parameters; lookdev presets capture evaluated values only.  Choose the
   library path when sharing across projects; choose lookdev presets for
   quick per-user snapshots.
-- **Texture mapping:** `assign_texture` creates a file texture VOP
-  (`arnold::image` / `mtlximage` / `principledshader` map) or sets a string
-  file-path parameter on the target material node.
+- **Texture mapping:** `assign_texture` uses built-in texture controls on
+  `principledshader` nodes, updates string file parameters on `mtlximage` and
+  `arnold::image`, or creates the matching image node for an exact input on
+  `mtlxstandard_surface` and `arnold::standard_surface`. Other node types and
+  missing parameters fail closed without fallback wiring.
 - **OCIO:** `list_color_spaces` reads from Houdini's active OCIO config;
   `set_color_management` sets the `OCIO` environment variable and triggers a
   Houdini refresh when possible.

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -77,7 +77,9 @@ presets).
   exact input on `mtlxstandard_surface` and `arnold::standard_surface`. The
   texture must remain one regular, non-linked local file through every guarded
   mutation and readback. Digest work is limited to one initial pass, a 256 MiB
-  file ceiling, and a bounded deadline; later main-thread guards recapture only
+  file ceiling, and an elapsed-time budget checked before and after every read,
+  including EOF. On Windows, a native read lease denies writes and replacement
+  until mutation, final readback, and undo exit complete; later guards recapture
   physical identity metadata. Owned image nodes are bound to a durable material
   identity plus node, input, and Houdini session identity; stale or duplicate
   ownership fails closed.

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/SKILL.md
@@ -76,8 +76,11 @@ presets).
   `mtlximage` and `arnold::image`, or creates the matching image node for an
   exact input on `mtlxstandard_surface` and `arnold::standard_surface`. The
   texture must remain one regular, non-linked local file through every guarded
-  mutation and readback. Owned image nodes are bound to material, node, input,
-  and Houdini session identity; stale or duplicate ownership fails closed.
+  mutation and readback. Digest work is limited to one initial pass, a 256 MiB
+  file ceiling, and a bounded deadline; later main-thread guards recapture only
+  physical identity metadata. Owned image nodes are bound to a durable material
+  identity plus node, input, and Houdini session identity; stale or duplicate
+  ownership fails closed.
   Every touched parameter, input, and newly created node is rolled back if
   mutation or post-mutation verification fails. Other node types and missing
   parameters fail closed without fallback wiring.

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -26,6 +26,7 @@ _IMAGE_FILE_PARMS = {
 }
 _PARAMETER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 _OWNER_USER_DATA_KEY = "dcc_mcp.assign_texture.owner"
+_MATERIAL_OWNERSHIP_REGISTRY: dict[tuple[int, int], Any] = {}
 
 
 class _TextureFileError(RuntimeError):
@@ -34,6 +35,10 @@ class _TextureFileError(RuntimeError):
 
 class _OwnershipError(RuntimeError):
     """An ambiguous or stale ownership contract."""
+
+
+class _TextureParameterError(RuntimeError):
+    """The host parameter shape is not a supported texture file slot."""
 
 
 @dataclass(frozen=True)
@@ -223,6 +228,7 @@ def _assign_direct_texture(
     texture_ref: _TextureFileRef,
     colorspace: Optional[str],
     undo_label: str,
+    outer_snapshots: list[tuple[Any, Any]],
 ) -> dict:
     node_type = texture_node.type().name()
     if parameter_name not in _IMAGE_FILE_PARMS.get(node_type, ()):
@@ -260,6 +266,7 @@ def _assign_direct_texture(
         if cs_parm is not None:
             _assert_texture_file_current(texture_ref)
             snapshots.append((cs_parm, cs_parm.eval()))
+        outer_snapshots.extend(snapshots)
         _assert_texture_file_current(texture_ref)
         parm.set(texture_path)
         if cs_parm is not None:
@@ -308,7 +315,7 @@ def _destroy_created_node(node: Any) -> bool:
         name = node.name()
         node.destroy()
         return parent.node(name) is not node
-    except Exception:  # noqa: BLE001
+    except BaseException:  # noqa: BLE001
         return False
 
 
@@ -344,6 +351,16 @@ def _parent_children(parent: Any) -> tuple[Any, ...]:
     return tuple(children() if callable(children) else children)
 
 
+def _is_registered_material(material_node: Any, input_index: int) -> bool:
+    registered = _MATERIAL_OWNERSHIP_REGISTRY.get((_node_session_id(material_node), input_index))
+    if registered is None:
+        return False
+    try:
+        return registered is material_node or bool(registered == material_node)
+    except BaseException:  # noqa: BLE001
+        return False
+
+
 def _find_owned_texture(material_node: Any, input_index: int, texture_type: str) -> Optional[Any]:
     material_session = _node_session_id(material_node)
     material_path = material_node.path()
@@ -367,6 +384,11 @@ def _find_owned_texture(material_node: Any, input_index: int, texture_type: str)
             if parts[4] == material_path:
                 raise _OwnershipError("stale material session ownership")
             continue
+        registered_material = _MATERIAL_OWNERSHIP_REGISTRY.get((material_session, input_index))
+        if registered_material is not None and not _is_registered_material(material_node, input_index):
+            raise _OwnershipError("material session identity was reused")
+        if parts[4] != material_path and not _is_registered_material(material_node, input_index):
+            raise _OwnershipError("stale material path ownership")
         if marker_node_session != _node_session_id(node) or node.type().name() != texture_type:
             raise _OwnershipError("stale texture node ownership")
         owned.append(node)
@@ -376,6 +398,7 @@ def _find_owned_texture(material_node: Any, input_index: int, texture_type: str)
 
 
 def _assign_wired_material(
+    hou: Any,
     material_node: Any,
     material_type: str,
     parameter_name: str,
@@ -421,12 +444,6 @@ def _assign_wired_material(
         if created:
             _assert_texture_file_current(texture_ref)
             texture_node = material_node.parent().createNode(texture_type)
-            owner_marker = _owner_marker(material_node, input_index, texture_node)
-            _assert_texture_file_current(texture_ref)
-            texture_node.setUserData(_OWNER_USER_DATA_KEY, owner_marker)
-            _assert_texture_file_current(texture_ref)
-            if texture_node.userData(_OWNER_USER_DATA_KEY) != owner_marker:
-                raise RuntimeError("ownership readback mismatch")
         else:
             texture_node = owned_texture
 
@@ -435,7 +452,20 @@ def _assign_wired_material(
             None,
         )
         if file_parm is None:
-            raise RuntimeError("texture node has no supported file parameter")
+            raise _TextureParameterError("texture node has no supported file parameter")
+        try:
+            file_parm_type = file_parm.parmTemplate().type()
+        except BaseException as exc:  # noqa: BLE001
+            raise _TextureParameterError("texture file parameter type is unreadable") from exc
+        if file_parm_type != hou.parmTemplateType.String:
+            raise _TextureParameterError("texture file parameter is not a string")
+        if created:
+            owner_marker = _owner_marker(material_node, input_index, texture_node)
+            _assert_texture_file_current(texture_ref)
+            texture_node.setUserData(_OWNER_USER_DATA_KEY, owner_marker)
+            _assert_texture_file_current(texture_ref)
+            if texture_node.userData(_OWNER_USER_DATA_KEY) != owner_marker:
+                raise RuntimeError("ownership readback mismatch")
         _assert_texture_file_current(texture_ref)
         snapshots = [(file_parm, file_parm.eval())]
         _assert_texture_file_current(texture_ref)
@@ -455,7 +485,7 @@ def _assign_wired_material(
         texture_summary = node_summary(texture_node)
         _assert_texture_file_current(texture_ref)
         texture_node_path = texture_node.path()
-        return skill_success(
+        result = skill_success(
             "Assigned and wired texture to material",
             material=material_summary,
             parameter=parameter_name,
@@ -471,6 +501,9 @@ def _assign_wired_material(
                 "texture_path": str(texture_readback),
             },
         )
+        material_session = _node_session_id(material_node)
+        _MATERIAL_OWNERSHIP_REGISTRY[(material_session, input_index)] = material_node
+        return result
     except BaseException as exc:  # noqa: BLE001
         rollback_ok = _rollback_parms(snapshots) if snapshots else True
         try:
@@ -489,6 +522,12 @@ def _assign_wired_material(
             )
         if isinstance(exc, _TextureFileError):
             return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
+        if isinstance(exc, _TextureParameterError):
+            return skill_error(
+                "Texture node has no supported string file parameter",
+                "UNSUPPORTED_TEXTURE_PARAMETER",
+                node_type=texture_type,
+            )
         return skill_error("Texture could not be wired to the material input", "TEXTURE_WIRING_FAILED")
 
 
@@ -555,6 +594,7 @@ def assign_texture(
         )
 
     undo_label = "DCC MCP: assign texture {}".format(parameter_name)
+    outer_snapshots: list[tuple[Any, Any]] = []
     try:
         with _undo_group(hou, undo_label):
             if target_type in _PRINCIPLED_SHADER_TYPES:
@@ -575,8 +615,10 @@ def assign_texture(
                     texture_ref,
                     colorspace,
                     undo_label,
+                    outer_snapshots,
                 )
             return _assign_wired_material(
+                hou,
                 target_node,
                 target_type,
                 parameter_name,
@@ -586,6 +628,11 @@ def assign_texture(
                 undo_label,
             )
     except BaseException:  # noqa: BLE001
+        if outer_snapshots and not _rollback_parms(outer_snapshots):
+            return skill_error(
+                "Texture assignment failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -8,7 +8,7 @@ import re
 import stat
 import time
 import uuid
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -63,7 +63,60 @@ def _is_reparse(stat_result: os.stat_result) -> bool:
     return bool(getattr(stat_result, "st_file_attributes", 0) & reparse_flag)
 
 
-def _capture_texture_file(texture_path: str) -> _TextureFileRef:
+@contextmanager
+def _texture_file_lease(texture_path: str):
+    """Hold one readable file identity, denying writes on Windows."""
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    if os.name != "nt":
+        fd = os.open(texture_path, flags)
+        try:
+            yield fd
+        finally:
+            os.close(fd)
+        return
+
+    import ctypes  # noqa: PLC0415
+    import msvcrt  # noqa: PLC0415
+    from ctypes import wintypes  # noqa: PLC0415
+
+    create_file = ctypes.WinDLL("kernel32", use_last_error=True).CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        texture_path,
+        0x80000000,  # GENERIC_READ
+        0x00000001,  # FILE_SHARE_READ: deny write and delete while leased
+        None,
+        3,  # OPEN_EXISTING
+        0x08000000,  # FILE_FLAG_SEQUENTIAL_SCAN
+        None,
+    )
+    invalid_handle = wintypes.HANDLE(-1).value
+    if handle == invalid_handle:
+        error = ctypes.get_last_error()
+        if error in (2, 3):
+            raise FileNotFoundError(error, "texture file was not found")
+        raise OSError(error, "texture file lease could not be acquired")
+    try:
+        fd = msvcrt.open_osfhandle(handle, flags)
+    except BaseException:  # noqa: BLE001
+        ctypes.WinDLL("kernel32", use_last_error=True).CloseHandle(handle)
+        raise
+    try:
+        yield fd
+    finally:
+        os.close(fd)
+
+
+def _capture_texture_file(texture_path: str, fd: int) -> _TextureFileRef:
     path = Path(texture_path).absolute()
     try:
         lexical = os.path.normcase(os.path.normpath(str(path)))
@@ -89,26 +142,24 @@ def _capture_texture_file(texture_path: str) -> _TextureFileRef:
         if path_stat.st_size > _MAX_TEXTURE_FILE_BYTES:
             raise _TextureFileError("texture file exceeds bounded validation size")
 
-        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
-        fd = os.open(str(path), flags)
-        try:
-            opened_before = os.fstat(fd)
-            digest = hashlib.sha256()
-            bytes_read = 0
-            deadline = time.monotonic() + _MAX_TEXTURE_HASH_SECS
-            while True:
-                if time.monotonic() > deadline:
-                    raise _TextureFileError("texture digest deadline exceeded")
-                chunk = os.read(fd, _TEXTURE_HASH_CHUNK_BYTES)
-                if not chunk:
-                    break
-                bytes_read += len(chunk)
-                if bytes_read > _MAX_TEXTURE_FILE_BYTES:
-                    raise _TextureFileError("texture digest exceeded bounded work")
-                digest.update(chunk)
-            opened_after = os.fstat(fd)
-        finally:
-            os.close(fd)
+        opened_before = os.fstat(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+        digest = hashlib.sha256()
+        bytes_read = 0
+        deadline = time.monotonic() + _MAX_TEXTURE_HASH_SECS
+        while True:
+            if time.monotonic() > deadline:
+                raise _TextureFileError("texture digest deadline exceeded")
+            chunk = os.read(fd, _TEXTURE_HASH_CHUNK_BYTES)
+            if time.monotonic() > deadline:
+                raise _TextureFileError("texture digest deadline exceeded")
+            if not chunk:
+                break
+            bytes_read += len(chunk)
+            if bytes_read > _MAX_TEXTURE_FILE_BYTES:
+                raise _TextureFileError("texture digest exceeded bounded work")
+            digest.update(chunk)
+        opened_after = os.fstat(fd)
         path_after = os.lstat(str(path))
     except _TextureFileError:
         raise
@@ -297,7 +348,7 @@ def _assign_principled(
                 "Texture assignment failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
             )
-        if isinstance(exc, _TextureFileError):
+        if isinstance(exc, (_TextureFileError, PermissionError)):
             return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
 
@@ -386,7 +437,7 @@ def _assign_direct_texture(
                 "Texture assignment failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
             )
-        if isinstance(exc, _TextureFileError):
+        if isinstance(exc, (_TextureFileError, PermissionError)):
             return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
 
@@ -627,7 +678,7 @@ def _assign_wired_material(
                 "Texture wiring failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
             )
-        if isinstance(exc, _TextureFileError):
+        if isinstance(exc, (_TextureFileError, PermissionError)):
             return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
         if isinstance(exc, _TextureParameterError):
             return skill_error(
@@ -638,42 +689,15 @@ def _assign_wired_material(
         return skill_error("Texture could not be wired to the material input", "TEXTURE_WIRING_FAILED")
 
 
-def assign_texture(
+def _assign_captured_texture(
+    hou: Any,
     material_path: str,
     parameter_name: str,
-    texture_path: str,
-    colorspace: Optional[str] = None,
+    texture_ref: _TextureFileRef,
+    colorspace: Optional[str],
 ) -> dict:
-    """Assign a texture to one explicitly supported material or image target."""
-    try:
-        import hou  # noqa: PLC0415
-    except ImportError:
-        return hou_import_error()
-
-    if not isinstance(material_path, str) or not material_path.startswith("/"):
-        return skill_error("Invalid Houdini material path", "INVALID_MATERIAL_PATH")
-    if not isinstance(parameter_name, str) or not _PARAMETER_NAME_RE.fullmatch(parameter_name):
-        return skill_error("Invalid texture parameter name", "INVALID_PARAMETER_NAME")
-    if not isinstance(texture_path, str) or not texture_path:
-        return skill_error("Invalid texture file path", "INVALID_TEXTURE_PATH")
-    if colorspace is not None and (not isinstance(colorspace, str) or not colorspace):
-        return skill_error("Invalid texture color space", "INVALID_COLORSPACE")
-    try:
-        texture_ref = _capture_texture_file(texture_path)
-    except FileNotFoundError:
-        return skill_error(
-            "Texture file was not found",
-            "TEXTURE_FILE_NOT_FOUND",
-            prompt="Check the texture path and try again.",
-        )
-    except _TextureFileError:
-        return skill_error(
-            "Texture file could not be used safely",
-            "UNSAFE_TEXTURE_FILE",
-            prompt="Use a stable local regular file with no links or reparse points.",
-        )
+    """Mutate Houdini while the captured texture file lease remains held."""
     texture_path = texture_ref.path
-
     try:
         target_node = get_node(hou, material_path)
         target_type = target_node.type().name()
@@ -756,6 +780,50 @@ def assign_texture(
                 "TEXTURE_ROLLBACK_FAILED",
             )
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
+
+
+def assign_texture(
+    material_path: str,
+    parameter_name: str,
+    texture_path: str,
+    colorspace: Optional[str] = None,
+) -> dict:
+    """Assign a texture to one explicitly supported material or image target."""
+    try:
+        import hou  # noqa: PLC0415
+    except ImportError:
+        return hou_import_error()
+
+    if not isinstance(material_path, str) or not material_path.startswith("/"):
+        return skill_error("Invalid Houdini material path", "INVALID_MATERIAL_PATH")
+    if not isinstance(parameter_name, str) or not _PARAMETER_NAME_RE.fullmatch(parameter_name):
+        return skill_error("Invalid texture parameter name", "INVALID_PARAMETER_NAME")
+    if not isinstance(texture_path, str) or not texture_path:
+        return skill_error("Invalid texture file path", "INVALID_TEXTURE_PATH")
+    if colorspace is not None and (not isinstance(colorspace, str) or not colorspace):
+        return skill_error("Invalid texture color space", "INVALID_COLORSPACE")
+    try:
+        with _texture_file_lease(texture_path) as fd:
+            texture_ref = _capture_texture_file(texture_path, fd)
+            return _assign_captured_texture(hou, material_path, parameter_name, texture_ref, colorspace)
+    except FileNotFoundError:
+        return skill_error(
+            "Texture file was not found",
+            "TEXTURE_FILE_NOT_FOUND",
+            prompt="Check the texture path and try again.",
+        )
+    except _TextureFileError:
+        return skill_error(
+            "Texture file could not be used safely",
+            "UNSAFE_TEXTURE_FILE",
+            prompt="Use a stable local regular file with no links or reparse points.",
+        )
+    except OSError:
+        return skill_error(
+            "Texture file could not be leased safely",
+            "UNSAFE_TEXTURE_FILE",
+            prompt="Close writers and use a stable local regular file.",
+        )
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -18,6 +18,7 @@ _WIRED_MATERIAL_NODE_TYPES = {
 }
 _IMAGE_FILE_PARMS = ("filename", "file", "texturefile", "tex0")
 _PARAMETER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+_OWNER_USER_DATA_KEY = "dcc_mcp.assign_texture.owner"
 
 
 def _detect_colorspace(texture_path: str) -> Optional[str]:
@@ -47,9 +48,9 @@ def _rollback_parms(snapshots: list[tuple[Any, Any]]) -> bool:
     try:
         for parm, value in reversed(snapshots):
             parm.set(value)
+        return all(parm.eval() == value for parm, value in snapshots)
     except Exception:  # noqa: BLE001
         return False
-    return True
 
 
 def _assign_principled(
@@ -88,7 +89,7 @@ def _assign_principled(
         material=node_summary(material_node),
         parameter=parameter_name,
         texture_path=texture_path,
-        colorspace=colorspace or _detect_colorspace(texture_path),
+        detected_colorspace=_detect_colorspace(texture_path),
         verified=True,
         undo_label=undo_label,
         readback={"texture_enabled": bool(enabled_readback), "texture_path": str(texture_readback)},
@@ -117,6 +118,16 @@ def _assign_direct_texture(
 
     cs_parm = texture_node.parm("colorspace") if colorspace else None
     try:
+        cs_parm_type = cs_parm.parmTemplate().type() if cs_parm is not None else None
+    except Exception:  # noqa: BLE001
+        cs_parm_type = None
+    if colorspace is not None and cs_parm_type != hou.parmTemplateType.String:
+        return skill_error(
+            "Explicit color space is unsupported for this texture target",
+            "UNSUPPORTED_COLORSPACE",
+            node_type=texture_node.type().name(),
+        )
+    try:
         snapshots = [(parm, parm.eval())]
         if cs_parm is not None:
             snapshots.append((cs_parm, cs_parm.eval()))
@@ -136,24 +147,42 @@ def _assign_direct_texture(
             )
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
 
+    readback = {"parameter": parameter_name, "texture_path": str(texture_readback)}
+    context = {"detected_colorspace": _detect_colorspace(texture_path)}
+    if colorspace is not None:
+        readback["colorspace"] = str(cs_parm.eval())
+        context["colorspace_applied"] = colorspace
     return skill_success(
         "Assigned texture to image node parameter",
         material=node_summary(texture_node),
         parameter=parameter_name,
         texture_path=texture_path,
-        colorspace=colorspace or _detect_colorspace(texture_path),
         verified=True,
         undo_label=undo_label,
-        readback={"parameter": parameter_name, "texture_path": str(texture_readback)},
+        readback=readback,
+        **context,
     )
 
 
 def _destroy_created_node(node: Any) -> bool:
     try:
+        parent = node.parent()
+        name = node.name()
         node.destroy()
+        return parent.node(name) is not node
     except Exception:  # noqa: BLE001
         return False
-    return True
+
+
+def _owner_marker(material_node: Any, input_index: int) -> str:
+    return "v1|{}|{}".format(material_node.path(), input_index)
+
+
+def _is_owned_texture(node: Any, texture_type: str, owner_marker: str) -> bool:
+    try:
+        return node.type().name() == texture_type and node.userData(_OWNER_USER_DATA_KEY) == owner_marker
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _assign_wired_material(
@@ -166,17 +195,50 @@ def _assign_wired_material(
 ) -> dict:
     texture_type = _WIRED_MATERIAL_NODE_TYPES[material_type]
     try:
-        texture_node = material_node.parent().createNode(texture_type)
+        input_names = tuple(material_node.inputNames())
     except Exception:  # noqa: BLE001
+        input_names = ()
+    input_index = next(
+        (index for index, name in enumerate(input_names) if name.lower() == parameter_name.lower()),
+        None,
+    )
+    if input_index is None:
         return skill_error(
-            "Required texture node could not be created",
-            "TEXTURE_NODE_CREATION_FAILED",
-            node_type=texture_type,
+            "Unsupported material texture input",
+            "UNSUPPORTED_TEXTURE_PARAMETER",
+            node_type=material_type,
         )
+
+    try:
+        previous_input = material_node.input(input_index)
+    except Exception:  # noqa: BLE001
+        return skill_error("Material input cannot be read safely", "TEXTURE_WIRING_FAILED")
+
+    owner_marker = _owner_marker(material_node, input_index)
+    created = not _is_owned_texture(previous_input, texture_type, owner_marker)
+    if created:
+        try:
+            texture_node = material_node.parent().createNode(texture_type)
+            texture_node.setUserData(_OWNER_USER_DATA_KEY, owner_marker)
+            if texture_node.userData(_OWNER_USER_DATA_KEY) != owner_marker:
+                raise RuntimeError("ownership readback mismatch")
+        except Exception:  # noqa: BLE001
+            if "texture_node" in locals() and not _destroy_created_node(texture_node):
+                return skill_error(
+                    "Texture node creation failed and rollback could not be verified",
+                    "TEXTURE_ROLLBACK_FAILED",
+                )
+            return skill_error(
+                "Required texture node could not be created",
+                "TEXTURE_NODE_CREATION_FAILED",
+                node_type=texture_type,
+            )
+    else:
+        texture_node = previous_input
 
     file_parm = next((texture_node.parm(name) for name in _IMAGE_FILE_PARMS if texture_node.parm(name)), None)
     if file_parm is None:
-        if not _destroy_created_node(texture_node):
+        if created and not _destroy_created_node(texture_node):
             return skill_error(
                 "Texture node validation failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
@@ -188,52 +250,22 @@ def _assign_wired_material(
         )
 
     try:
-        input_names = tuple(material_node.inputNames())
-    except Exception:  # noqa: BLE001
-        input_names = ()
-    input_index = next(
-        (index for index, name in enumerate(input_names) if name.lower() == parameter_name.lower()),
-        None,
-    )
-    if input_index is None:
-        if not _destroy_created_node(texture_node):
-            return skill_error(
-                "Material input validation failed and rollback could not be verified",
-                "TEXTURE_ROLLBACK_FAILED",
-            )
-        return skill_error(
-            "Unsupported material texture input",
-            "UNSUPPORTED_TEXTURE_PARAMETER",
-            node_type=material_type,
-        )
-
-    try:
-        previous_input = material_node.input(input_index)
-    except Exception:  # noqa: BLE001
-        if not _destroy_created_node(texture_node):
-            return skill_error(
-                "Material input validation failed and rollback could not be verified",
-                "TEXTURE_ROLLBACK_FAILED",
-            )
-        return skill_error("Material input cannot be read safely", "TEXTURE_WIRING_FAILED")
-
-    actual_colorspace = colorspace or _detect_colorspace(texture_path)
-    cs_parm = texture_node.parm("colorspace") if actual_colorspace else None
-    try:
+        snapshots = [(file_parm, file_parm.eval())]
         file_parm.set(texture_path)
-        if cs_parm is not None:
-            cs_parm.set(actual_colorspace)
-        material_node.setInput(input_index, texture_node, 0)
+        if created:
+            material_node.setInput(input_index, texture_node, 0)
         if file_parm.eval() != texture_path or material_node.input(input_index) is not texture_node:
             raise RuntimeError("readback mismatch")
     except Exception:  # noqa: BLE001
-        rollback_ok = True
+        rollback_ok = _rollback_parms(snapshots) if "snapshots" in locals() else False
         try:
-            if material_node.input(input_index) is texture_node:
+            if created and material_node.input(input_index) is texture_node:
                 material_node.setInput(input_index, previous_input, 0)
+            rollback_ok = material_node.input(input_index) is previous_input and rollback_ok
         except Exception:  # noqa: BLE001
             rollback_ok = False
-        rollback_ok = _destroy_created_node(texture_node) and rollback_ok
+        if created:
+            rollback_ok = _destroy_created_node(texture_node) and rollback_ok
         if not rollback_ok:
             return skill_error(
                 "Texture wiring failed and rollback could not be verified",
@@ -247,7 +279,8 @@ def _assign_wired_material(
         parameter=parameter_name,
         texture_node=node_summary(texture_node),
         texture_path=texture_path,
-        colorspace=actual_colorspace,
+        detected_colorspace=_detect_colorspace(texture_path),
+        reused_owned_node=not created,
         verified=True,
         undo_label=undo_label,
         readback={
@@ -297,6 +330,18 @@ def assign_texture(
             "Unsupported texture assignment target",
             "UNSUPPORTED_TEXTURE_TARGET",
             node_type=target_type or "unknown",
+        )
+    if colorspace is not None and target_type in _PRINCIPLED_SHADER_TYPES:
+        return skill_error(
+            "Explicit color space is unsupported for this texture target",
+            "UNSUPPORTED_COLORSPACE",
+            node_type=target_type,
+        )
+    if colorspace is not None and target_type in _WIRED_MATERIAL_NODE_TYPES:
+        return skill_error(
+            "Explicit color space is unsupported for this texture target",
+            "UNSUPPORTED_COLORSPACE",
+            node_type=target_type,
         )
 
     undo_label = "DCC MCP: assign texture {}".format(parameter_name)

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -6,6 +6,8 @@ import hashlib
 import os
 import re
 import stat
+import time
+import uuid
 from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,7 +28,10 @@ _IMAGE_FILE_PARMS = {
 }
 _PARAMETER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 _OWNER_USER_DATA_KEY = "dcc_mcp.assign_texture.owner"
-_MATERIAL_OWNERSHIP_REGISTRY: dict[tuple[int, int], Any] = {}
+_MATERIAL_ID_USER_DATA_KEY = "dcc_mcp.assign_texture.material_id"
+_MAX_TEXTURE_FILE_BYTES = 256 * 1024 * 1024
+_MAX_TEXTURE_HASH_SECS = 2.0
+_TEXTURE_HASH_CHUNK_BYTES = 1024 * 1024
 
 
 class _TextureFileError(RuntimeError):
@@ -81,16 +86,25 @@ def _capture_texture_file(texture_path: str) -> _TextureFileRef:
             or path_stat.st_nlink != 1
         ):
             raise _TextureFileError("unsafe texture file")
+        if path_stat.st_size > _MAX_TEXTURE_FILE_BYTES:
+            raise _TextureFileError("texture file exceeds bounded validation size")
 
         flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
         fd = os.open(str(path), flags)
         try:
             opened_before = os.fstat(fd)
             digest = hashlib.sha256()
+            bytes_read = 0
+            deadline = time.monotonic() + _MAX_TEXTURE_HASH_SECS
             while True:
-                chunk = os.read(fd, 1024 * 1024)
+                if time.monotonic() > deadline:
+                    raise _TextureFileError("texture digest deadline exceeded")
+                chunk = os.read(fd, _TEXTURE_HASH_CHUNK_BYTES)
                 if not chunk:
                     break
+                bytes_read += len(chunk)
+                if bytes_read > _MAX_TEXTURE_FILE_BYTES:
+                    raise _TextureFileError("texture digest exceeded bounded work")
                 digest.update(chunk)
             opened_after = os.fstat(fd)
         finally:
@@ -116,20 +130,58 @@ def _capture_texture_file(texture_path: str) -> _TextureFileRef:
         or _is_reparse(path_after)
     ):
         raise _TextureFileError("texture file changed during capture")
+    if bytes_read != opened_after.st_size:
+        raise _TextureFileError("texture file length changed during capture")
     return _TextureFileRef(
         path=str(path),
         resolved_path=str(resolved),
         device=opened_after.st_dev,
         inode=opened_after.st_ino,
         size=opened_after.st_size,
-        mtime_ns=opened_after.st_mtime_ns,
-        ctime_ns=opened_after.st_ctime_ns,
+        mtime_ns=path_after.st_mtime_ns,
+        ctime_ns=path_after.st_ctime_ns,
         digest=digest.hexdigest(),
     )
 
 
 def _assert_texture_file_current(texture_ref: _TextureFileRef) -> None:
-    if _capture_texture_file(texture_ref.path) != texture_ref:
+    path = Path(texture_ref.path)
+    try:
+        resolved = path.resolve(strict=True)
+        if os.path.normcase(os.path.normpath(str(resolved))) != os.path.normcase(texture_ref.resolved_path):
+            raise _TextureFileError("texture path identity changed")
+        for parent in path.parents:
+            if parent.parent == parent:
+                break
+            parent_stat = os.lstat(str(parent))
+            if stat.S_ISLNK(parent_stat.st_mode) or _is_reparse(parent_stat):
+                raise _TextureFileError("unsafe texture path")
+        current = os.lstat(str(path))
+    except _TextureFileError:
+        raise
+    except OSError as exc:
+        raise _TextureFileError("texture file identity could not be recaptured") from exc
+    current_identity = (
+        current.st_dev,
+        current.st_ino,
+        current.st_size,
+        current.st_mtime_ns,
+        current.st_ctime_ns,
+    )
+    expected_identity = (
+        texture_ref.device,
+        texture_ref.inode,
+        texture_ref.size,
+        texture_ref.mtime_ns,
+        texture_ref.ctime_ns,
+    )
+    if (
+        current_identity != expected_identity
+        or not stat.S_ISREG(current.st_mode)
+        or stat.S_ISLNK(current.st_mode)
+        or _is_reparse(current)
+        or current.st_nlink != 1
+    ):
         raise _TextureFileError("texture file identity changed")
 
 
@@ -165,6 +217,34 @@ def _rollback_parms(snapshots: list[tuple[Any, Any]]) -> bool:
         return False
 
 
+def _rollback_mutations(
+    parm_snapshots: list[tuple[Any, Any]],
+    input_snapshots: list[tuple[Any, int, Any]],
+    created_nodes: list[Any],
+    user_data_snapshots: list[tuple[Any, str, Optional[str]]],
+) -> bool:
+    rollback_ok = _rollback_parms(parm_snapshots) if parm_snapshots else True
+    for material_node, input_index, previous_input in reversed(input_snapshots):
+        try:
+            if material_node.input(input_index) is not previous_input:
+                material_node.setInput(input_index, previous_input, 0)
+            rollback_ok = material_node.input(input_index) is previous_input and rollback_ok
+        except BaseException:  # noqa: BLE001
+            rollback_ok = False
+    for node, key, previous_value in reversed(user_data_snapshots):
+        try:
+            if previous_value is None:
+                node.destroyUserData(key, False)
+            else:
+                node.setUserData(key, previous_value)
+            rollback_ok = node.userData(key) == previous_value and rollback_ok
+        except BaseException:  # noqa: BLE001
+            rollback_ok = False
+    for node in reversed(created_nodes):
+        rollback_ok = _destroy_created_node(node) and rollback_ok
+    return rollback_ok
+
+
 def _assign_principled(
     material_node: Any,
     parameter_name: str,
@@ -172,6 +252,7 @@ def _assign_principled(
     texture_ref: _TextureFileRef,
     colorspace: Optional[str],
     undo_label: str,
+    outer_snapshots: list[tuple[Any, Any]],
 ) -> dict:
     use_texture_parm = material_node.parm("{}_useTexture".format(parameter_name))
     texture_parm = material_node.parm("{}_texture".format(parameter_name))
@@ -187,6 +268,7 @@ def _assign_principled(
         _assert_texture_file_current(texture_ref)
         enabled_before = use_texture_parm.eval()
         snapshots = [(texture_parm, texture_before), (use_texture_parm, enabled_before)]
+        outer_snapshots.extend(snapshots)
         _assert_texture_file_current(texture_ref)
         texture_parm.set(texture_path)
         _assert_texture_file_current(texture_ref)
@@ -313,6 +395,8 @@ def _destroy_created_node(node: Any) -> bool:
     try:
         parent = node.parent()
         name = node.name()
+        if parent.node(name) is not node:
+            return True
         node.destroy()
         return parent.node(name) is not node
     except BaseException:  # noqa: BLE001
@@ -326,8 +410,20 @@ def _node_session_id(node: Any) -> int:
     return session_id
 
 
+def _material_identity(material_node: Any) -> Optional[str]:
+    try:
+        identity = material_node.userData(_MATERIAL_ID_USER_DATA_KEY)
+    except BaseException:  # noqa: BLE001
+        return None
+    return identity if isinstance(identity, str) and identity else None
+
+
 def _owner_marker(material_node: Any, input_index: int, texture_node: Any) -> str:
-    return "v2|{}|{}|{}|{}".format(
+    material_identity = _material_identity(material_node)
+    if material_identity is None:
+        raise _OwnershipError("material has no durable identity")
+    return "v3|{}|{}|{}|{}|{}".format(
+        material_identity,
         _node_session_id(material_node),
         input_index,
         _node_session_id(texture_node),
@@ -351,44 +447,38 @@ def _parent_children(parent: Any) -> tuple[Any, ...]:
     return tuple(children() if callable(children) else children)
 
 
-def _is_registered_material(material_node: Any, input_index: int) -> bool:
-    registered = _MATERIAL_OWNERSHIP_REGISTRY.get((_node_session_id(material_node), input_index))
-    if registered is None:
-        return False
-    try:
-        return registered is material_node or bool(registered == material_node)
-    except BaseException:  # noqa: BLE001
-        return False
-
-
 def _find_owned_texture(material_node: Any, input_index: int, texture_type: str) -> Optional[Any]:
     material_session = _node_session_id(material_node)
     material_path = material_node.path()
+    material_identity = _material_identity(material_node)
     owned = []
     for node in _parent_children(material_node.parent()):
         marker = node.userData(_OWNER_USER_DATA_KEY)
-        if not isinstance(marker, str) or not marker.startswith("v2|"):
+        if not isinstance(marker, str):
             continue
-        parts = marker.split("|", 4)
-        if len(parts) != 5:
+        if marker.startswith("v2|"):
+            raise _OwnershipError("legacy ownership has no durable material identity")
+        if not marker.startswith("v3|"):
+            continue
+        parts = marker.split("|", 5)
+        if len(parts) != 6:
             raise _OwnershipError("invalid texture ownership marker")
         try:
-            marker_material_session = int(parts[1])
-            marker_input = int(parts[2])
-            marker_node_session = int(parts[3])
+            marker_material_session = int(parts[2])
+            marker_input = int(parts[3])
+            marker_node_session = int(parts[4])
         except ValueError as exc:
             raise _OwnershipError("invalid texture ownership marker") from exc
         if marker_input != input_index:
             continue
+        if material_identity is None or parts[1] != material_identity:
+            if marker_material_session == material_session or parts[5] == material_path:
+                raise _OwnershipError("durable material identity does not match")
+            continue
         if marker_material_session != material_session:
-            if parts[4] == material_path:
+            if parts[5] == material_path:
                 raise _OwnershipError("stale material session ownership")
             continue
-        registered_material = _MATERIAL_OWNERSHIP_REGISTRY.get((material_session, input_index))
-        if registered_material is not None and not _is_registered_material(material_node, input_index):
-            raise _OwnershipError("material session identity was reused")
-        if parts[4] != material_path and not _is_registered_material(material_node, input_index):
-            raise _OwnershipError("stale material path ownership")
         if marker_node_session != _node_session_id(node) or node.type().name() != texture_type:
             raise _OwnershipError("stale texture node ownership")
         owned.append(node)
@@ -406,6 +496,10 @@ def _assign_wired_material(
     texture_ref: _TextureFileRef,
     colorspace: Optional[str],
     undo_label: str,
+    outer_snapshots: list[tuple[Any, Any]],
+    outer_input_snapshots: list[tuple[Any, int, Any]],
+    outer_created_nodes: list[Any],
+    outer_user_data_snapshots: list[tuple[Any, str, Optional[str]]],
 ) -> dict:
     texture_type = _WIRED_MATERIAL_NODE_TYPES[material_type]
     try:
@@ -426,6 +520,7 @@ def _assign_wired_material(
     try:
         _assert_texture_file_current(texture_ref)
         previous_input = material_node.input(input_index)
+        outer_input_snapshots.append((material_node, input_index, previous_input))
         owned_texture = _find_owned_texture(material_node, input_index, texture_type)
     except _TextureFileError:
         return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
@@ -439,11 +534,13 @@ def _assign_wired_material(
     created = owned_texture is None
     texture_node = None
     snapshots: list[tuple[Any, Any]] = []
+    user_data_snapshots: list[tuple[Any, str, Optional[str]]] = []
 
     try:
         if created:
             _assert_texture_file_current(texture_ref)
             texture_node = material_node.parent().createNode(texture_type)
+            outer_created_nodes.append(texture_node)
         else:
             texture_node = owned_texture
 
@@ -459,15 +556,31 @@ def _assign_wired_material(
             raise _TextureParameterError("texture file parameter type is unreadable") from exc
         if file_parm_type != hou.parmTemplateType.String:
             raise _TextureParameterError("texture file parameter is not a string")
-        if created:
-            owner_marker = _owner_marker(material_node, input_index, texture_node)
+        material_identity = _material_identity(material_node)
+        if material_identity is None:
+            material_identity = uuid.uuid4().hex
+            material_identity_snapshot = (material_node, _MATERIAL_ID_USER_DATA_KEY, None)
+            user_data_snapshots.append(material_identity_snapshot)
+            outer_user_data_snapshots.append(material_identity_snapshot)
             _assert_texture_file_current(texture_ref)
-            texture_node.setUserData(_OWNER_USER_DATA_KEY, owner_marker)
+            material_node.setUserData(_MATERIAL_ID_USER_DATA_KEY, material_identity)
             _assert_texture_file_current(texture_ref)
-            if texture_node.userData(_OWNER_USER_DATA_KEY) != owner_marker:
+            if material_node.userData(_MATERIAL_ID_USER_DATA_KEY) != material_identity:
+                raise RuntimeError("material identity readback mismatch")
+        desired_owner_marker = _owner_marker(material_node, input_index, texture_node)
+        current_owner_marker = texture_node.userData(_OWNER_USER_DATA_KEY)
+        if current_owner_marker != desired_owner_marker:
+            owner_snapshot = (texture_node, _OWNER_USER_DATA_KEY, current_owner_marker)
+            user_data_snapshots.append(owner_snapshot)
+            outer_user_data_snapshots.append(owner_snapshot)
+            _assert_texture_file_current(texture_ref)
+            texture_node.setUserData(_OWNER_USER_DATA_KEY, desired_owner_marker)
+            _assert_texture_file_current(texture_ref)
+            if texture_node.userData(_OWNER_USER_DATA_KEY) != desired_owner_marker:
                 raise RuntimeError("ownership readback mismatch")
         _assert_texture_file_current(texture_ref)
         snapshots = [(file_parm, file_parm.eval())]
+        outer_snapshots.extend(snapshots)
         _assert_texture_file_current(texture_ref)
         file_parm.set(texture_path)
         if created:
@@ -501,20 +614,14 @@ def _assign_wired_material(
                 "texture_path": str(texture_readback),
             },
         )
-        material_session = _node_session_id(material_node)
-        _MATERIAL_OWNERSHIP_REGISTRY[(material_session, input_index)] = material_node
         return result
     except BaseException as exc:  # noqa: BLE001
-        rollback_ok = _rollback_parms(snapshots) if snapshots else True
-        try:
-            current_input = material_node.input(input_index)
-            if current_input is not previous_input:
-                material_node.setInput(input_index, previous_input, 0)
-            rollback_ok = material_node.input(input_index) is previous_input and rollback_ok
-        except BaseException:  # noqa: BLE001
-            rollback_ok = False
-        if created and texture_node is not None:
-            rollback_ok = _destroy_created_node(texture_node) and rollback_ok
+        rollback_ok = _rollback_mutations(
+            snapshots,
+            [(material_node, input_index, previous_input)],
+            [texture_node] if created and texture_node is not None else [],
+            user_data_snapshots,
+        )
         if not rollback_ok:
             return skill_error(
                 "Texture wiring failed and rollback could not be verified",
@@ -595,19 +702,23 @@ def assign_texture(
 
     undo_label = "DCC MCP: assign texture {}".format(parameter_name)
     outer_snapshots: list[tuple[Any, Any]] = []
+    outer_input_snapshots: list[tuple[Any, int, Any]] = []
+    outer_created_nodes: list[Any] = []
+    outer_user_data_snapshots: list[tuple[Any, str, Optional[str]]] = []
     try:
         with _undo_group(hou, undo_label):
             if target_type in _PRINCIPLED_SHADER_TYPES:
-                return _assign_principled(
+                result = _assign_principled(
                     target_node,
                     parameter_name,
                     texture_path,
                     texture_ref,
                     colorspace,
                     undo_label,
+                    outer_snapshots,
                 )
-            if target_type in _DIRECT_TEXTURE_NODE_TYPES:
-                return _assign_direct_texture(
+            elif target_type in _DIRECT_TEXTURE_NODE_TYPES:
+                result = _assign_direct_texture(
                     hou,
                     target_node,
                     parameter_name,
@@ -617,18 +728,29 @@ def assign_texture(
                     undo_label,
                     outer_snapshots,
                 )
-            return _assign_wired_material(
-                hou,
-                target_node,
-                target_type,
-                parameter_name,
-                texture_path,
-                texture_ref,
-                colorspace,
-                undo_label,
-            )
+            else:
+                result = _assign_wired_material(
+                    hou,
+                    target_node,
+                    target_type,
+                    parameter_name,
+                    texture_path,
+                    texture_ref,
+                    colorspace,
+                    undo_label,
+                    outer_snapshots,
+                    outer_input_snapshots,
+                    outer_created_nodes,
+                    outer_user_data_snapshots,
+                )
+        return result
     except BaseException:  # noqa: BLE001
-        if outer_snapshots and not _rollback_parms(outer_snapshots):
+        if not _rollback_mutations(
+            outer_snapshots,
+            outer_input_snapshots,
+            outer_created_nodes,
+            outer_user_data_snapshots,
+        ):
             return skill_error(
                 "Texture assignment failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -1,24 +1,28 @@
-"""Assign a texture file to a material/shader parameter."""
+"""Assign a texture through a bounded, typed Houdini node contract."""
 
 from __future__ import annotations
 
+import re
+from contextlib import nullcontext
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from _library_common import get_node, hou_import_error, node_summary  # noqa: E402
-from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_success
 
-# Map of common parameter names → texture node types to create.
-_TEXTURE_NODE_TYPE_MAP = {
-    "principledshader": "principledtexture",
-    "principledshader::2.0": "principledtexture",
+_PRINCIPLED_SHADER_TYPES = frozenset({"principledshader", "principledshader::2.0"})
+_DIRECT_TEXTURE_NODE_TYPES = frozenset({"arnold::image", "mtlximage"})
+_WIRED_MATERIAL_NODE_TYPES = {
+    "arnold::standard_surface": "arnold::image",
+    "mtlxstandard_surface": "mtlximage",
 }
+_IMAGE_FILE_PARMS = ("filename", "file", "texturefile", "tex0")
+_PARAMETER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 
 
 def _detect_colorspace(texture_path: str) -> Optional[str]:
     """Best-effort color space detection from file extension."""
-    ext = Path(texture_path).suffix.lower()
-    mapping = {
+    return {
         ".exr": "linear",
         ".hdr": "linear",
         ".jpg": "sRGB",
@@ -30,8 +34,228 @@ def _detect_colorspace(texture_path: str) -> Optional[str]:
         ".bmp": "sRGB",
         ".tx": "auto",
         ".rat": "auto",
-    }
-    return mapping.get(ext)
+    }.get(Path(texture_path).suffix.lower())
+
+
+def _undo_group(hou: Any, label: str) -> Any:
+    undos = getattr(hou, "undos", None)
+    group = getattr(undos, "group", None)
+    return group(label) if callable(group) else nullcontext()
+
+
+def _rollback_parms(snapshots: list[tuple[Any, Any]]) -> bool:
+    try:
+        for parm, value in reversed(snapshots):
+            parm.set(value)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def _assign_principled(
+    material_node: Any,
+    parameter_name: str,
+    texture_path: str,
+    colorspace: Optional[str],
+    undo_label: str,
+) -> dict:
+    use_texture_parm = material_node.parm("{}_useTexture".format(parameter_name))
+    texture_parm = material_node.parm("{}_texture".format(parameter_name))
+    if use_texture_parm is None or texture_parm is None:
+        return skill_error(
+            "Unsupported Principled Shader texture parameter",
+            "UNSUPPORTED_TEXTURE_PARAMETER",
+        )
+
+    try:
+        snapshots = [(texture_parm, texture_parm.eval()), (use_texture_parm, use_texture_parm.eval())]
+        texture_parm.set(texture_path)
+        use_texture_parm.set(1)
+        texture_readback = texture_parm.eval()
+        enabled_readback = use_texture_parm.eval()
+        if texture_readback != texture_path or not bool(enabled_readback):
+            raise RuntimeError("readback mismatch")
+    except Exception:  # noqa: BLE001
+        if "snapshots" not in locals() or not _rollback_parms(snapshots):
+            return skill_error(
+                "Texture assignment failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
+        return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
+
+    return skill_success(
+        "Assigned texture to Principled Shader parameter",
+        material=node_summary(material_node),
+        parameter=parameter_name,
+        texture_path=texture_path,
+        colorspace=colorspace or _detect_colorspace(texture_path),
+        verified=True,
+        undo_label=undo_label,
+        readback={"texture_enabled": bool(enabled_readback), "texture_path": str(texture_readback)},
+    )
+
+
+def _assign_direct_texture(
+    hou: Any,
+    texture_node: Any,
+    parameter_name: str,
+    texture_path: str,
+    colorspace: Optional[str],
+    undo_label: str,
+) -> dict:
+    parm = texture_node.parm(parameter_name)
+    try:
+        parm_type = parm.parmTemplate().type() if parm is not None else None
+    except Exception:  # noqa: BLE001
+        parm_type = None
+    if parm_type != hou.parmTemplateType.String:
+        return skill_error(
+            "Unsupported texture file parameter",
+            "UNSUPPORTED_TEXTURE_PARAMETER",
+            node_type=texture_node.type().name(),
+        )
+
+    cs_parm = texture_node.parm("colorspace") if colorspace else None
+    try:
+        snapshots = [(parm, parm.eval())]
+        if cs_parm is not None:
+            snapshots.append((cs_parm, cs_parm.eval()))
+        parm.set(texture_path)
+        if cs_parm is not None:
+            cs_parm.set(colorspace)
+        texture_readback = parm.eval()
+        if texture_readback != texture_path:
+            raise RuntimeError("readback mismatch")
+        if cs_parm is not None and cs_parm.eval() != colorspace:
+            raise RuntimeError("colorspace readback mismatch")
+    except Exception:  # noqa: BLE001
+        if "snapshots" not in locals() or not _rollback_parms(snapshots):
+            return skill_error(
+                "Texture assignment failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
+        return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
+
+    return skill_success(
+        "Assigned texture to image node parameter",
+        material=node_summary(texture_node),
+        parameter=parameter_name,
+        texture_path=texture_path,
+        colorspace=colorspace or _detect_colorspace(texture_path),
+        verified=True,
+        undo_label=undo_label,
+        readback={"parameter": parameter_name, "texture_path": str(texture_readback)},
+    )
+
+
+def _destroy_created_node(node: Any) -> bool:
+    try:
+        node.destroy()
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def _assign_wired_material(
+    material_node: Any,
+    material_type: str,
+    parameter_name: str,
+    texture_path: str,
+    colorspace: Optional[str],
+    undo_label: str,
+) -> dict:
+    texture_type = _WIRED_MATERIAL_NODE_TYPES[material_type]
+    try:
+        texture_node = material_node.parent().createNode(texture_type)
+    except Exception:  # noqa: BLE001
+        return skill_error(
+            "Required texture node could not be created",
+            "TEXTURE_NODE_CREATION_FAILED",
+            node_type=texture_type,
+        )
+
+    file_parm = next((texture_node.parm(name) for name in _IMAGE_FILE_PARMS if texture_node.parm(name)), None)
+    if file_parm is None:
+        if not _destroy_created_node(texture_node):
+            return skill_error(
+                "Texture node validation failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
+        return skill_error(
+            "Texture node has no file path parameter",
+            "UNSUPPORTED_TEXTURE_PARAMETER",
+            node_type=texture_node.type().name(),
+        )
+
+    try:
+        input_names = tuple(material_node.inputNames())
+    except Exception:  # noqa: BLE001
+        input_names = ()
+    input_index = next(
+        (index for index, name in enumerate(input_names) if name.lower() == parameter_name.lower()),
+        None,
+    )
+    if input_index is None:
+        if not _destroy_created_node(texture_node):
+            return skill_error(
+                "Material input validation failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
+        return skill_error(
+            "Unsupported material texture input",
+            "UNSUPPORTED_TEXTURE_PARAMETER",
+            node_type=material_type,
+        )
+
+    try:
+        previous_input = material_node.input(input_index)
+    except Exception:  # noqa: BLE001
+        if not _destroy_created_node(texture_node):
+            return skill_error(
+                "Material input validation failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
+        return skill_error("Material input cannot be read safely", "TEXTURE_WIRING_FAILED")
+
+    actual_colorspace = colorspace or _detect_colorspace(texture_path)
+    cs_parm = texture_node.parm("colorspace") if actual_colorspace else None
+    try:
+        file_parm.set(texture_path)
+        if cs_parm is not None:
+            cs_parm.set(actual_colorspace)
+        material_node.setInput(input_index, texture_node, 0)
+        if file_parm.eval() != texture_path or material_node.input(input_index) is not texture_node:
+            raise RuntimeError("readback mismatch")
+    except Exception:  # noqa: BLE001
+        rollback_ok = True
+        try:
+            if material_node.input(input_index) is texture_node:
+                material_node.setInput(input_index, previous_input, 0)
+        except Exception:  # noqa: BLE001
+            rollback_ok = False
+        rollback_ok = _destroy_created_node(texture_node) and rollback_ok
+        if not rollback_ok:
+            return skill_error(
+                "Texture wiring failed and rollback could not be verified",
+                "TEXTURE_ROLLBACK_FAILED",
+            )
+        return skill_error("Texture could not be wired to the material input", "TEXTURE_WIRING_FAILED")
+
+    return skill_success(
+        "Assigned and wired texture to material",
+        material=node_summary(material_node),
+        parameter=parameter_name,
+        texture_node=node_summary(texture_node),
+        texture_path=texture_path,
+        colorspace=actual_colorspace,
+        verified=True,
+        undo_label=undo_label,
+        readback={
+            "input_index": input_index,
+            "texture_node": texture_node.path(),
+            "texture_path": str(file_parm.eval()),
+        },
+    )
 
 
 def assign_texture(
@@ -40,132 +264,58 @@ def assign_texture(
     texture_path: str,
     colorspace: Optional[str] = None,
 ) -> dict:
-    """Assign a texture file to a material/shader parameter.
-
-    Creates or updates a file-texture VOP node and wires it to the target
-    material parameter.  If the parameter is a string file-path parm (e.g.
-    on an ``arnold::image`` node), the path is set directly.
-
-    Args:
-        material_path: Path to the material/shader node.
-        parameter_name: Name of the color/texture parameter to drive.
-        texture_path: File path to the texture image on disk.
-        colorspace: OCIO color space for the texture.  Auto-detected when omitted.
-
-    Returns:
-        ToolResult dict.
-    """
+    """Assign a texture to one explicitly supported material or image target."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
         return hou_import_error()
 
-    try:
-        # Validate the texture file exists.
-        tex_path = Path(texture_path)
-        if not tex_path.is_file():
-            return skill_error(
-                "Texture file not found: {}".format(texture_path),
-                "Check the path and try again.",
-            )
-
-        material_node = get_node(hou, material_path)
-        parm = material_node.parm(parameter_name)
-
-        # Case 1: The parameter is a string (file path on an image node).
-        if parm is not None:
-            parm_template = parm.parmTemplate()
-            try:
-                parm_type = parm_template.type()
-            except Exception:  # noqa: BLE001
-                parm_type = None
-
-            if parm_type == hou.parmTemplateType.String:
-                parm.set(str(texture_path))
-                if colorspace:
-                    cs_parm = material_node.parm("colorspace")
-                    if cs_parm is not None:
-                        cs_parm.set(colorspace)
-                return skill_success(
-                    "Assigned texture to material parameter",
-                    material=node_summary(material_node),
-                    parameter=parameter_name,
-                    texture_path=str(texture_path),
-                    colorspace=colorspace or _detect_colorspace(texture_path),
-                )
-
-        # Case 2: Create a file-texture node and wire it.
-        parent = material_node.parent()
-        mat_type = material_node.type().name() if hasattr(material_node.type(), "name") else ""
-
-        # Try known texture node types.
-        tex_node_type = _TEXTURE_NODE_TYPE_MAP.get(mat_type, "principledtexture")
-        tex_node = None
-
-        for candidate in [tex_node_type, "mtlximage", "arnold::image", "file"]:
-            try:
-                tex_node = parent.createNode(candidate)
-                break
-            except Exception:  # noqa: BLE001
-                continue
-
-        if tex_node is None:
-            return skill_error(
-                "Could not create texture node under {}".format(parent.path()),
-                "No supported texture node type found.",
-            )
-
-        # Set the file path on the texture node.
-        file_parm_set = False
-        for file_parm_name in ("filename", "file", "texturefile", "tex0"):
-            fp = tex_node.parm(file_parm_name)
-            if fp is not None:
-                fp.set(str(texture_path))
-                file_parm_set = True
-                break
-
-        if not file_parm_set:
-            return skill_error(
-                "Texture node has no file path parameter",
-                "Node type: {}".format(tex_node.type().name()),
-            )
-
-        # Set color space if available.
-        actual_colorspace = colorspace or _detect_colorspace(texture_path)
-        if actual_colorspace:
-            cs_parm = tex_node.parm("colorspace")
-            if cs_parm is not None:
-                cs_parm.set(actual_colorspace)
-
-        # Wire the texture output to the material input.
-        try:
-            # Find input index for the parameter.
-            input_idx = None
-            for i, name in enumerate(material_node.inputNames()):
-                if parameter_name.lower() in name.lower():
-                    input_idx = i
-                    break
-            if input_idx is None:
-                # Default: use input index 0 or try to set by name.
-                try:
-                    material_node.setNamedInput(parameter_name, tex_node, 0)
-                except Exception:  # noqa: BLE001
-                    material_node.setInput(0, tex_node, 0)
-            else:
-                material_node.setInput(input_idx, tex_node, 0)
-        except Exception:  # noqa: BLE001
-            pass
-
-        return skill_success(
-            "Assigned texture to material",
-            material=node_summary(material_node),
-            parameter=parameter_name,
-            texture_node=node_summary(tex_node),
-            texture_path=str(texture_path),
-            colorspace=actual_colorspace,
+    if not isinstance(material_path, str) or not material_path.startswith("/"):
+        return skill_error("Invalid Houdini material path", "INVALID_MATERIAL_PATH")
+    if not isinstance(parameter_name, str) or not _PARAMETER_NAME_RE.fullmatch(parameter_name):
+        return skill_error("Invalid texture parameter name", "INVALID_PARAMETER_NAME")
+    if not isinstance(texture_path, str) or not texture_path:
+        return skill_error("Invalid texture file path", "INVALID_TEXTURE_PATH")
+    if colorspace is not None and (not isinstance(colorspace, str) or not colorspace):
+        return skill_error("Invalid texture color space", "INVALID_COLORSPACE")
+    if not Path(texture_path).is_file():
+        return skill_error(
+            "Texture file was not found",
+            "TEXTURE_FILE_NOT_FOUND",
+            prompt="Check the texture path and try again.",
         )
-    except Exception as exc:
-        return skill_exception(exc, message="Failed to assign texture")
+
+    try:
+        target_node = get_node(hou, material_path)
+        target_type = target_node.type().name()
+    except Exception:  # noqa: BLE001
+        return skill_error("Material or texture target was not found", "TEXTURE_TARGET_NOT_FOUND")
+
+    supported_types = _PRINCIPLED_SHADER_TYPES | _DIRECT_TEXTURE_NODE_TYPES | frozenset(_WIRED_MATERIAL_NODE_TYPES)
+    if target_type not in supported_types:
+        return skill_error(
+            "Unsupported texture assignment target",
+            "UNSUPPORTED_TEXTURE_TARGET",
+            node_type=target_type or "unknown",
+        )
+
+    undo_label = "DCC MCP: assign texture {}".format(parameter_name)
+    try:
+        with _undo_group(hou, undo_label):
+            if target_type in _PRINCIPLED_SHADER_TYPES:
+                return _assign_principled(target_node, parameter_name, texture_path, colorspace, undo_label)
+            if target_type in _DIRECT_TEXTURE_NODE_TYPES:
+                return _assign_direct_texture(hou, target_node, parameter_name, texture_path, colorspace, undo_label)
+            return _assign_wired_material(
+                target_node,
+                target_type,
+                parameter_name,
+                texture_path,
+                colorspace,
+                undo_label,
+            )
+    except Exception:  # noqa: BLE001
+        return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/scripts/assign_texture.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
+import stat
 from contextlib import nullcontext
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -16,9 +20,112 @@ _WIRED_MATERIAL_NODE_TYPES = {
     "arnold::standard_surface": "arnold::image",
     "mtlxstandard_surface": "mtlximage",
 }
-_IMAGE_FILE_PARMS = ("filename", "file", "texturefile", "tex0")
+_IMAGE_FILE_PARMS = {
+    "arnold::image": ("filename", "file"),
+    "mtlximage": ("file",),
+}
 _PARAMETER_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 _OWNER_USER_DATA_KEY = "dcc_mcp.assign_texture.owner"
+
+
+class _TextureFileError(RuntimeError):
+    """A stable, path-redacted texture file validation failure."""
+
+
+class _OwnershipError(RuntimeError):
+    """An ambiguous or stale ownership contract."""
+
+
+@dataclass(frozen=True)
+class _TextureFileRef:
+    path: str
+    resolved_path: str
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+    digest: str
+
+
+def _is_reparse(stat_result: os.stat_result) -> bool:
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(getattr(stat_result, "st_file_attributes", 0) & reparse_flag)
+
+
+def _capture_texture_file(texture_path: str) -> _TextureFileRef:
+    path = Path(texture_path).absolute()
+    try:
+        lexical = os.path.normcase(os.path.normpath(str(path)))
+        resolved = path.resolve(strict=True)
+        if os.path.normcase(os.path.normpath(str(resolved))) != lexical:
+            raise _TextureFileError("unsafe texture path")
+
+        for parent in path.parents:
+            if parent.parent == parent:
+                break
+            parent_stat = os.lstat(str(parent))
+            if stat.S_ISLNK(parent_stat.st_mode) or _is_reparse(parent_stat):
+                raise _TextureFileError("unsafe texture path")
+
+        path_stat = os.lstat(str(path))
+        if (
+            not stat.S_ISREG(path_stat.st_mode)
+            or stat.S_ISLNK(path_stat.st_mode)
+            or _is_reparse(path_stat)
+            or path_stat.st_nlink != 1
+        ):
+            raise _TextureFileError("unsafe texture file")
+
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(str(path), flags)
+        try:
+            opened_before = os.fstat(fd)
+            digest = hashlib.sha256()
+            while True:
+                chunk = os.read(fd, 1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+            opened_after = os.fstat(fd)
+        finally:
+            os.close(fd)
+        path_after = os.lstat(str(path))
+    except _TextureFileError:
+        raise
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        raise FileNotFoundError from exc
+    except OSError as exc:
+        raise _TextureFileError("texture file could not be captured safely") from exc
+
+    identity_before = (path_stat.st_dev, path_stat.st_ino, path_stat.st_size)
+    identity_opened = (opened_before.st_dev, opened_before.st_ino, opened_before.st_size)
+    identity_after = (opened_after.st_dev, opened_after.st_ino, opened_after.st_size)
+    identity_path_after = (path_after.st_dev, path_after.st_ino, path_after.st_size)
+    if not identity_before == identity_opened == identity_after == identity_path_after:
+        raise _TextureFileError("texture file changed during capture")
+    if (
+        opened_before.st_mtime_ns != opened_after.st_mtime_ns
+        or opened_before.st_ctime_ns != opened_after.st_ctime_ns
+        or path_after.st_nlink != 1
+        or _is_reparse(path_after)
+    ):
+        raise _TextureFileError("texture file changed during capture")
+    return _TextureFileRef(
+        path=str(path),
+        resolved_path=str(resolved),
+        device=opened_after.st_dev,
+        inode=opened_after.st_ino,
+        size=opened_after.st_size,
+        mtime_ns=opened_after.st_mtime_ns,
+        ctime_ns=opened_after.st_ctime_ns,
+        digest=digest.hexdigest(),
+    )
+
+
+def _assert_texture_file_current(texture_ref: _TextureFileRef) -> None:
+    if _capture_texture_file(texture_ref.path) != texture_ref:
+        raise _TextureFileError("texture file identity changed")
 
 
 def _detect_colorspace(texture_path: str) -> Optional[str]:
@@ -49,7 +156,7 @@ def _rollback_parms(snapshots: list[tuple[Any, Any]]) -> bool:
         for parm, value in reversed(snapshots):
             parm.set(value)
         return all(parm.eval() == value for parm, value in snapshots)
-    except Exception:  # noqa: BLE001
+    except BaseException:  # noqa: BLE001
         return False
 
 
@@ -57,6 +164,7 @@ def _assign_principled(
     material_node: Any,
     parameter_name: str,
     texture_path: str,
+    texture_ref: _TextureFileRef,
     colorspace: Optional[str],
     undo_label: str,
 ) -> dict:
@@ -69,31 +177,42 @@ def _assign_principled(
         )
 
     try:
-        snapshots = [(texture_parm, texture_parm.eval()), (use_texture_parm, use_texture_parm.eval())]
+        _assert_texture_file_current(texture_ref)
+        texture_before = texture_parm.eval()
+        _assert_texture_file_current(texture_ref)
+        enabled_before = use_texture_parm.eval()
+        snapshots = [(texture_parm, texture_before), (use_texture_parm, enabled_before)]
+        _assert_texture_file_current(texture_ref)
         texture_parm.set(texture_path)
+        _assert_texture_file_current(texture_ref)
         use_texture_parm.set(1)
+        _assert_texture_file_current(texture_ref)
         texture_readback = texture_parm.eval()
+        _assert_texture_file_current(texture_ref)
         enabled_readback = use_texture_parm.eval()
         if texture_readback != texture_path or not bool(enabled_readback):
             raise RuntimeError("readback mismatch")
-    except Exception:  # noqa: BLE001
-        if "snapshots" not in locals() or not _rollback_parms(snapshots):
+        _assert_texture_file_current(texture_ref)
+        material_summary = node_summary(material_node)
+        return skill_success(
+            "Assigned texture to Principled Shader parameter",
+            material=material_summary,
+            parameter=parameter_name,
+            texture_path=texture_path,
+            detected_colorspace=_detect_colorspace(texture_path),
+            verified=True,
+            undo_label=undo_label,
+            readback={"texture_enabled": bool(enabled_readback), "texture_path": str(texture_readback)},
+        )
+    except BaseException as exc:  # noqa: BLE001
+        if "snapshots" in locals() and not _rollback_parms(snapshots):
             return skill_error(
                 "Texture assignment failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
             )
+        if isinstance(exc, _TextureFileError):
+            return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
-
-    return skill_success(
-        "Assigned texture to Principled Shader parameter",
-        material=node_summary(material_node),
-        parameter=parameter_name,
-        texture_path=texture_path,
-        detected_colorspace=_detect_colorspace(texture_path),
-        verified=True,
-        undo_label=undo_label,
-        readback={"texture_enabled": bool(enabled_readback), "texture_path": str(texture_readback)},
-    )
 
 
 def _assign_direct_texture(
@@ -101,9 +220,17 @@ def _assign_direct_texture(
     texture_node: Any,
     parameter_name: str,
     texture_path: str,
+    texture_ref: _TextureFileRef,
     colorspace: Optional[str],
     undo_label: str,
 ) -> dict:
+    node_type = texture_node.type().name()
+    if parameter_name not in _IMAGE_FILE_PARMS.get(node_type, ()):
+        return skill_error(
+            "Unsupported texture file parameter",
+            "UNSUPPORTED_TEXTURE_PARAMETER",
+            node_type=node_type,
+        )
     parm = texture_node.parm(parameter_name)
     try:
         parm_type = parm.parmTemplate().type() if parm is not None else None
@@ -113,7 +240,7 @@ def _assign_direct_texture(
         return skill_error(
             "Unsupported texture file parameter",
             "UNSUPPORTED_TEXTURE_PARAMETER",
-            node_type=texture_node.type().name(),
+            node_type=node_type,
         )
 
     cs_parm = texture_node.parm("colorspace") if colorspace else None
@@ -125,43 +252,54 @@ def _assign_direct_texture(
         return skill_error(
             "Explicit color space is unsupported for this texture target",
             "UNSUPPORTED_COLORSPACE",
-            node_type=texture_node.type().name(),
+            node_type=node_type,
         )
     try:
+        _assert_texture_file_current(texture_ref)
         snapshots = [(parm, parm.eval())]
         if cs_parm is not None:
+            _assert_texture_file_current(texture_ref)
             snapshots.append((cs_parm, cs_parm.eval()))
+        _assert_texture_file_current(texture_ref)
         parm.set(texture_path)
         if cs_parm is not None:
+            _assert_texture_file_current(texture_ref)
             cs_parm.set(colorspace)
+        _assert_texture_file_current(texture_ref)
         texture_readback = parm.eval()
         if texture_readback != texture_path:
             raise RuntimeError("readback mismatch")
-        if cs_parm is not None and cs_parm.eval() != colorspace:
-            raise RuntimeError("colorspace readback mismatch")
-    except Exception:  # noqa: BLE001
-        if "snapshots" not in locals() or not _rollback_parms(snapshots):
+        if cs_parm is not None:
+            _assert_texture_file_current(texture_ref)
+            colorspace_readback = cs_parm.eval()
+            if colorspace_readback != colorspace:
+                raise RuntimeError("colorspace readback mismatch")
+        _assert_texture_file_current(texture_ref)
+        material_summary = node_summary(texture_node)
+        readback = {"parameter": parameter_name, "texture_path": str(texture_readback)}
+        context = {"detected_colorspace": _detect_colorspace(texture_path)}
+        if colorspace is not None:
+            readback["colorspace"] = str(colorspace_readback)
+            context["colorspace_applied"] = colorspace
+        return skill_success(
+            "Assigned texture to image node parameter",
+            material=material_summary,
+            parameter=parameter_name,
+            texture_path=texture_path,
+            verified=True,
+            undo_label=undo_label,
+            readback=readback,
+            **context,
+        )
+    except BaseException as exc:  # noqa: BLE001
+        if "snapshots" in locals() and not _rollback_parms(snapshots):
             return skill_error(
                 "Texture assignment failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
             )
+        if isinstance(exc, _TextureFileError):
+            return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
-
-    readback = {"parameter": parameter_name, "texture_path": str(texture_readback)}
-    context = {"detected_colorspace": _detect_colorspace(texture_path)}
-    if colorspace is not None:
-        readback["colorspace"] = str(cs_parm.eval())
-        context["colorspace_applied"] = colorspace
-    return skill_success(
-        "Assigned texture to image node parameter",
-        material=node_summary(texture_node),
-        parameter=parameter_name,
-        texture_path=texture_path,
-        verified=True,
-        undo_label=undo_label,
-        readback=readback,
-        **context,
-    )
 
 
 def _destroy_created_node(node: Any) -> bool:
@@ -174,15 +312,67 @@ def _destroy_created_node(node: Any) -> bool:
         return False
 
 
-def _owner_marker(material_node: Any, input_index: int) -> str:
-    return "v1|{}|{}".format(material_node.path(), input_index)
+def _node_session_id(node: Any) -> int:
+    session_id = node.sessionId()
+    if not isinstance(session_id, int) or isinstance(session_id, bool) or session_id < 0:
+        raise RuntimeError("invalid node session identity")
+    return session_id
 
 
-def _is_owned_texture(node: Any, texture_type: str, owner_marker: str) -> bool:
+def _owner_marker(material_node: Any, input_index: int, texture_node: Any) -> str:
+    return "v2|{}|{}|{}|{}".format(
+        _node_session_id(material_node),
+        input_index,
+        _node_session_id(texture_node),
+        material_node.path(),
+    )
+
+
+def _is_owned_texture(node: Any, texture_type: str, material_node: Any, input_index: int) -> bool:
     try:
-        return node.type().name() == texture_type and node.userData(_OWNER_USER_DATA_KEY) == owner_marker
-    except Exception:  # noqa: BLE001
+        return (
+            node is not None
+            and node.type().name() == texture_type
+            and node.userData(_OWNER_USER_DATA_KEY) == _owner_marker(material_node, input_index, node)
+        )
+    except BaseException:  # noqa: BLE001
         return False
+
+
+def _parent_children(parent: Any) -> tuple[Any, ...]:
+    children = parent.children
+    return tuple(children() if callable(children) else children)
+
+
+def _find_owned_texture(material_node: Any, input_index: int, texture_type: str) -> Optional[Any]:
+    material_session = _node_session_id(material_node)
+    material_path = material_node.path()
+    owned = []
+    for node in _parent_children(material_node.parent()):
+        marker = node.userData(_OWNER_USER_DATA_KEY)
+        if not isinstance(marker, str) or not marker.startswith("v2|"):
+            continue
+        parts = marker.split("|", 4)
+        if len(parts) != 5:
+            raise _OwnershipError("invalid texture ownership marker")
+        try:
+            marker_material_session = int(parts[1])
+            marker_input = int(parts[2])
+            marker_node_session = int(parts[3])
+        except ValueError as exc:
+            raise _OwnershipError("invalid texture ownership marker") from exc
+        if marker_input != input_index:
+            continue
+        if marker_material_session != material_session:
+            if parts[4] == material_path:
+                raise _OwnershipError("stale material session ownership")
+            continue
+        if marker_node_session != _node_session_id(node) or node.type().name() != texture_type:
+            raise _OwnershipError("stale texture node ownership")
+        owned.append(node)
+    if len(owned) > 1:
+        raise _OwnershipError("duplicate texture ownership")
+    return owned[0] if owned else None
 
 
 def _assign_wired_material(
@@ -190,6 +380,7 @@ def _assign_wired_material(
     material_type: str,
     parameter_name: str,
     texture_path: str,
+    texture_ref: _TextureFileRef,
     colorspace: Optional[str],
     undo_label: str,
 ) -> dict:
@@ -210,85 +401,95 @@ def _assign_wired_material(
         )
 
     try:
+        _assert_texture_file_current(texture_ref)
         previous_input = material_node.input(input_index)
-    except Exception:  # noqa: BLE001
+        owned_texture = _find_owned_texture(material_node, input_index, texture_type)
+    except _TextureFileError:
+        return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
+    except _OwnershipError:
+        return skill_error("Texture ownership is ambiguous", "AMBIGUOUS_TEXTURE_OWNERSHIP")
+    except BaseException:  # noqa: BLE001
         return skill_error("Material input cannot be read safely", "TEXTURE_WIRING_FAILED")
 
-    owner_marker = _owner_marker(material_node, input_index)
-    created = not _is_owned_texture(previous_input, texture_type, owner_marker)
-    if created:
-        try:
-            texture_node = material_node.parent().createNode(texture_type)
-            texture_node.setUserData(_OWNER_USER_DATA_KEY, owner_marker)
-            if texture_node.userData(_OWNER_USER_DATA_KEY) != owner_marker:
-                raise RuntimeError("ownership readback mismatch")
-        except Exception:  # noqa: BLE001
-            if "texture_node" in locals() and not _destroy_created_node(texture_node):
-                return skill_error(
-                    "Texture node creation failed and rollback could not be verified",
-                    "TEXTURE_ROLLBACK_FAILED",
-                )
-            return skill_error(
-                "Required texture node could not be created",
-                "TEXTURE_NODE_CREATION_FAILED",
-                node_type=texture_type,
-            )
-    else:
-        texture_node = previous_input
-
-    file_parm = next((texture_node.parm(name) for name in _IMAGE_FILE_PARMS if texture_node.parm(name)), None)
-    if file_parm is None:
-        if created and not _destroy_created_node(texture_node):
-            return skill_error(
-                "Texture node validation failed and rollback could not be verified",
-                "TEXTURE_ROLLBACK_FAILED",
-            )
-        return skill_error(
-            "Texture node has no file path parameter",
-            "UNSUPPORTED_TEXTURE_PARAMETER",
-            node_type=texture_node.type().name(),
-        )
+    if owned_texture is not None and owned_texture is not previous_input:
+        return skill_error("Texture ownership is ambiguous", "AMBIGUOUS_TEXTURE_OWNERSHIP")
+    created = owned_texture is None
+    texture_node = None
+    snapshots: list[tuple[Any, Any]] = []
 
     try:
+        if created:
+            _assert_texture_file_current(texture_ref)
+            texture_node = material_node.parent().createNode(texture_type)
+            owner_marker = _owner_marker(material_node, input_index, texture_node)
+            _assert_texture_file_current(texture_ref)
+            texture_node.setUserData(_OWNER_USER_DATA_KEY, owner_marker)
+            _assert_texture_file_current(texture_ref)
+            if texture_node.userData(_OWNER_USER_DATA_KEY) != owner_marker:
+                raise RuntimeError("ownership readback mismatch")
+        else:
+            texture_node = owned_texture
+
+        file_parm = next(
+            (texture_node.parm(name) for name in _IMAGE_FILE_PARMS.get(texture_type, ()) if texture_node.parm(name)),
+            None,
+        )
+        if file_parm is None:
+            raise RuntimeError("texture node has no supported file parameter")
+        _assert_texture_file_current(texture_ref)
         snapshots = [(file_parm, file_parm.eval())]
+        _assert_texture_file_current(texture_ref)
         file_parm.set(texture_path)
         if created:
+            _assert_texture_file_current(texture_ref)
             material_node.setInput(input_index, texture_node, 0)
-        if file_parm.eval() != texture_path or material_node.input(input_index) is not texture_node:
+        _assert_texture_file_current(texture_ref)
+        texture_readback = file_parm.eval()
+        _assert_texture_file_current(texture_ref)
+        input_readback = material_node.input(input_index)
+        if texture_readback != texture_path or input_readback is not texture_node:
             raise RuntimeError("readback mismatch")
-    except Exception:  # noqa: BLE001
-        rollback_ok = _rollback_parms(snapshots) if "snapshots" in locals() else False
+        _assert_texture_file_current(texture_ref)
+        material_summary = node_summary(material_node)
+        _assert_texture_file_current(texture_ref)
+        texture_summary = node_summary(texture_node)
+        _assert_texture_file_current(texture_ref)
+        texture_node_path = texture_node.path()
+        return skill_success(
+            "Assigned and wired texture to material",
+            material=material_summary,
+            parameter=parameter_name,
+            texture_node=texture_summary,
+            texture_path=texture_path,
+            detected_colorspace=_detect_colorspace(texture_path),
+            reused_owned_node=not created,
+            verified=True,
+            undo_label=undo_label,
+            readback={
+                "input_index": input_index,
+                "texture_node": texture_node_path,
+                "texture_path": str(texture_readback),
+            },
+        )
+    except BaseException as exc:  # noqa: BLE001
+        rollback_ok = _rollback_parms(snapshots) if snapshots else True
         try:
-            if created and material_node.input(input_index) is texture_node:
+            current_input = material_node.input(input_index)
+            if current_input is not previous_input:
                 material_node.setInput(input_index, previous_input, 0)
             rollback_ok = material_node.input(input_index) is previous_input and rollback_ok
-        except Exception:  # noqa: BLE001
+        except BaseException:  # noqa: BLE001
             rollback_ok = False
-        if created:
+        if created and texture_node is not None:
             rollback_ok = _destroy_created_node(texture_node) and rollback_ok
         if not rollback_ok:
             return skill_error(
                 "Texture wiring failed and rollback could not be verified",
                 "TEXTURE_ROLLBACK_FAILED",
             )
+        if isinstance(exc, _TextureFileError):
+            return skill_error("Texture file changed during assignment", "TEXTURE_FILE_CHANGED")
         return skill_error("Texture could not be wired to the material input", "TEXTURE_WIRING_FAILED")
-
-    return skill_success(
-        "Assigned and wired texture to material",
-        material=node_summary(material_node),
-        parameter=parameter_name,
-        texture_node=node_summary(texture_node),
-        texture_path=texture_path,
-        detected_colorspace=_detect_colorspace(texture_path),
-        reused_owned_node=not created,
-        verified=True,
-        undo_label=undo_label,
-        readback={
-            "input_index": input_index,
-            "texture_node": texture_node.path(),
-            "texture_path": str(file_parm.eval()),
-        },
-    )
 
 
 def assign_texture(
@@ -311,12 +512,21 @@ def assign_texture(
         return skill_error("Invalid texture file path", "INVALID_TEXTURE_PATH")
     if colorspace is not None and (not isinstance(colorspace, str) or not colorspace):
         return skill_error("Invalid texture color space", "INVALID_COLORSPACE")
-    if not Path(texture_path).is_file():
+    try:
+        texture_ref = _capture_texture_file(texture_path)
+    except FileNotFoundError:
         return skill_error(
             "Texture file was not found",
             "TEXTURE_FILE_NOT_FOUND",
             prompt="Check the texture path and try again.",
         )
+    except _TextureFileError:
+        return skill_error(
+            "Texture file could not be used safely",
+            "UNSAFE_TEXTURE_FILE",
+            prompt="Use a stable local regular file with no links or reparse points.",
+        )
+    texture_path = texture_ref.path
 
     try:
         target_node = get_node(hou, material_path)
@@ -348,18 +558,34 @@ def assign_texture(
     try:
         with _undo_group(hou, undo_label):
             if target_type in _PRINCIPLED_SHADER_TYPES:
-                return _assign_principled(target_node, parameter_name, texture_path, colorspace, undo_label)
+                return _assign_principled(
+                    target_node,
+                    parameter_name,
+                    texture_path,
+                    texture_ref,
+                    colorspace,
+                    undo_label,
+                )
             if target_type in _DIRECT_TEXTURE_NODE_TYPES:
-                return _assign_direct_texture(hou, target_node, parameter_name, texture_path, colorspace, undo_label)
+                return _assign_direct_texture(
+                    hou,
+                    target_node,
+                    parameter_name,
+                    texture_path,
+                    texture_ref,
+                    colorspace,
+                    undo_label,
+                )
             return _assign_wired_material(
                 target_node,
                 target_type,
                 parameter_name,
                 texture_path,
+                texture_ref,
                 colorspace,
                 undo_label,
             )
-    except Exception:  # noqa: BLE001
+    except BaseException:  # noqa: BLE001
         return skill_error("Texture assignment failed", "TEXTURE_ASSIGNMENT_FAILED")
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
@@ -144,9 +144,10 @@ tools:
       MaterialX/Arnold surface nodes create and own one matching image-node
       connection per material input, then reuse it on repeated calls. Existing
       upstream nodes owned by another target are preserved. Texture files are
-      bound to a regular-file identity and digest through guarded mutation and
-      readback; linked files, stale/duplicate ownership, and unsupported string
-      parameters fail without fallback wiring or partial graph mutation.
+      bound to a regular-file identity and one bounded digest pass (maximum
+      256 MiB) followed by metadata-only guarded mutation and readback; linked
+      files, stale/duplicate ownership, and unsupported string parameters fail
+      without fallback wiring or partial graph mutation.
     source_file: scripts/assign_texture.py
     execution: sync
     affinity: main

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
@@ -138,9 +138,11 @@ tools:
   # ── Texture Management ─────────────────────────────────────────────
   - name: assign_texture
     description: >-
-      Assign a texture file to a material/shader parameter.  Creates or
-      updates a file-texture VOP node and wires it to the target parameter.
-      Supports principledshader, MaterialX, and Arnold shaders.
+      Assign a texture through an explicit Principled Shader, MaterialX, or
+      Arnold contract.  Principled Shader uses its built-in texture toggle and
+      path; supported image nodes update a string file parameter; supported
+      MaterialX/Arnold surface nodes create and verify a matching image-node
+      connection. Unsupported targets fail without fallback wiring.
     source_file: scripts/assign_texture.py
     execution: sync
     affinity: main
@@ -155,20 +157,25 @@ tools:
     input_schema:
       type: object
       required: [material_path, parameter_name, texture_path]
+      additionalProperties: false
       properties:
         material_path:
           type: string
+          pattern: ^/
           description: Path to the material/shader node.
         parameter_name:
           type: string
+          pattern: ^[A-Za-z][A-Za-z0-9_]*$
           description: >-
             Name of the color/texture parameter to drive
             (e.g. basecolor, baseColor, diffuse, base_color).
         texture_path:
           type: string
+          minLength: 1
           description: File path to the texture image on disk.
         colorspace:
           type: string
+          minLength: 1
           description: >-
             OCIO color space for the texture (e.g. Utility - sRGB - Texture,
             ACES - ACEScg).  Auto-detected from file extension when omitted.

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
@@ -143,8 +143,10 @@ tools:
       path; supported image nodes update a string file parameter; supported
       MaterialX/Arnold surface nodes create and own one matching image-node
       connection per material input, then reuse it on repeated calls. Existing
-      upstream nodes owned by another target are preserved. Unsupported targets
-      fail without fallback wiring.
+      upstream nodes owned by another target are preserved. Texture files are
+      bound to a regular-file identity and digest through guarded mutation and
+      readback; linked files, stale/duplicate ownership, and unsupported string
+      parameters fail without fallback wiring or partial graph mutation.
     source_file: scripts/assign_texture.py
     execution: sync
     affinity: main

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
@@ -141,8 +141,10 @@ tools:
       Assign a texture through an explicit Principled Shader, MaterialX, or
       Arnold contract.  Principled Shader uses its built-in texture toggle and
       path; supported image nodes update a string file parameter; supported
-      MaterialX/Arnold surface nodes create and verify a matching image-node
-      connection. Unsupported targets fail without fallback wiring.
+      MaterialX/Arnold surface nodes create and own one matching image-node
+      connection per material input, then reuse it on repeated calls. Existing
+      upstream nodes owned by another target are preserved. Unsupported targets
+      fail without fallback wiring.
     source_file: scripts/assign_texture.py
     execution: sync
     affinity: main
@@ -177,8 +179,10 @@ tools:
           type: string
           minLength: 1
           description: >-
-            OCIO color space for the texture (e.g. Utility - sRGB - Texture,
-            ACES - ACEScg).  Auto-detected from file extension when omitted.
+            Explicit OCIO color space for a direct image node exposing a string
+            colorspace parameter. Principled and wired material targets reject
+            explicit values before mutation. When omitted, extension detection
+            is advisory only and does not change host color-space parameters.
 
   - name: list_images
     description: >-

--- a/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-material-library/tools.yaml
@@ -144,10 +144,11 @@ tools:
       MaterialX/Arnold surface nodes create and own one matching image-node
       connection per material input, then reuse it on repeated calls. Existing
       upstream nodes owned by another target are preserved. Texture files are
-      bound to a regular-file identity and one bounded digest pass (maximum
-      256 MiB) followed by metadata-only guarded mutation and readback; linked
-      files, stale/duplicate ownership, and unsupported string parameters fail
-      without fallback wiring or partial graph mutation.
+      bound to a regular-file identity and one digest pass (maximum 256 MiB,
+      with elapsed time checked before and after each read). Windows holds a
+      native write-denying lease through mutation, final readback, and undo
+      exit. Linked files, stale/duplicate ownership, and unsupported string
+      parameters fail without fallback wiring or partial graph mutation.
     source_file: scripts/assign_texture.py
     execution: sync
     affinity: main

--- a/tests/test_assign_texture.py
+++ b/tests/test_assign_texture.py
@@ -1,0 +1,462 @@
+"""Behavior tests for the typed Houdini texture-assignment contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+from jsonschema import Draft202012Validator
+from skill_loader import skill_script_import_context
+
+_SCRIPT = (
+    Path(__file__).parent.parent
+    / "src"
+    / "dcc_mcp_houdini"
+    / "skills"
+    / "houdini-material-library"
+    / "scripts"
+    / "assign_texture.py"
+)
+_TOOLS = _SCRIPT.parent.parent / "tools.yaml"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("test_assign_texture_script", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return module
+
+
+class _FakeParmTemplate:
+    def __init__(self, parm_type: object) -> None:
+        self._parm_type = parm_type
+
+    def type(self) -> object:
+        return self._parm_type
+
+
+class _FakeParm:
+    def __init__(self, value: object, parm_type: object) -> None:
+        self.value = value
+        self._template = _FakeParmTemplate(parm_type)
+
+    def parmTemplate(self) -> _FakeParmTemplate:
+        return self._template
+
+    def set(self, value: object) -> None:
+        self.value = value
+
+    def eval(self) -> object:
+        return self.value
+
+
+class _FailOnValueParm(_FakeParm):
+    def __init__(self, value: object, parm_type: object, rejected: object) -> None:
+        super().__init__(value, parm_type)
+        self._rejected = rejected
+
+    def set(self, value: object) -> None:
+        if value == self._rejected:
+            raise RuntimeError("private workstation failure")
+        super().set(value)
+
+
+class _FakeNodeType:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
+class _FakeParent:
+    def __init__(self) -> None:
+        self.created_types: list[str] = []
+
+    def createNode(self, node_type: str):
+        self.created_types.append(node_type)
+        raise RuntimeError("texture VOP creation should not be attempted")
+
+    def path(self) -> str:
+        return "/mat"
+
+
+class _FakePrincipledShader:
+    def __init__(self, string_type: object) -> None:
+        self._parent = _FakeParent()
+        numeric_type = object()
+        self.parms = {
+            "basecolor": _FakeParm((1.0, 1.0, 1.0), numeric_type),
+            "basecolor_useTexture": _FakeParm(0, numeric_type),
+            "basecolor_texture": _FakeParm("", string_type),
+        }
+
+    def parm(self, name: str):
+        return self.parms.get(name)
+
+    def parent(self) -> _FakeParent:
+        return self._parent
+
+    def type(self) -> _FakeNodeType:
+        return _FakeNodeType("principledshader::2.0")
+
+    def path(self) -> str:
+        return "/mat/principledshader1"
+
+    def name(self) -> str:
+        return "principledshader1"
+
+
+class _FakeUnsupportedNode:
+    def __init__(self) -> None:
+        self._parent = _FakeParent()
+
+    def parm(self, _name: str):
+        return None
+
+    def parent(self) -> _FakeParent:
+        return self._parent
+
+    def type(self) -> _FakeNodeType:
+        return _FakeNodeType("subnet")
+
+    def path(self) -> str:
+        return "/mat/not_a_shader"
+
+    def name(self) -> str:
+        return "not_a_shader"
+
+
+class _FakeTextureNode:
+    def __init__(self, parent: "_FakeWiringParent", node_type: str, string_type: object) -> None:
+        self._parent = parent
+        self._type = node_type
+        self._file = _FakeParm("", string_type)
+
+    def parm(self, name: str):
+        return self._file if name == "file" else None
+
+    def type(self) -> _FakeNodeType:
+        return _FakeNodeType(self._type)
+
+    def path(self) -> str:
+        return "/mat/image1"
+
+    def name(self) -> str:
+        return "image1"
+
+    def destroy(self) -> None:
+        self._parent.children.remove(self)
+
+
+class _FakeWiringParent:
+    def __init__(self, string_type: object) -> None:
+        self._string_type = string_type
+        self.children: list[_FakeTextureNode] = []
+
+    def createNode(self, node_type: str) -> _FakeTextureNode:
+        node = _FakeTextureNode(self, node_type, self._string_type)
+        self.children.append(node)
+        return node
+
+    def path(self) -> str:
+        return "/mat"
+
+
+class _FakeWiredMaterial:
+    def __init__(self, string_type: object) -> None:
+        self._parent = _FakeWiringParent(string_type)
+
+    def parm(self, _name: str):
+        return None
+
+    def parent(self) -> _FakeWiringParent:
+        return self._parent
+
+    def type(self) -> _FakeNodeType:
+        return _FakeNodeType("mtlxstandard_surface")
+
+    def path(self) -> str:
+        return "/mat/standard_surface1"
+
+    def name(self) -> str:
+        return "standard_surface1"
+
+    def inputNames(self) -> tuple[str, ...]:
+        return ("base_color",)
+
+    def input(self, _index: int):
+        return None
+
+    def setInput(self, _index: int, _node: _FakeTextureNode, _output: int) -> None:
+        raise RuntimeError("private workstation path must not escape")
+
+
+class _FakeSuccessfulWiredMaterial(_FakeWiredMaterial):
+    def __init__(self, string_type: object) -> None:
+        super().__init__(string_type)
+        self._input = None
+
+    def setInput(self, index: int, node: _FakeTextureNode, output: int) -> None:
+        assert index == 0
+        assert output == 0
+        self._input = node
+
+    def input(self, index: int):
+        assert index == 0
+        return self._input
+
+
+class _FakeUndoGroup:
+    def __init__(self, owner: "_FakeUndos", label: str) -> None:
+        self._owner = owner
+        self._label = label
+
+    def __enter__(self) -> None:
+        self._owner.entered.append(self._label)
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        self._owner.exited.append(self._label)
+
+
+class _FakeUndos:
+    def __init__(self) -> None:
+        self.entered: list[str] = []
+        self.exited: list[str] = []
+
+    def group(self, label: str) -> _FakeUndoGroup:
+        return _FakeUndoGroup(self, label)
+
+
+def test_principled_shader_uses_builtin_texture_slot_without_orphan_vop(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _FakeUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is True
+    assert material.parms["basecolor_useTexture"].value == 1
+    assert material.parms["basecolor_texture"].value == str(texture)
+    assert material.parent().created_types == []
+
+
+def test_unsupported_node_type_fails_without_scene_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    material = _FakeUnsupportedNode()
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": object()})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_TEXTURE_TARGET"
+    assert result["context"]["node_type"] == "subnet"
+    assert material.parent().created_types == []
+
+
+def test_invalid_parameter_name_fails_before_scene_lookup(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    hou = ModuleType("hou")
+    hou.node = lambda _path: (_ for _ in ()).throw(AssertionError("scene lookup must not run"))
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture("/mat/principledshader1", "../basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "INVALID_PARAMETER_NAME"
+
+
+def test_missing_texture_file_returns_stable_redacted_error(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    hou = ModuleType("hou")
+    hou.node = lambda _path: (_ for _ in ()).throw(AssertionError("scene lookup must not run"))
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    missing = tmp_path / "customer-secret" / "missing.png"
+
+    result = module.assign_texture("/mat/principledshader1", "basecolor", str(missing))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_FILE_NOT_FOUND"
+    assert "customer-secret" not in str(result)
+
+
+def test_wiring_failure_fails_closed_and_removes_created_texture(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_WIRING_FAILED"
+    assert "private workstation" not in str(result)
+    assert material.parent().children == []
+
+
+def test_principled_partial_write_rolls_back_without_side_effect(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    material.parms["basecolor_texture"].value = "original.png"
+    material.parms["basecolor_useTexture"] = _FailOnValueParm(0, object(), rejected=1)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ASSIGNMENT_FAILED"
+    assert "private workstation" not in str(result)
+    assert material.parms["basecolor_texture"].value == "original.png"
+    assert material.parms["basecolor_useTexture"].value == 0
+
+
+def test_principled_missing_builtin_texture_parameter_fails_without_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    del material.parms["basecolor_texture"]
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_TEXTURE_PARAMETER"
+    assert material.parms["basecolor_useTexture"].value == 0
+    assert material.parent().created_types == []
+
+
+def test_supported_texture_node_returns_verified_file_readback(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(image.path(), "file", str(texture))
+
+    assert result["success"] is True
+    assert result["context"]["readback"] == {
+        "parameter": "file",
+        "texture_path": str(texture),
+    }
+    assert image.parm("file").value == str(texture)
+    assert parent.children == []
+
+
+def test_supported_material_wiring_returns_verified_connection_readback(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _FakeUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is True
+    image = material.parent().children[0]
+    assert result["context"]["readback"] == {
+        "input_index": 0,
+        "texture_node": image.path(),
+        "texture_path": str(texture),
+    }
+    assert material.input(0) is image
+    assert hou.undos.entered == [result["context"]["undo_label"]]
+    assert hou.undos.exited == hou.undos.entered
+
+
+def test_successful_assignment_uses_one_named_undo_group(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _FakeUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is True
+    assert hou.undos.entered == [result["context"]["undo_label"]]
+    assert hou.undos.exited == hou.undos.entered
+    assert result["context"]["undo_label"].startswith("DCC MCP: assign texture ")
+
+
+def test_assign_texture_schema_matches_runtime_validation() -> None:
+    module = _load_script()
+    tools = yaml.safe_load(_TOOLS.read_text(encoding="utf-8"))["tools"]
+    contract = next(tool for tool in tools if tool["name"] == "assign_texture")["input_schema"]
+
+    Draft202012Validator.check_schema(contract)
+    signature = inspect.signature(module.assign_texture)
+    assert set(contract["properties"]) == set(signature.parameters)
+    assert set(contract["required"]) == {
+        name for name, parameter in signature.parameters.items() if parameter.default is inspect.Parameter.empty
+    }
+    assert contract["additionalProperties"] is False
+    assert contract["properties"]["material_path"]["pattern"] == r"^/"
+    assert contract["properties"]["parameter_name"]["pattern"] == r"^[A-Za-z][A-Za-z0-9_]*$"
+    assert contract["properties"]["texture_path"]["minLength"] == 1
+
+
+def test_runtime_rejects_material_path_that_schema_rejects(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    hou = ModuleType("hou")
+    hou.node = lambda _path: (_ for _ in ()).throw(AssertionError("scene lookup must not run"))
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture("mat/principledshader1", "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "INVALID_MATERIAL_PATH"

--- a/tests/test_assign_texture.py
+++ b/tests/test_assign_texture.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 import yaml
 from jsonschema import Draft202012Validator
 from skill_loader import skill_script_import_context
@@ -154,15 +156,17 @@ class _FakeTextureNode:
         self._type = node_type
         self._file = _FakeParm("", string_type)
         self._colorspace = None
+        self._extra_parms: dict[str, _FakeParm] = {}
         self._user_data: dict[str, str] = {}
         self._name = "image{}".format(len(parent.children) + 1)
+        self._session_id = 1000 + len(parent.children)
 
     def parm(self, name: str):
         if name == "file":
             return self._file
         if name == "colorspace":
             return self._colorspace
-        return None
+        return self._extra_parms.get(name)
 
     def enable_colorspace(self, value: str = "auto") -> None:
         self._colorspace = _FakeParm(value, self._file.parmTemplate().type())
@@ -178,6 +182,9 @@ class _FakeTextureNode:
 
     def name(self) -> str:
         return self._name
+
+    def sessionId(self) -> int:
+        return self._session_id
 
     def userData(self, key: str):
         return self._user_data.get(key)
@@ -222,6 +229,8 @@ class _FakeWiredMaterial:
     def __init__(self, string_type: object, node_type: str = "mtlxstandard_surface") -> None:
         self._parent = _FakeWiringParent(string_type)
         self._type = node_type
+        self._session_id = 100
+        self._path = "/mat/standard_surface1"
 
     def parm(self, _name: str):
         return None
@@ -233,10 +242,13 @@ class _FakeWiredMaterial:
         return _FakeNodeType(self._type)
 
     def path(self) -> str:
-        return "/mat/standard_surface1"
+        return self._path
 
     def name(self) -> str:
         return "standard_surface1"
+
+    def sessionId(self) -> int:
+        return self._session_id
 
     def inputNames(self) -> tuple[str, ...]:
         return ("base_color",)
@@ -363,6 +375,72 @@ def test_invalid_parameter_name_fails_before_scene_lookup(monkeypatch, tmp_path:
 
     assert result["success"] is False
     assert result["error"] == "INVALID_PARAMETER_NAME"
+
+
+def test_hardlinked_texture_file_fails_before_scene_lookup(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    hou = ModuleType("hou")
+    hou.node = lambda _path: (_ for _ in ()).throw(AssertionError("scene lookup must not run"))
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    original = tmp_path / "original.png"
+    texture = tmp_path / "alias.png"
+    original.write_bytes(b"png")
+    os.link(original, texture)
+
+    result = module.assign_texture("/mat/principledshader1", "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSAFE_TEXTURE_FILE"
+
+
+def test_symlinked_texture_file_fails_before_scene_lookup(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    hou = ModuleType("hou")
+    hou.node = lambda _path: (_ for _ in ()).throw(AssertionError("scene lookup must not run"))
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    original = tmp_path / "original.png"
+    texture = tmp_path / "alias.png"
+    original.write_bytes(b"png")
+    try:
+        texture.symlink_to(original)
+    except OSError as exc:
+        pytest.skip("file symlinks are unavailable: {}".format(exc.winerror if hasattr(exc, "winerror") else exc))
+
+    result = module.assign_texture("/mat/principledshader1", "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSAFE_TEXTURE_FILE"
+
+
+def test_texture_replacement_after_preflight_fails_without_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"first")
+    original_guard = module._assert_texture_file_current
+    replaced = False
+
+    def replace_before_guard(texture_ref) -> None:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            texture.unlink()
+            texture.write_bytes(b"second")
+        original_guard(texture_ref)
+
+    monkeypatch.setattr(module, "_assert_texture_file_current", replace_before_guard)
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_FILE_CHANGED"
+    assert material.parms["basecolor_useTexture"].value == 0
+    assert material.parms["basecolor_texture"].value == ""
 
 
 def test_missing_texture_file_returns_stable_redacted_error(monkeypatch, tmp_path: Path) -> None:
@@ -521,6 +599,26 @@ def test_supported_texture_node_returns_verified_file_readback(monkeypatch, tmp_
     assert parent.children == []
 
 
+def test_direct_image_rejects_non_file_string_parameter(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    image._extra_parms["label"] = _FakeParm("keep me", string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(image.path(), "label", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_TEXTURE_PARAMETER"
+    assert image.parm("label").value == "keep me"
+
+
 def test_explicit_colorspace_requires_parameter_before_direct_mutation(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     string_type = object()
@@ -628,6 +726,76 @@ def test_repeated_materialx_assignment_reuses_owned_image_node(monkeypatch, tmp_
     assert second["success"] is True
     assert material.input(0) is first_image
     assert material.parent().children == [first_image]
+
+
+def test_duplicate_owned_texture_nodes_fail_closed_without_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    first = material.parent().createNode("mtlximage")
+    second = material.parent().createNode("mtlximage")
+    first.setUserData(module._OWNER_USER_DATA_KEY, module._owner_marker(material, 0, first))
+    second.setUserData(module._OWNER_USER_DATA_KEY, module._owner_marker(material, 0, second))
+    material._input = first
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "AMBIGUOUS_TEXTURE_OWNERSHIP"
+    assert material.input(0) is first
+    assert first.parm("file").value == ""
+    assert second.parm("file").value == ""
+
+
+def test_material_rename_reuses_one_durable_owned_texture_node(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    first = module.assign_texture(material.path(), "base_color", str(texture))
+    owned = material.input(0)
+    material._path = "/mat/renamed_surface"
+    second = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert material.input(0) is owned
+    assert material.parent().children == [owned]
+
+
+def test_replaced_material_session_rejects_stale_owned_node(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    first = module.assign_texture(material.path(), "base_color", str(texture))
+    owned = material.input(0)
+    material._session_id += 1
+    second = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert first["success"] is True
+    assert second["success"] is False
+    assert second["error"] == "AMBIGUOUS_TEXTURE_OWNERSHIP"
+    assert material.input(0) is owned
+    assert material.parent().children == [owned]
 
 
 def test_arnold_material_assignment_creates_exact_owned_image_type(monkeypatch, tmp_path: Path) -> None:
@@ -756,6 +924,55 @@ def test_successful_assignment_uses_one_named_undo_group(monkeypatch, tmp_path: 
     assert hou.undos.entered == [result["context"]["undo_label"]]
     assert hou.undos.exited == hou.undos.entered
     assert result["context"]["undo_label"].startswith("DCC MCP: assign texture ")
+
+
+def test_post_mutation_node_summary_failure_rolls_back_wired_graph(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _FakeUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    monkeypatch.setattr(
+        module,
+        "node_summary",
+        lambda _node: (_ for _ in ()).throw(KeyboardInterrupt("post-mutation failure")),
+    )
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_WIRING_FAILED"
+    assert material.input(0) is None
+    assert material.parent().children == []
+
+
+def test_post_mutation_skill_success_failure_rolls_back_direct_parameter(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    monkeypatch.setattr(
+        module,
+        "skill_success",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit("post-mutation failure")),
+    )
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(image.path(), "file", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ASSIGNMENT_FAILED"
+    assert image.parm("file").value == ""
 
 
 def test_assign_texture_schema_matches_runtime_validation() -> None:

--- a/tests/test_assign_texture.py
+++ b/tests/test_assign_texture.py
@@ -68,6 +68,19 @@ class _FailOnValueParm(_FakeParm):
         super().set(value)
 
 
+class _RetainsMutationParm(_FakeParm):
+    def __init__(self, value: object, parm_type: object) -> None:
+        super().__init__(value, parm_type)
+        self._original = value
+        self._mutated = False
+
+    def set(self, value: object) -> None:
+        if self._mutated and value == self._original:
+            return
+        self._mutated = True
+        super().set(value)
+
+
 class _FakeNodeType:
     def __init__(self, name: str) -> None:
         self._name = name
@@ -89,8 +102,9 @@ class _FakeParent:
 
 
 class _FakePrincipledShader:
-    def __init__(self, string_type: object) -> None:
+    def __init__(self, string_type: object, node_type: str = "principledshader::2.0") -> None:
         self._parent = _FakeParent()
+        self._type = node_type
         numeric_type = object()
         self.parms = {
             "basecolor": _FakeParm((1.0, 1.0, 1.0), numeric_type),
@@ -105,7 +119,7 @@ class _FakePrincipledShader:
         return self._parent
 
     def type(self) -> _FakeNodeType:
-        return _FakeNodeType("principledshader::2.0")
+        return _FakeNodeType(self._type)
 
     def path(self) -> str:
         return "/mat/principledshader1"
@@ -139,18 +153,37 @@ class _FakeTextureNode:
         self._parent = parent
         self._type = node_type
         self._file = _FakeParm("", string_type)
+        self._colorspace = None
+        self._user_data: dict[str, str] = {}
+        self._name = "image{}".format(len(parent.children) + 1)
 
     def parm(self, name: str):
-        return self._file if name == "file" else None
+        if name == "file":
+            return self._file
+        if name == "colorspace":
+            return self._colorspace
+        return None
+
+    def enable_colorspace(self, value: str = "auto") -> None:
+        self._colorspace = _FakeParm(value, self._file.parmTemplate().type())
 
     def type(self) -> _FakeNodeType:
         return _FakeNodeType(self._type)
 
+    def parent(self) -> "_FakeWiringParent":
+        return self._parent
+
     def path(self) -> str:
-        return "/mat/image1"
+        return "/mat/{}".format(self._name)
 
     def name(self) -> str:
-        return "image1"
+        return self._name
+
+    def userData(self, key: str):
+        return self._user_data.get(key)
+
+    def setUserData(self, key: str, value: str) -> None:
+        self._user_data[key] = value
 
     def destroy(self) -> None:
         self._parent.children.remove(self)
@@ -169,10 +202,26 @@ class _FakeWiringParent:
     def path(self) -> str:
         return "/mat"
 
+    def node(self, name: str):
+        return next((child for child in self.children if child.name() == name), None)
+
+
+class _FakeRetainedDestroyNode(_FakeTextureNode):
+    def destroy(self) -> None:
+        return None
+
+
+class _FakeRetainedDestroyParent(_FakeWiringParent):
+    def createNode(self, node_type: str) -> _FakeTextureNode:
+        node = _FakeRetainedDestroyNode(self, node_type, self._string_type)
+        self.children.append(node)
+        return node
+
 
 class _FakeWiredMaterial:
-    def __init__(self, string_type: object) -> None:
+    def __init__(self, string_type: object, node_type: str = "mtlxstandard_surface") -> None:
         self._parent = _FakeWiringParent(string_type)
+        self._type = node_type
 
     def parm(self, _name: str):
         return None
@@ -181,7 +230,7 @@ class _FakeWiredMaterial:
         return self._parent
 
     def type(self) -> _FakeNodeType:
-        return _FakeNodeType("mtlxstandard_surface")
+        return _FakeNodeType(self._type)
 
     def path(self) -> str:
         return "/mat/standard_surface1"
@@ -200,8 +249,8 @@ class _FakeWiredMaterial:
 
 
 class _FakeSuccessfulWiredMaterial(_FakeWiredMaterial):
-    def __init__(self, string_type: object) -> None:
-        super().__init__(string_type)
+    def __init__(self, string_type: object, node_type: str = "mtlxstandard_surface") -> None:
+        super().__init__(string_type, node_type)
         self._input = None
 
     def setInput(self, index: int, node: _FakeTextureNode, output: int) -> None:
@@ -212,6 +261,17 @@ class _FakeSuccessfulWiredMaterial(_FakeWiredMaterial):
     def input(self, index: int):
         assert index == 0
         return self._input
+
+
+class _FakeStickyRollbackMaterial(_FakeSuccessfulWiredMaterial):
+    def __init__(self, string_type: object, previous_input: _FakeTextureNode) -> None:
+        super().__init__(string_type)
+        self._input = previous_input
+
+    def setInput(self, index: int, node: _FakeTextureNode, output: int) -> None:
+        if node is self._input:
+            return
+        super().setInput(index, node, output)
 
 
 class _FakeUndoGroup:
@@ -251,6 +311,24 @@ def test_principled_shader_uses_builtin_texture_slot_without_orphan_vop(monkeypa
 
     assert result["success"] is True
     assert material.parms["basecolor_useTexture"].value == 1
+    assert material.parms["basecolor_texture"].value == str(texture)
+    assert material.parent().created_types == []
+
+
+def test_unversioned_principled_shader_uses_builtin_texture_slot(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type, "principledshader")
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is True
     assert material.parms["basecolor_texture"].value == str(texture)
     assert material.parent().created_types == []
 
@@ -320,6 +398,25 @@ def test_wiring_failure_fails_closed_and_removes_created_texture(monkeypatch, tm
     assert material.parent().children == []
 
 
+def test_nonthrowing_node_destroy_requires_exact_readback(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeWiredMaterial(string_type)
+    material._parent = _FakeRetainedDestroyParent(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ROLLBACK_FAILED"
+    assert len(material.parent().children) == 1
+
+
 def test_principled_partial_write_rolls_back_without_side_effect(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     string_type = object()
@@ -342,6 +439,26 @@ def test_principled_partial_write_rolls_back_without_side_effect(monkeypatch, tm
     assert material.parms["basecolor_useTexture"].value == 0
 
 
+def test_nonthrowing_parameter_rollback_requires_exact_readback(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    material.parms["basecolor_texture"] = _RetainsMutationParm("original.png", string_type)
+    material.parms["basecolor_useTexture"] = _FailOnValueParm(0, object(), rejected=1)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ROLLBACK_FAILED"
+    assert "original.png" not in str(result)
+
+
 def test_principled_missing_builtin_texture_parameter_fails_without_mutation(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     string_type = object()
@@ -360,6 +477,25 @@ def test_principled_missing_builtin_texture_parameter_fails_without_mutation(mon
     assert result["error"] == "UNSUPPORTED_TEXTURE_PARAMETER"
     assert material.parms["basecolor_useTexture"].value == 0
     assert material.parent().created_types == []
+
+
+def test_principled_rejects_explicit_colorspace_before_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture), colorspace="ACEScg")
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_COLORSPACE"
+    assert material.parms["basecolor_useTexture"].value == 0
+    assert material.parms["basecolor_texture"].value == ""
 
 
 def test_supported_texture_node_returns_verified_file_readback(monkeypatch, tmp_path: Path) -> None:
@@ -383,6 +519,67 @@ def test_supported_texture_node_returns_verified_file_readback(monkeypatch, tmp_
     }
     assert image.parm("file").value == str(texture)
     assert parent.children == []
+
+
+def test_explicit_colorspace_requires_parameter_before_direct_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(image.path(), "file", str(texture), colorspace="ACEScg")
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_COLORSPACE"
+    assert image.parm("file").value == ""
+
+
+def test_explicit_colorspace_is_applied_and_read_back_on_direct_image(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "arnold::image", string_type)
+    image.enable_colorspace()
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(image.path(), "file", str(texture), colorspace="ACEScg")
+
+    assert result["success"] is True
+    assert result["context"]["colorspace_applied"] == "ACEScg"
+    assert result["context"]["readback"]["colorspace"] == "ACEScg"
+    assert image.parm("colorspace").value == "ACEScg"
+
+
+def test_auto_colorspace_is_advisory_and_not_reported_as_applied(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    image.enable_colorspace("host-default")
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(image.path(), "file", str(texture))
+
+    assert result["success"] is True
+    assert result["context"]["detected_colorspace"] == "sRGB"
+    assert "colorspace_applied" not in result["context"]
+    assert image.parm("colorspace").value == "host-default"
 
 
 def test_supported_material_wiring_returns_verified_connection_readback(monkeypatch, tmp_path: Path) -> None:
@@ -409,6 +606,136 @@ def test_supported_material_wiring_returns_verified_connection_readback(monkeypa
     assert material.input(0) is image
     assert hou.undos.entered == [result["context"]["undo_label"]]
     assert hou.undos.exited == hou.undos.entered
+
+
+def test_repeated_materialx_assignment_reuses_owned_image_node(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _FakeUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    first = module.assign_texture(material.path(), "base_color", str(texture))
+    first_image = material.input(0)
+    second = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert material.input(0) is first_image
+    assert material.parent().children == [first_image]
+
+
+def test_arnold_material_assignment_creates_exact_owned_image_type(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type, "arnold::standard_surface")
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is True
+    assert material.input(0).type().name() == "arnold::image"
+    assert [node.type().name() for node in material.parent().children] == ["arnold::image"]
+
+
+def test_existing_unowned_upstream_node_is_preserved(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    existing = material.parent().createNode("mtlximage")
+    material._input = existing
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is True
+    assert material.input(0) is not existing
+    assert existing in material.parent().children
+    assert len(material.parent().children) == 2
+
+
+def test_foreign_owned_upstream_node_is_preserved(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    existing = material.parent().createNode("mtlximage")
+    existing.setUserData("dcc_mcp.assign_texture.owner", "v1|/mat/other_material|0")
+    material._input = existing
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is True
+    assert material.input(0) is not existing
+    assert existing in material.parent().children
+
+
+def test_wired_material_rejects_explicit_colorspace_before_node_creation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type, "arnold::standard_surface")
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture), colorspace="ACEScg")
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_COLORSPACE"
+    assert material.parent().children == []
+
+
+def test_wiring_rollback_requires_exact_input_readback(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    existing = parent.createNode("mtlximage")
+    material = _FakeStickyRollbackMaterial(string_type, existing)
+    material._parent = parent
+    original_set_input = material.setInput
+
+    def fail_then_retain(index: int, node: _FakeTextureNode, output: int) -> None:
+        if node is existing:
+            return
+        original_set_input(index, node, output)
+        raise RuntimeError("private wiring failure")
+
+    material.setInput = fail_then_retain
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ROLLBACK_FAILED"
+    assert "private wiring" not in str(result)
 
 
 def test_successful_assignment_uses_one_named_undo_group(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_assign_texture.py
+++ b/tests/test_assign_texture.py
@@ -225,6 +225,18 @@ class _FakeRetainedDestroyParent(_FakeWiringParent):
         return node
 
 
+class _FakeBaseExceptionDestroyNode(_FakeTextureNode):
+    def destroy(self) -> None:
+        raise KeyboardInterrupt("destroy failed")
+
+
+class _FakeBaseExceptionDestroyParent(_FakeWiringParent):
+    def createNode(self, node_type: str) -> _FakeTextureNode:
+        node = _FakeBaseExceptionDestroyNode(self, node_type, self._string_type)
+        self.children.append(node)
+        return node
+
+
 class _FakeWiredMaterial:
     def __init__(self, string_type: object, node_type: str = "mtlxstandard_surface") -> None:
         self._parent = _FakeWiringParent(string_type)
@@ -305,6 +317,17 @@ class _FakeUndos:
 
     def group(self, label: str) -> _FakeUndoGroup:
         return _FakeUndoGroup(self, label)
+
+
+class _ExitBaseExceptionUndoGroup(_FakeUndoGroup):
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        super().__exit__(_exc_type, _exc, _tb)
+        raise KeyboardInterrupt("undo close failed")
+
+
+class _ExitBaseExceptionUndos(_FakeUndos):
+    def group(self, label: str) -> _FakeUndoGroup:
+        return _ExitBaseExceptionUndoGroup(self, label)
 
 
 def test_principled_shader_uses_builtin_texture_slot_without_orphan_vop(monkeypatch, tmp_path: Path) -> None:
@@ -493,6 +516,24 @@ def test_nonthrowing_node_destroy_requires_exact_readback(monkeypatch, tmp_path:
     assert result["success"] is False
     assert result["error"] == "TEXTURE_ROLLBACK_FAILED"
     assert len(material.parent().children) == 1
+
+
+def test_destroy_baseexception_is_reported_as_unverified_rollback(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeWiredMaterial(string_type)
+    material._parent = _FakeBaseExceptionDestroyParent(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ROLLBACK_FAILED"
 
 
 def test_principled_partial_write_rolls_back_without_side_effect(monkeypatch, tmp_path: Path) -> None:
@@ -706,6 +747,26 @@ def test_supported_material_wiring_returns_verified_connection_readback(monkeypa
     assert hou.undos.exited == hou.undos.entered
 
 
+def test_wired_image_rejects_non_string_file_host_shape_before_mutation(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    non_string_type = object()
+    material = _FakeSuccessfulWiredMaterial(non_string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSUPPORTED_TEXTURE_PARAMETER"
+    assert material.input(0) is None
+    assert material.parent().children == []
+
+
 def test_repeated_materialx_assignment_reuses_owned_image_node(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     string_type = object()
@@ -796,6 +857,35 @@ def test_replaced_material_session_rejects_stale_owned_node(monkeypatch, tmp_pat
     assert second["error"] == "AMBIGUOUS_TEXTURE_OWNERSHIP"
     assert material.input(0) is owned
     assert material.parent().children == [owned]
+
+
+def test_reused_material_session_cannot_claim_stale_path_alias(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    active_material = material
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: active_material if path == active_material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    first = module.assign_texture(material.path(), "base_color", str(texture))
+    owned = material.input(0)
+    replacement = _FakeSuccessfulWiredMaterial(string_type)
+    replacement._parent = material.parent()
+    replacement._input = owned
+    replacement._session_id = material.sessionId()
+    replacement._path = "/mat/reused_session_alias"
+    active_material = replacement
+    second = module.assign_texture(replacement.path(), "base_color", str(texture))
+
+    assert first["success"] is True
+    assert second["success"] is False
+    assert second["error"] == "AMBIGUOUS_TEXTURE_OWNERSHIP"
+    assert replacement.input(0) is owned
+    assert replacement.parent().children == [owned]
 
 
 def test_arnold_material_assignment_creates_exact_owned_image_type(monkeypatch, tmp_path: Path) -> None:
@@ -965,6 +1055,26 @@ def test_post_mutation_skill_success_failure_rolls_back_direct_parameter(monkeyp
         "skill_success",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit("post-mutation failure")),
     )
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(image.path(), "file", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ASSIGNMENT_FAILED"
+    assert image.parm("file").value == ""
+
+
+def test_undo_group_exit_baseexception_rolls_back_direct_parameter(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    hou.undos = _ExitBaseExceptionUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
     texture = tmp_path / "albedo.exr"
     texture.write_bytes(b"exr")
 

--- a/tests/test_assign_texture.py
+++ b/tests/test_assign_texture.py
@@ -479,6 +479,47 @@ def test_texture_replacement_after_preflight_fails_without_mutation(monkeypatch,
     assert material.parms["basecolor_texture"].value == ""
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows write-denying lease contract")
+def test_equal_length_in_place_overwrite_cannot_replace_hashed_payload(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    original_payload = b"first!"
+    replacement_payload = b"second"
+    texture.write_bytes(original_payload)
+    original_stat = texture.stat()
+    texture_parm = material.parms["basecolor_texture"]
+    original_set = texture_parm.set
+    overwrite_denied = False
+
+    def overwrite_during_mutation(value: object) -> None:
+        nonlocal overwrite_denied
+        try:
+            with texture.open("r+b") as stream:
+                stream.write(replacement_payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.utime(texture, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        except PermissionError:
+            overwrite_denied = True
+        original_set(value)
+
+    texture_parm.set = overwrite_during_mutation
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is True, result
+    assert overwrite_denied is True
+    assert texture.read_bytes() == original_payload
+    assert material.parms["basecolor_useTexture"].value == 1
+    assert material.parms["basecolor_texture"].value == str(texture)
+
+
 def test_texture_payload_is_hashed_once_per_assignment(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     string_type = object()
@@ -505,6 +546,34 @@ def test_texture_payload_is_hashed_once_per_assignment(monkeypatch, tmp_path: Pa
 
     assert result["success"] is True, result
     assert bytes_read == texture.stat().st_size
+
+
+def test_texture_digest_deadline_is_checked_after_eof_read(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    hou = ModuleType("hou")
+    hou.node = lambda _path: (_ for _ in ()).throw(AssertionError("scene lookup must not run"))
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "empty.exr"
+    texture.write_bytes(b"")
+    now = 0.0
+    original_read = module.os.read
+
+    def monotonic() -> float:
+        return now
+
+    def delayed_eof_read(fd: int, size: int) -> bytes:
+        nonlocal now
+        chunk = original_read(fd, size)
+        now = module._MAX_TEXTURE_HASH_SECS + 0.001
+        return chunk
+
+    monkeypatch.setattr(module.time, "monotonic", monotonic)
+    monkeypatch.setattr(module.os, "read", delayed_eof_read)
+
+    result = module.assign_texture("/mat/principledshader1", "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "UNSAFE_TEXTURE_FILE"
 
 
 def test_missing_texture_file_returns_stable_redacted_error(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_assign_texture.py
+++ b/tests/test_assign_texture.py
@@ -192,6 +192,9 @@ class _FakeTextureNode:
     def setUserData(self, key: str, value: str) -> None:
         self._user_data[key] = value
 
+    def destroyUserData(self, key: str, _must_exist: bool = True) -> None:
+        self._user_data.pop(key, None)
+
     def destroy(self) -> None:
         self._parent.children.remove(self)
 
@@ -243,6 +246,7 @@ class _FakeWiredMaterial:
         self._type = node_type
         self._session_id = 100
         self._path = "/mat/standard_surface1"
+        self._user_data: dict[str, str] = {}
 
     def parm(self, _name: str):
         return None
@@ -261,6 +265,15 @@ class _FakeWiredMaterial:
 
     def sessionId(self) -> int:
         return self._session_id
+
+    def userData(self, key: str):
+        return self._user_data.get(key)
+
+    def setUserData(self, key: str, value: str) -> None:
+        self._user_data[key] = value
+
+    def destroyUserData(self, key: str, _must_exist: bool = True) -> None:
+        self._user_data.pop(key, None)
 
     def inputNames(self) -> tuple[str, ...]:
         return ("base_color",)
@@ -464,6 +477,34 @@ def test_texture_replacement_after_preflight_fails_without_mutation(monkeypatch,
     assert result["error"] == "TEXTURE_FILE_CHANGED"
     assert material.parms["basecolor_useTexture"].value == 0
     assert material.parms["basecolor_texture"].value == ""
+
+
+def test_texture_payload_is_hashed_once_per_assignment(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    parent = _FakeWiringParent(string_type)
+    image = _FakeTextureNode(parent, "mtlximage", string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: image if path == image.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"x" * (4 * 1024 * 1024))
+    original_read = module.os.read
+    bytes_read = 0
+
+    def measured_read(fd: int, size: int) -> bytes:
+        nonlocal bytes_read
+        chunk = original_read(fd, size)
+        bytes_read += len(chunk)
+        return chunk
+
+    monkeypatch.setattr(module.os, "read", measured_read)
+
+    result = module.assign_texture(image.path(), "file", str(texture))
+
+    assert result["success"] is True, result
+    assert bytes_read == texture.stat().st_size
 
 
 def test_missing_texture_file_returns_stable_redacted_error(monkeypatch, tmp_path: Path) -> None:
@@ -795,6 +836,7 @@ def test_duplicate_owned_texture_nodes_fail_closed_without_mutation(monkeypatch,
     material = _FakeSuccessfulWiredMaterial(string_type)
     first = material.parent().createNode("mtlximage")
     second = material.parent().createNode("mtlximage")
+    material.setUserData(module._MATERIAL_ID_USER_DATA_KEY, "material-identity")
     first.setUserData(module._OWNER_USER_DATA_KEY, module._owner_marker(material, 0, first))
     second.setUserData(module._OWNER_USER_DATA_KEY, module._owner_marker(material, 0, second))
     material._input = first
@@ -888,6 +930,36 @@ def test_reused_material_session_cannot_claim_stale_path_alias(monkeypatch, tmp_
     assert replacement.parent().children == [owned]
 
 
+def test_reloaded_module_rejects_replacement_with_reused_session_and_path(monkeypatch, tmp_path: Path) -> None:
+    first_module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    active_material = material
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: active_material if path == active_material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    first = first_module.assign_texture(material.path(), "base_color", str(texture))
+    owned = material.input(0)
+    replacement = _FakeSuccessfulWiredMaterial(string_type)
+    replacement._parent = material.parent()
+    replacement._input = owned
+    replacement._session_id = material.sessionId()
+    replacement._path = material.path()
+    active_material = replacement
+    reloaded_module = _load_script()
+    second = reloaded_module.assign_texture(replacement.path(), "base_color", str(texture))
+
+    assert first["success"] is True
+    assert second["success"] is False
+    assert second["error"] == "AMBIGUOUS_TEXTURE_OWNERSHIP"
+    assert replacement.input(0) is owned
+    assert replacement.parent().children == [owned]
+
+
 def test_arnold_material_assignment_creates_exact_owned_image_type(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     string_type = object()
@@ -933,6 +1005,31 @@ def test_foreign_owned_upstream_node_is_preserved(monkeypatch, tmp_path: Path) -
     material = _FakeSuccessfulWiredMaterial(string_type)
     existing = material.parent().createNode("mtlximage")
     existing.setUserData("dcc_mcp.assign_texture.owner", "v1|/mat/other_material|0")
+    material._input = existing
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is True
+    assert material.input(0) is not existing
+    assert existing in material.parent().children
+
+
+def test_foreign_durable_owned_upstream_node_is_preserved(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    material.setUserData(module._MATERIAL_ID_USER_DATA_KEY, "current-material")
+    existing = material.parent().createNode("mtlximage")
+    existing.setUserData(
+        module._OWNER_USER_DATA_KEY,
+        "v3|foreign-material|999|0|{}|/mat/other_material".format(existing.sessionId()),
+    )
     material._input = existing
     hou = ModuleType("hou")
     hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
@@ -1083,6 +1180,46 @@ def test_undo_group_exit_baseexception_rolls_back_direct_parameter(monkeypatch, 
     assert result["success"] is False
     assert result["error"] == "TEXTURE_ASSIGNMENT_FAILED"
     assert image.parm("file").value == ""
+
+
+def test_undo_group_exit_baseexception_rolls_back_principled_parameters(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakePrincipledShader(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _ExitBaseExceptionUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.png"
+    texture.write_bytes(b"png")
+
+    result = module.assign_texture(material.path(), "basecolor", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ASSIGNMENT_FAILED"
+    assert material.parms["basecolor_useTexture"].value == 0
+    assert material.parms["basecolor_texture"].value == ""
+
+
+def test_undo_group_exit_baseexception_rolls_back_wired_graph(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    string_type = object()
+    material = _FakeSuccessfulWiredMaterial(string_type)
+    hou = ModuleType("hou")
+    hou.parmTemplateType = type("ParmTemplateType", (), {"String": string_type})
+    hou.node = lambda path: material if path == material.path() else None
+    hou.undos = _ExitBaseExceptionUndos()
+    monkeypatch.setitem(sys.modules, "hou", hou)
+    texture = tmp_path / "albedo.exr"
+    texture.write_bytes(b"exr")
+
+    result = module.assign_texture(material.path(), "base_color", str(texture))
+
+    assert result["success"] is False
+    assert result["error"] == "TEXTURE_ASSIGNMENT_FAILED"
+    assert material.input(0) is None
+    assert material.parent().children == []
 
 
 def test_assign_texture_schema_matches_runtime_validation() -> None:


### PR DESCRIPTION
## Summary
- make repeated MaterialX and Arnold texture assignments converge on one exactly owned image node
- preserve unowned and foreign-owned upstream nodes while verifying parameter, input, ownership, and rollback readback
- apply explicit color space only on supported direct image parameters; reject unsupported targets before mutation
- keep the typed allowlists, stable redacted errors, undo grouping, and schema/runtime contract aligned

## Validation
- `python -m pytest -q` (1166 passed, 1 skipped, 3 deselected)
- `ruff check src tests tools packaging`
- `ruff format --check src tests tools packaging` (419 files formatted)
- `python tools/lint_skills.py --require-cli --warnings-as-errors` (35 skills, 0 errors, 0 warnings)
- `python tools/check_py37_syntax.py src tests tools packaging`
- wheel and sdist build; `twine check` passed for both artifacts
- exact-head CI run 33034510552: success
- exact-head E2E run 33034510548: success, with live Houdini step skipped because SideFX credentials were not configured

## Real-host boundary
No safely callable licensed Houdini 22 instance was available during final validation. CI, the Docker workflow's credential-skip path, and mocked HOM tests are not real-host proof.

Refs #264