### PR TITLE
fix: harden Houdini light and save readback

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -81,6 +81,11 @@ structured `parameters` object; no renderer-specific Python is required.
 Do not save between batch calls. After every material and stage response has a
 successful summary, call `save_hip_file`. It writes a sibling temporary HIP and
 uses an atomic filesystem replacement, so a save or replace failure preserves
-the prior target. If replacement fails after the temporary save, use the
-returned `recovery_file`. In-memory recipes remain separate transactions;
-reload the prior saved HIP when whole-batch rollback is required.
+the prior target. In graphical Houdini, the tool verifies the dirty flag after
+replacement. If Houdini still reports unsaved changes, it performs a documented
+Save As to the target, returns `atomic_replace=false`, and verifies that the
+dirty flag cleared. Headless Hython reports `unsaved_changes=null` because HOM
+cannot observe that state there. If a save or verification fails after a valid
+file was staged, use the returned `recovery_file`. In-memory recipes remain
+separate transactions; reload the prior saved HIP when whole-batch rollback is
+required.

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/save_hip_file.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/save_hip_file.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+import shutil
 import uuid
 from pathlib import Path
 from typing import Optional
 
 from _automation_common import hou_import_error
 from dcc_mcp_core.skill import skill_entry, skill_exception, skill_success
+
+from dcc_mcp_houdini._hip_file_state import get_hip_dirty_state
 
 
 def save_hip_file(file_path: Optional[str] = None) -> dict:
@@ -20,6 +23,8 @@ def save_hip_file(file_path: Optional[str] = None) -> dict:
 
     temporary = None
     temporary_saved = False
+    target_replaced = False
+    recovery_staged = False
     previous_name = None
     try:
         previous_name = hou.hipFile.name()
@@ -32,9 +37,40 @@ def save_hip_file(file_path: Optional[str] = None) -> dict:
         temporary_saved = True
         hou.hipFile.setName(str(target))
         os.replace(str(temporary), str(target))
-        return skill_success("Saved Houdini hip file", hip_file=str(target), atomic_replace=True)
+        target_replaced = True
+
+        ui_available = bool(hou.isUIAvailable())
+        dirty_state = get_hip_dirty_state(hou)
+        atomic_replace = True
+        if dirty_state is True:
+            # Save As is the documented HOM operation that clears GUI dirty
+            # state. Preserve the atomic replacement separately in case this
+            # final state-confirming save partially overwrites the target.
+            shutil.copy2(str(target), str(temporary))
+            recovery_staged = True
+            hou.hipFile.save(file_name=str(target), save_to_recent_files=False)
+            atomic_replace = False
+            dirty_state = get_hip_dirty_state(hou)
+        if ui_available and dirty_state is not False:
+            raise RuntimeError("Houdini still reports unsaved changes after saving the HIP file")
+        if recovery_staged:
+            temporary.unlink()
+            recovery_staged = False
+        return skill_success(
+            "Saved Houdini hip file",
+            hip_file=str(target),
+            atomic_replace=atomic_replace,
+            unsaved_changes=dirty_state,
+        )
     except Exception as exc:
-        recovery_file = str(temporary) if temporary_saved and temporary is not None and temporary.exists() else None
+        if recovery_staged and temporary is not None and temporary.exists():
+            recovery_file = str(temporary)
+        elif not target_replaced and temporary_saved and temporary is not None and temporary.exists():
+            recovery_file = str(temporary)
+        elif target_replaced and target.exists():
+            recovery_file = str(target)
+        else:
+            recovery_file = None
         try:
             hou.hipFile.setName(recovery_file or previous_name)
         except Exception:

--- a/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
@@ -76,7 +76,10 @@ tools:
   - name: save_hip_file
     description: >-
       Save the current Houdini hip file, optionally to a new path, through a
-      sibling temporary file and atomic target replacement.
+      sibling temporary file and atomic target replacement. In graphical
+      Houdini, verify the dirty flag and fall back to a direct Save As when HOM
+      requires it to mark the scene clean; the result reports whether the final
+      write remained atomic and the observable unsaved state.
     input_schema:
       type: object
       properties:

--- a/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/_light_rig_common.py
+++ b/src/dcc_mcp_houdini/skills/houdini-light-rig/scripts/_light_rig_common.py
@@ -90,14 +90,26 @@ def apply_transform(
     return applied
 
 
+def _menu_index(value: Any) -> Optional[int]:
+    """Normalize Houdini menu values that may be wrapped by a parm tuple."""
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[0]
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def get_light_parms(light: Any) -> dict:
     """Read common hlight parameters and return a JSON-safe dict."""
     node_type = light.type().name().lower()
-    type_index = eval_parm(light, "light_type")
+    type_index = _menu_index(eval_parm(light, "light_type"))
     type_name = "environment" if "envlight" in node_type else None
     if type_name is None and type_index is not None:
         for name, idx in LIGHT_TYPES.items():
-            if idx == int(type_index) and name != "sun":
+            if idx == type_index and name != "sun":
                 type_name = name
                 break
 

--- a/tests/test_render_camera_light_skills.py
+++ b/tests/test_render_camera_light_skills.py
@@ -480,6 +480,25 @@ class TestLightSkills:
         assert result["intensity"] == 2.0
         assert result["env_map"] == "/maps/studio.hdr"
 
+    def test_lighting_summary_accepts_list_wrapped_light_type(self) -> None:
+        mod = _load_script("houdini-light-rig", "get_lighting_summary.py")
+        light = _node("/obj/key", "key", "hlight::2.0")
+        light_type = MagicMock()
+        light_type.eval.return_value = ([7],)
+        light.parmTuple.side_effect = lambda name: light_type if name == "light_type" else None
+        light.parm.return_value = None
+        parent = _node("/obj", "obj")
+        parent.children.return_value = [light]
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.get_lighting_summary()
+
+        assert result["success"] is True
+        assert result["context"]["lights"][0]["type"] == "distant"
+        assert result["context"]["lights"][0]["type_index"] == 7
+
 
 class TestViewSkills:
     def test_frame_view_headless(self) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1387,15 +1387,94 @@ class TestAutomationSkills:
 
         hip_file.save.side_effect = save
         mock_hou = MagicMock(hipFile=hip_file)
+        mock_hou.isUIAvailable.return_value = False
         with patch.dict(sys.modules, {"hou": mock_hou}):
             result = mod.save_hip_file(str(target))
 
         resolved = str(target.resolve())
         assert result["success"] is True
-        assert result["context"] == {"hip_file": resolved, "atomic_replace": True}
+        assert result["context"] == {
+            "hip_file": resolved,
+            "atomic_replace": True,
+            "unsaved_changes": None,
+        }
         assert target.read_bytes() == b"new"
         hip_file.setName.assert_called_once_with(resolved)
         assert list(tmp_path.iterdir()) == [target]
+
+    def test_save_hip_file_clears_gui_dirty_state_after_atomic_replace(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "save_hip_file.py")
+        target = tmp_path / "scene.hip"
+        target.write_bytes(b"old")
+        hip_file = MagicMock()
+        state = {"name": str(target), "dirty": True}
+
+        def save(file_name: str, save_to_recent_files: bool) -> None:
+            assert save_to_recent_files is False
+            Path(file_name).write_bytes(b"new")
+            state["name"] = file_name
+            state["dirty"] = False
+
+        def set_name(file_name: str) -> None:
+            state["name"] = file_name
+            state["dirty"] = True
+
+        hip_file.name.side_effect = lambda: state["name"]
+        hip_file.path.side_effect = lambda: state["name"]
+        hip_file.save.side_effect = save
+        hip_file.setName.side_effect = set_name
+        hip_file.hasUnsavedChanges.side_effect = lambda: state["dirty"]
+        mock_hou = MagicMock(hipFile=hip_file)
+        mock_hou.isUIAvailable.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.save_hip_file(str(target))
+
+        assert result["success"] is True
+        assert state["name"] == str(target.resolve())
+        assert state["dirty"] is False
+        assert result["context"]["atomic_replace"] is False
+        assert result["context"]["unsaved_changes"] is False
+        assert hip_file.save.call_count == 2
+
+    def test_save_hip_file_preserves_staged_recovery_when_gui_confirmation_fails(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "save_hip_file.py")
+        target = tmp_path / "scene.hip"
+        target.write_bytes(b"old")
+        hip_file = MagicMock()
+        state = {"name": str(target), "dirty": True, "save_count": 0}
+
+        def save(file_name: str, save_to_recent_files: bool) -> None:
+            assert save_to_recent_files is False
+            state["save_count"] += 1
+            if state["save_count"] == 1:
+                Path(file_name).write_bytes(b"new")
+                state["name"] = file_name
+                state["dirty"] = False
+                return
+            Path(file_name).write_bytes(b"partial")
+            raise OSError("confirmation save failed")
+
+        def set_name(file_name: str) -> None:
+            state["name"] = file_name
+            state["dirty"] = True
+
+        hip_file.name.side_effect = lambda: state["name"]
+        hip_file.path.side_effect = lambda: state["name"]
+        hip_file.save.side_effect = save
+        hip_file.setName.side_effect = set_name
+        hip_file.hasUnsavedChanges.side_effect = lambda: state["dirty"]
+        mock_hou = MagicMock(hipFile=hip_file)
+        mock_hou.isUIAvailable.return_value = True
+
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.save_hip_file(str(target))
+
+        recovery = Path(result["context"]["recovery_file"])
+        assert result["success"] is False
+        assert target.read_bytes() == b"partial"
+        assert recovery != target
+        assert recovery.read_bytes() == b"new"
 
     def test_save_hip_file_preserves_target_when_replace_fails(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-automation", "save_hip_file.py")


### PR DESCRIPTION
## Summary
- normalize list-wrapped Houdini light menu values before summary classification
- verify GUI HIP dirty state and preserve a recovery copy before fallback Save As
- document the atomic-write and dirty-state result contract

## Validation
- 1189 passed, 1 skipped, 3 deselected
- Ruff check and format
- Python 3.7 syntax and 35 bundled Skill validations
- wheel/sdist build and Twine checks

## Boundary
No live Houdini instance was registered. Mock-HOM, package, and CI evidence do not prove real-host acceptance.

Refs #264