### PR TITLE
feat: bound Houdini script output

### DIFF
--- a/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     dcc: houdini
     layer: pipeline
     stage: pipeline
-    version: "1.2.0"
+    version: "1.3.0"
     tags: [houdini, automation, hip, timeline, pipeline, scripts]
     search-hint: "run python file, save hip, load hip, timeline, build node chain"
     search-aliases: [run script file, save hip, open hip, load scene, set frame range, timeline, build node chain, automate houdini]
@@ -44,6 +44,15 @@ metadata:
 
 Higher-level repeatable automation for Houdini sessions. Prefer `run_python_file`
 for reviewed scripts on disk, and `build_node_chain` for compact graph recipes.
+
+`run_python_file` bounds inline stdout, stderr, and result payloads. Its default
+`output_mode=full` keeps the legacy string result while applying the configured
+character caps. Use `output_mode=structured` to preserve JSON-safe result types,
+or `output_mode=summary` to return counts and artifact metadata without inline
+bodies. When `spill_overflow_to_artifact=true`, truncated channels are written
+as complete UTF-8 temporary artifacts with byte counts and SHA-256; summary mode
+persists every non-empty channel. Treat those files as potentially sensitive
+script output and delete them after collection.
 
 `build_node_chain` is a structured atomic mutation surface, not an arbitrary
 code executor. It validates the parent, every node type/name/reference, and all

--- a/src/dcc_mcp_houdini/skills/houdini-automation/scripts/run_python_file.py
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/scripts/run_python_file.py
@@ -3,14 +3,180 @@
 from __future__ import annotations
 
 import contextlib
-import io
+import hashlib
+import json
 import os
+import tempfile
 import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from _automation_common import existing_file, hou_import_error
 from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+_OUTPUT_MODES = {"summary", "structured", "full"}
+_MAX_INLINE_CHARS = 1_000_000
+_SPOOL_MEMORY_BYTES = 64 * 1024
+
+
+class _BoundedTextCapture:
+    """Capture text with bounded memory and an optional durable overflow copy."""
+
+    def __init__(self, max_chars: int) -> None:
+        self.max_chars = max_chars
+        self.total_chars = 0
+        self._stream = tempfile.SpooledTemporaryFile(
+            max_size=_SPOOL_MEMORY_BYTES,
+            mode="w+t",
+            encoding="utf-8",
+            newline="",
+        )
+
+    @property
+    def truncated(self) -> bool:
+        return self.total_chars > self.max_chars
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        self.total_chars += len(text)
+        return self._stream.write(text)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def reset(self) -> None:
+        self._stream.seek(0)
+        self._stream.truncate(0)
+        self.total_chars = 0
+
+    def preview(self) -> str:
+        self._stream.flush()
+        position = self._stream.tell()
+        try:
+            self._stream.seek(0)
+            return self._stream.read(self.max_chars)
+        finally:
+            self._stream.seek(position)
+
+    def persist(self, label: str, force: bool = False, suffix: str = ".txt") -> Optional[dict]:
+        if self.total_chars == 0 or (not force and not self.truncated):
+            return None
+
+        self._stream.flush()
+        position = self._stream.tell()
+        artifact_path: Optional[Path] = None
+        digest = hashlib.sha256()
+        byte_count = 0
+        try:
+            self._stream.seek(0)
+            with tempfile.NamedTemporaryFile(
+                prefix="dcc-mcp-houdini-{}-".format(label),
+                suffix=suffix,
+                delete=False,
+            ) as artifact:
+                artifact_path = Path(artifact.name).resolve()
+                while True:
+                    chunk = self._stream.read(64 * 1024)
+                    if not chunk:
+                        break
+                    encoded = chunk.encode("utf-8")
+                    artifact.write(encoded)
+                    digest.update(encoded)
+                    byte_count += len(encoded)
+        except Exception:
+            if artifact_path is not None:
+                try:
+                    artifact_path.unlink()
+                except FileNotFoundError:
+                    pass
+            raise
+        finally:
+            self._stream.seek(position)
+
+        return {
+            "path": str(artifact_path),
+            "chars": self.total_chars,
+            "bytes": byte_count,
+            "sha256": digest.hexdigest(),
+            "encoding": "utf-8",
+        }
+
+    def close(self) -> None:
+        self._stream.close()
+
+
+def _require_char_limit(value: int, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= _MAX_INLINE_CHARS:
+        raise ValueError("{} must be an integer from 0 to {}".format(label, _MAX_INLINE_CHARS))
+    return value
+
+
+def _capture_result(value: Any, max_chars: int, output_mode: str) -> tuple:
+    capture = _BoundedTextCapture(max_chars)
+    if value is None:
+        return capture, None, False
+
+    if output_mode == "full":
+        capture.write(str(value))
+        return capture, capture.preview(), False
+
+    json_encoded = True
+    try:
+        encoder = json.JSONEncoder(ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+        for chunk in encoder.iterencode(value):
+            capture.write(chunk)
+    except (TypeError, ValueError):
+        json_encoded = False
+        capture.reset()
+        capture.write(str(value))
+
+    if output_mode == "summary" or capture.truncated:
+        return capture, None, json_encoded
+    if json_encoded:
+        return capture, json.loads(capture.preview()), True
+    return capture, capture.preview(), False
+
+
+def _output_summary(
+    output_mode: str,
+    stdout_capture: _BoundedTextCapture,
+    stderr_capture: _BoundedTextCapture,
+    result_capture: _BoundedTextCapture,
+    result_is_json: bool,
+    spill_overflow_to_artifact: bool,
+) -> dict:
+    captures = {
+        "stdout": stdout_capture,
+        "stderr": stderr_capture,
+        "result": result_capture,
+    }
+    artifacts: Dict[str, dict] = {}
+    if spill_overflow_to_artifact:
+        force = output_mode == "summary"
+        try:
+            for label, capture in captures.items():
+                artifact = capture.persist(
+                    label,
+                    force=force,
+                    suffix=".json" if label == "result" and result_is_json else ".txt",
+                )
+                if artifact is not None:
+                    artifacts[label] = artifact
+        except Exception:
+            for artifact in artifacts.values():
+                try:
+                    Path(artifact["path"]).unlink()
+                except FileNotFoundError:
+                    pass
+            raise
+    return {
+        "mode": output_mode,
+        "stdout_chars": stdout_capture.total_chars,
+        "stderr_chars": stderr_capture.total_chars,
+        "result_chars": result_capture.total_chars,
+        "truncated": {label: capture.truncated for label, capture in captures.items()},
+        "artifacts": artifacts,
+    }
 
 
 @contextlib.contextmanager
@@ -31,14 +197,39 @@ def run_python_file(
     args: Optional[List[Any]] = None,
     context: Optional[Dict[str, Any]] = None,
     working_directory: Optional[str] = None,
+    output_mode: str = "full",
+    max_stdout_chars: int = 4000,
+    max_stderr_chars: int = 4000,
+    max_result_chars: int = 8000,
+    spill_overflow_to_artifact: bool = True,
 ) -> dict:
-    """Execute a Python file with Houdini globals."""
+    """Execute a Python file with Houdini globals and bounded inline output."""
     try:
         import hou  # noqa: PLC0415
     except ImportError:
         return hou_import_error()
 
+    stdout_capture: Optional[_BoundedTextCapture] = None
+    stderr_capture: Optional[_BoundedTextCapture] = None
+    result_capture: Optional[_BoundedTextCapture] = None
     try:
+        if output_mode not in _OUTPUT_MODES:
+            return skill_error(
+                "Invalid output mode",
+                "output_mode must be one of: full, structured, summary",
+            )
+        try:
+            max_stdout_chars = _require_char_limit(max_stdout_chars, "max_stdout_chars")
+            max_stderr_chars = _require_char_limit(max_stderr_chars, "max_stderr_chars")
+            max_result_chars = _require_char_limit(max_result_chars, "max_result_chars")
+        except ValueError as exc:
+            return skill_error("Invalid output limit", str(exc))
+        if not isinstance(spill_overflow_to_artifact, bool):
+            return skill_error(
+                "Invalid spill option",
+                "spill_overflow_to_artifact must be a boolean",
+            )
+
         path = existing_file(file_path, suffixes={".py"})
         if working_directory is not None and not Path(working_directory).expanduser().is_dir():
             return skill_error("Working directory not found", str(working_directory))
@@ -50,30 +241,73 @@ def run_python_file(
             "context": dict(context or {}),
         }
         namespace.update(context or {})
-        stdout_buf = io.StringIO()
-        stderr_buf = io.StringIO()
+        stdout_capture = _BoundedTextCapture(max_stdout_chars)
+        stderr_capture = _BoundedTextCapture(max_stderr_chars)
         try:
-            with _pushd(working_directory), contextlib.redirect_stdout(stdout_buf), contextlib.redirect_stderr(
-                stderr_buf
+            with _pushd(working_directory), contextlib.redirect_stdout(stdout_capture), contextlib.redirect_stderr(
+                stderr_capture
             ):
                 exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), namespace)  # noqa: S102
         except Exception:
             error = traceback.format_exc()
+            stderr_capture.write(error)
+            result_capture = _BoundedTextCapture(max_result_chars)
+            output_summary = _output_summary(
+                output_mode,
+                stdout_capture,
+                stderr_capture,
+                result_capture,
+                result_is_json=False,
+                spill_overflow_to_artifact=spill_overflow_to_artifact,
+            )
             return skill_error(
                 "Python file execution failed",
-                error,
-                stdout=stdout_buf.getvalue(),
-                stderr=stderr_buf.getvalue() + error,
+                (
+                    "See output_summary artifacts for the captured traceback"
+                    if output_mode == "summary"
+                    else stderr_capture.preview()
+                ),
+                stdout=None if output_mode == "summary" else stdout_capture.preview(),
+                stderr=None if output_mode == "summary" else stderr_capture.preview(),
+                result=None,
+                output_summary=output_summary,
             )
+
+        result_capture, inline_result, result_is_json = _capture_result(
+            namespace.get("result"),
+            max_result_chars,
+            output_mode,
+        )
+        output_summary = _output_summary(
+            output_mode,
+            stdout_capture,
+            stderr_capture,
+            result_capture,
+            result_is_json=result_is_json,
+            spill_overflow_to_artifact=spill_overflow_to_artifact,
+        )
+        response_context = {
+            "file_path": str(path),
+            "stdout": None if output_mode == "summary" else stdout_capture.preview(),
+            "stderr": None if output_mode == "summary" else stderr_capture.preview(),
+            "result": inline_result,
+            "output_summary": output_summary,
+        }
+        if output_mode == "structured" and result_capture.truncated:
+            response_context["result_preview"] = result_capture.preview()
         return skill_success(
             "Python file executed successfully",
-            file_path=str(path),
-            stdout=stdout_buf.getvalue(),
-            stderr=stderr_buf.getvalue(),
-            result=str(namespace.get("result")) if namespace.get("result") is not None else None,
+            **response_context,
         )
     except Exception as exc:
         return skill_exception(exc, message="Failed to run Houdini Python file")
+    finally:
+        if stdout_capture is not None:
+            stdout_capture.close()
+        if stderr_capture is not None:
+            stderr_capture.close()
+        if result_capture is not None:
+            result_capture.close()
 
 
 @skill_entry

--- a/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-automation/tools.yaml
@@ -2,7 +2,9 @@ tools:
   - name: run_python_file
     description: >-
       Execute an existing Python file inside Houdini with `hou`, `args`, and
-      `context` pre-bound. Mutates the session according to the script.
+      `context` pre-bound. Mutates the session according to the script. Inline
+      stdout, stderr, and result payloads are bounded; optional overflow
+      artifacts retain the complete UTF-8 output with byte counts and SHA-256.
     input_schema:
       type: object
       required: [file_path]
@@ -22,6 +24,37 @@ tools:
         working_directory:
           type: string
           description: "Optional working directory while the script runs."
+        output_mode:
+          type: string
+          enum: [summary, structured, full]
+          default: full
+          description: >-
+            `full` preserves the legacy string result, `structured` returns a
+            JSON-safe result when possible, and `summary` omits inline bodies.
+        max_stdout_chars:
+          type: integer
+          minimum: 0
+          maximum: 1000000
+          default: 4000
+          description: "Maximum stdout characters returned inline."
+        max_stderr_chars:
+          type: integer
+          minimum: 0
+          maximum: 1000000
+          default: 4000
+          description: "Maximum stderr characters returned inline, including failure tracebacks."
+        max_result_chars:
+          type: integer
+          minimum: 0
+          maximum: 1000000
+          default: 8000
+          description: "Maximum serialized result characters returned inline."
+        spill_overflow_to_artifact:
+          type: boolean
+          default: true
+          description: >-
+            Persist complete truncated output to temporary UTF-8 artifacts and
+            return path, character count, byte count, and SHA-256 metadata.
     read_only: false
     destructive: true
     idempotent: false

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1373,6 +1373,199 @@ class TestAutomationSkills:
         assert "hello" in result["context"]["stdout"]
         assert result["context"]["result"] == "42"
 
+    def test_run_python_file_returns_structured_json_result(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "structured.py"
+        script.write_text(
+            "result = {'count': 2, 'items': ['box', 'sphere']}\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(str(script), output_mode="structured")
+
+        assert result["success"] is True
+        assert result["context"]["result"] == {
+            "count": 2,
+            "items": ["box", "sphere"],
+        }
+        assert result["context"]["output_summary"] == {
+            "mode": "structured",
+            "stdout_chars": 0,
+            "stderr_chars": 0,
+            "result_chars": 36,
+            "truncated": {"stdout": False, "stderr": False, "result": False},
+            "artifacts": {},
+        }
+
+    def test_run_python_file_bounds_inline_output_and_spills_full_artifacts(self, tmp_path: Path) -> None:
+        import hashlib
+
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "large_output.py"
+        script.write_text(
+            "import sys\n"
+            "print('s' * 200, end='')\n"
+            "print('e' * 180, end='', file=sys.stderr)\n"
+            "result = {'payload': 'r' * 220}\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(
+                str(script),
+                output_mode="structured",
+                max_stdout_chars=32,
+                max_stderr_chars=24,
+                max_result_chars=40,
+            )
+
+        assert result["success"] is True
+        context = result["context"]
+        assert context["stdout"] == "s" * 32
+        assert context["stderr"] == "e" * 24
+        assert context["result"] is None
+        assert len(context["result_preview"]) == 40
+        assert context["output_summary"]["truncated"] == {
+            "stdout": True,
+            "stderr": True,
+            "result": True,
+        }
+        assert set(context["output_summary"]["artifacts"]) == {"stdout", "stderr", "result"}
+
+        expected = {
+            "stdout": "s" * 200,
+            "stderr": "e" * 180,
+            "result": '{"payload":"' + "r" * 220 + '"}',
+        }
+        for channel, full_text in expected.items():
+            artifact = context["output_summary"]["artifacts"][channel]
+            artifact_path = Path(artifact["path"])
+            assert artifact_path.read_text(encoding="utf-8") == full_text
+            assert artifact["chars"] == len(full_text)
+            assert artifact["bytes"] == len(full_text.encode("utf-8"))
+            assert artifact["sha256"] == hashlib.sha256(full_text.encode("utf-8")).hexdigest()
+            artifact_path.unlink()
+
+    def test_run_python_file_can_truncate_without_persisting_artifacts(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "no_spill.py"
+        script.write_text("print('x' * 100, end='')\nresult = 'y' * 100\n", encoding="utf-8")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(
+                str(script),
+                max_stdout_chars=12,
+                max_result_chars=16,
+                spill_overflow_to_artifact=False,
+            )
+
+        assert result["success"] is True
+        assert result["context"]["stdout"] == "x" * 12
+        assert result["context"]["result"] == "y" * 16
+        assert result["context"]["output_summary"]["truncated"] == {
+            "stdout": True,
+            "stderr": False,
+            "result": True,
+        }
+        assert result["context"]["output_summary"]["artifacts"] == {}
+
+    def test_run_python_file_summary_omits_inline_bodies_and_persists_output(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "summary.py"
+        script.write_text("print('hello')\nresult = {'ok': True}\n", encoding="utf-8")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(str(script), output_mode="summary")
+
+        context = result["context"]
+        assert context["stdout"] is None
+        assert context["stderr"] is None
+        assert context["result"] is None
+        assert set(context["output_summary"]["artifacts"]) == {"stdout", "result"}
+        stdout_path = Path(context["output_summary"]["artifacts"]["stdout"]["path"])
+        result_path = Path(context["output_summary"]["artifacts"]["result"]["path"])
+        assert stdout_path.read_text(encoding="utf-8") == "hello\n"
+        assert result_path.read_text(encoding="utf-8") == '{"ok":true}'
+        stdout_path.unlink()
+        result_path.unlink()
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"output_mode": "verbose"}, "Invalid output mode"),
+            ({"max_stdout_chars": -1}, "max_stdout_chars must be an integer"),
+            ({"spill_overflow_to_artifact": "yes"}, "Invalid spill option"),
+        ],
+    )
+    def test_run_python_file_rejects_invalid_output_contract(
+        self,
+        tmp_path: Path,
+        kwargs: dict,
+        expected: str,
+    ) -> None:
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "noop.py"
+        script.write_text("result = None\n", encoding="utf-8")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(str(script), **kwargs)
+
+        assert result["success"] is False
+        assert expected in str(result)
+
+    def test_run_python_file_bounds_failure_traceback(self, tmp_path: Path) -> None:
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "failure.py"
+        script.write_text("print('before')\nraise RuntimeError('z' * 300)\n", encoding="utf-8")
+
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(str(script), max_stderr_chars=80)
+
+        assert result["success"] is False
+        assert result["context"]["stdout"] == "before\n"
+        assert len(result["context"]["stderr"]) == 80
+        summary = result["context"]["output_summary"]
+        assert summary["truncated"]["stderr"] is True
+        artifact = summary["artifacts"]["stderr"]
+        artifact_path = Path(artifact["path"])
+        assert "RuntimeError:" in artifact_path.read_text(encoding="utf-8")
+        artifact_path.unlink()
+
+    def test_run_python_file_cleans_partial_artifacts_when_spill_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mod = _load_script("houdini-automation", "run_python_file.py")
+        script = tmp_path / "spill_failure.py"
+        script.write_text(
+            "import sys\nprint('out' * 20)\nprint('err' * 20, file=sys.stderr)\n",
+            encoding="utf-8",
+        )
+        real_persist = mod._BoundedTextCapture.persist
+        persisted_paths = []
+
+        def persist(capture, label, **kwargs):
+            if label == "stderr":
+                raise OSError("injected artifact failure")
+            artifact = real_persist(capture, label, **kwargs)
+            if artifact is not None:
+                persisted_paths.append(Path(artifact["path"]))
+            return artifact
+
+        monkeypatch.setattr(mod._BoundedTextCapture, "persist", persist)
+        with patch.dict(sys.modules, {"hou": MagicMock()}):
+            result = mod.run_python_file(
+                str(script),
+                max_stdout_chars=8,
+                max_stderr_chars=8,
+            )
+
+        assert result["success"] is False
+        assert persisted_paths
+        assert all(not path.exists() for path in persisted_paths)
+
     def test_save_hip_file_atomically_replaces_target(self, tmp_path: Path) -> None:
         mod = _load_script("houdini-automation", "save_hip_file.py")
         target = tmp_path / "scene.hip"


### PR DESCRIPTION
## Summary
- bound inline stdout, stderr, and result payloads
- add structured and summary result modes
- preserve complete overflow as UTF-8 artifacts with byte counts and SHA-256
- keep the default legacy string-result contract

## Validation
- 1198 passed, 1 skipped, 3 deselected
- Ruff and format checks
- skill metadata lint
- Python 3.7 syntax check
- wheel/sdist build and Twine check

This addresses the Houdini-owned script-output portion of #283. Screenshot return modes and generic job long polling remain Core-owned follow-up work, so this PR does not close the issue.