### PR TITLE
fix: scan complete husk logs for render failures

### DIFF
--- a/.github/scripts/run_houdini_husk_acceptance.py
+++ b/.github/scripts/run_houdini_husk_acceptance.py
@@ -1,0 +1,121 @@
+"""Reproduce issue 238 with real hair procedural errors and a partial EXR.
+
+Run in a fresh licensed hython with this checkout installed. Temporary USD,
+EXR and durable job records are retained for inspection. No UI scene is used.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import hou
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdRender
+
+import dcc_mcp_houdini
+
+ROOT = Path(__file__).resolve().parents[2]
+assert ROOT in Path(dcc_mcp_houdini.__file__).resolve().parents, "Install this checkout first"
+sys.path.insert(0, str(ROOT / "tests"))
+from skill_loader import skill_script_import_context  # noqa: E402
+
+
+def _load(name):
+    path = ROOT / "src/dcc_mcp_houdini/skills/houdini-husk/scripts" / (name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    return getattr(module, name)
+
+
+def _scene(directory):
+    source = directory / "source.usda"
+    stage = Usd.Stage.CreateNew(str(source))
+    skin = UsdGeom.Mesh.Define(stage, "/World/skin")
+    points = [(-1, -1, 0), (1, -1, 0), (1, 1, 0), (-1, 1, 0)]
+    skin.CreatePointsAttr(points)
+    skin.CreateFaceVertexCountsAttr([4])
+    skin.CreateFaceVertexIndicesAttr([0, 1, 2, 3])
+    UsdGeom.PrimvarsAPI(skin).CreatePrimvar("rest", Sdf.ValueTypeNames.Point3fArray, "vertex").Set(points)
+    guides = UsdGeom.BasisCurves.Define(stage, "/World/guides")
+    guides.CreateTypeAttr("linear")
+    guides.CreateCurveVertexCountsAttr([2])
+    guides.CreatePointsAttr([(0, 0, 0), (0, 0, 1)])
+    guides.CreateWidthsAttr([0.01, 0.01])
+    # Deliberately omit skinprim/pscale to make the procedural fail during Husk.
+    UsdGeom.PrimvarsAPI(guides).CreatePrimvar("rest", Sdf.ValueTypeNames.Point3fArray, "vertex").Set(
+        [(0, 0, 0), (0, 0, 1)]
+    )
+    camera = UsdGeom.Camera.Define(stage, "/World/camera")
+    camera.AddTranslateOp().Set(Gf.Vec3d(0, 0, 5))
+    UsdLux.DomeLight.Define(stage, "/World/light").CreateIntensityAttr(1)
+    settings = UsdRender.Settings.Define(stage, "/Render/settings")
+    settings.CreateResolutionAttr(Gf.Vec2i(32, 32))
+    settings.CreateCameraRel().SetTargets(["/World/camera"])
+    product = UsdRender.Product.Define(stage, "/Render/product")
+    product.CreateProductNameAttr(str(directory / "partial.exr"))
+    product.CreateProductTypeAttr("raster")
+    var = UsdRender.Var.Define(stage, "/Render/color")
+    var.CreateDataTypeAttr("color4f")
+    var.CreateSourceNameAttr("C.*[LO]")
+    var.CreateSourceTypeAttr("lpe")
+    var.GetPrim().AddAppliedSchema("HuskRenderVarAPI")
+    var.GetPrim().CreateAttribute("driver:parameters:aov:husk:format", Sdf.ValueTypeNames.String).Set("color4f")
+    var.GetPrim().CreateAttribute("driver:parameters:aov:husk:name", Sdf.ValueTypeNames.String).Set("C")
+    product.CreateOrderedVarsRel().SetTargets(["/Render/color"])
+    settings.CreateProductsRel().SetTargets(["/Render/product"])
+    stage.SetMetadata("renderSettingsPrimPath", "/Render/settings")
+    stage.GetRootLayer().Save()
+    sub = hou.node("/stage").createNode("sublayer")
+    try:
+        sub.parm("filepath1").set(str(source))
+        hair = hou.node("/stage").createNode("houdinihairprocedural")
+        try:
+            hair.setInput(0, sub)
+            hair.setParms(
+                {"procprim": "/World/hair", "guideprims": "/World/guides", "skinprims": "/World/skin", "hairCount": 10}
+            )
+            usd = directory / "render.usda"
+            hair.stage().Export(str(usd))
+        finally:
+            hair.destroy()
+    finally:
+        sub.destroy()
+    return usd
+
+
+def main():
+    directory = Path(tempfile.mkdtemp(prefix="husk-procedural-acceptance-"))
+    usd = _scene(directory)
+    launch = _load("render_with_husk")(str(usd), str(directory / "partial.exr"), resolution=[32, 32])
+    assert launch["success"], launch
+    job_id = launch["context"]["job_id"]
+    poll = _load("get_husk_job")
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        status = poll(job_id)["context"]
+        if status["state"] in ("completed", "failed", "cancelled", "canceled"):
+            break
+        time.sleep(1)
+    else:
+        _load("cancel_husk_job")(job_id)
+        raise RuntimeError("render acceptance timed out")
+    assert status["returncode"] == 0, "Fixture did not reach a zero-exit render"
+    assert status["state"] == "failed", "Partial render was incorrectly accepted"
+    assert status["render_outcome"] == "completed_with_render_errors"
+    assert status["output_verification"]["state"] == "verified"
+    assert str(directory / "partial.exr") in status["written_files"]
+    assert (directory / "partial.exr").stat().st_size > 0
+    codes = {item["code"] for item in status["render_errors"]}
+    assert "HOUDINI_OPERATION_FAILED" in codes, "Expected procedural failure was not captured"
+    print(json.dumps({"houdini": hou.applicationVersionString(), "job_id": job_id, "error_codes": sorted(codes)}))
+    print("HOUDINI_HUSK_ACCEPTANCE_PASSED", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ci/houdini-husk-acceptance.md
+++ b/docs/ci/houdini-husk-acceptance.md
@@ -1,0 +1,22 @@
+# Husk procedural failure acceptance
+
+Run the fixture in a fresh licensed Houdini process with this checkout and its
+declared dependencies installed:
+
+```sh
+hython .github/scripts/run_houdini_husk_acceptance.py
+```
+
+The fixture exports a small USD skin and guides with deliberately missing hair
+attributes, then launches a real durable Husk job through the skill entrypoints.
+It asserts that a zero-exit render with a nonempty EXR and `hou.OperationFailed`
+returns `state=failed` and `render_outcome=completed_with_render_errors`, while
+preserving verified written-file evidence. A 120-second polling deadline cancels
+an unfinished job. Temporary scene/output files and job records remain available
+for inspection; no existing UI scene is used.
+
+The final marker is `HOUDINI_HUSK_ACCEPTANCE_PASSED`. This tests the renderer and
+job contract directly, rather than MCP transport or final image quality.
+The complete-log regression (errors outside the final 64 KB, split severity
+tokens, bounded diagnostic storage, and unreadable logs) is covered separately
+by `tests/test_husk_render.py`.

--- a/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/SKILL.md
@@ -46,6 +46,11 @@ hython worker so Karma cannot occupy Houdini's UI thread.
    `render_outcome`, `render_errors`, `warnings`, `written_files`, and
    `output_verification`; verified partial files do not override procedural errors.
 
+Terminal diagnostics scan the completed stderr file using bounded reads, not
+just its display tail. Error/warning lists retain at most 32 records of 1000
+characters each. An unreadable configured stderr log reports `STDERR_SCAN_FAILED`
+and cannot establish a clean render. Polling still returns compact log tails.
+
 `use_hython_fallback=true` is rejected because in-process rendering can freeze
 the Houdini event loop. Export a USD snapshot and use the isolated native Husk
 path instead.

--- a/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
+++ b/src/dcc_mcp_houdini/skills/houdini-husk/scripts/_husk_worker.py
@@ -33,24 +33,46 @@ def _written_files(status: dict) -> list:
     return written
 
 
-def _bounded_stderr(path_value) -> str:
+def _file_render_diagnostics(path_value):
+    """Scan the completed log with bounded reads and bounded diagnostic storage.
+
+    A tail is sufficient for display, but cannot establish a clean render.
+    Snapshot the file length so a growing log cannot make this scan unbounded.
+    Long lines retain overlap so severity tokens across read boundaries survive.
+    """
+    errors, warnings = [], []
     if not path_value:
-        return ""
+        return errors, warnings
     try:
         with Path(str(path_value)).open("rb") as stream:
-            stream.seek(0, os.SEEK_END)
-            stream.seek(max(0, stream.tell() - _STDERR_SCAN_BYTES))
-            payload = stream.read(_STDERR_SCAN_BYTES)
-    except OSError:
-        return ""
-    return payload.decode("utf-8", errors="replace")
+            remaining = os.fstat(stream.fileno()).st_size
+            overlap = b""
+            while remaining:
+                payload = stream.readline(min(remaining, _STDERR_SCAN_BYTES))
+                if not payload:
+                    raise OSError("Husk stderr changed during diagnostics scan")
+                remaining -= len(payload)
+                fragment = overlap + payload
+                found = _render_diagnostics(fragment.decode("utf-8", errors="replace"))
+                for target, items in zip((errors, warnings), found):
+                    for item in items:
+                        if len(target) < _MAX_DIAGNOSTICS and item not in target:
+                            target.append(item)
+                overlap = b"" if payload.endswith(b"\n") else fragment[-_MAX_DIAGNOSTIC_CHARS:]
+    except OSError as exc:
+        diagnostic = {"code": "STDERR_SCAN_FAILED", "message": str(exc)[:_MAX_DIAGNOSTIC_CHARS]}
+        if len(errors) >= _MAX_DIAGNOSTICS:
+            errors[-1] = diagnostic
+        else:
+            errors.append(diagnostic)
+    return errors, warnings
 
 
 def _render_diagnostics(stderr: str):
     render_errors = []
     warnings = []
     for raw_line in stderr.splitlines():
-        message = " ".join(raw_line.split())[:_MAX_DIAGNOSTIC_CHARS]
+        message = " ".join(raw_line.split())
         if not message:
             continue
         if "hou.OperationFailed" in message:
@@ -67,7 +89,7 @@ def _render_diagnostics(stderr: str):
             code = "RENDERER_WARNING"
         else:
             continue
-        diagnostic = {"code": code, "message": message}
+        diagnostic = {"code": code, "message": message[:_MAX_DIAGNOSTIC_CHARS]}
         if diagnostic not in target and len(target) < _MAX_DIAGNOSTICS:
             target.append(diagnostic)
     return render_errors, warnings
@@ -91,7 +113,7 @@ def main() -> None:
             check=False,
         )
         written_files = _written_files(status)
-        render_errors, warnings = _render_diagnostics(_bounded_stderr(status.get("stderr_path")))
+        render_errors, warnings = _file_render_diagnostics(status.get("stderr_path"))
         if process.returncode != 0:
             state = "failed"
             render_outcome = "failed"

--- a/tests/test_husk_render.py
+++ b/tests/test_husk_render.py
@@ -214,7 +214,8 @@ def test_husk_worker_verifies_written_output(tmp_path: Path) -> None:
     assert status["output_verification"]["state"] == "verified"
 
 
-def test_husk_worker_rejects_verified_output_with_procedural_render_errors(tmp_path: Path) -> None:
+@pytest.mark.parametrize("padding_lines", [0, 10000])
+def test_husk_worker_rejects_verified_output_with_procedural_render_errors(tmp_path: Path, padding_lines: int) -> None:
     worker = _load_script("_husk_worker.py")
     status_path = tmp_path / "status.json"
     stderr_path = tmp_path / "stderr.log"
@@ -234,9 +235,9 @@ def test_husk_worker_rejects_verified_output_with_procedural_render_errors(tmp_p
     def render(*_args, **_kwargs):
         output.write_bytes(b"degraded render")
         stderr_path.write_text(
-            "hou.OperationFailed: Invalid node setup\n"
+            "progress\n" * padding_lines + "hou.OperationFailed: Invalid node setup\n"
             "Error: Missing point attribute pscale\n"
-            "Houdini procedural invocation failed for /World/Hair\n",
+            "Houdini procedural invocation failed for /World/Hair\n" + "progress\n" * padding_lines,
             encoding="utf-8",
         )
         return SimpleNamespace(returncode=0)
@@ -262,6 +263,37 @@ def test_husk_worker_rejects_verified_output_with_procedural_render_errors(tmp_p
     assert status["warnings"] == []
     assert status["written_files"] == [str(output)]
     assert status["output_verification"]["state"] == "verified"
+
+
+def test_husk_diagnostics_scan_bounds_records_and_handles_split_severity(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    log = tmp_path / "stderr.log"
+    log.write_bytes(
+        b"x" * (worker._STDERR_SCAN_BYTES - 6)
+        + b" hou.OperationFailed: broken setup\n"
+        + b"".join("Error: failure {}\n".format(i).encode() for i in range(100))
+        + b"Warning: render fallback\n"
+    )
+    errors, warnings = worker._file_render_diagnostics(log)
+    assert any(item["code"] == "HOUDINI_OPERATION_FAILED" for item in errors)
+    assert len(errors) == worker._MAX_DIAGNOSTICS
+    assert all(len(item["message"]) <= worker._MAX_DIAGNOSTIC_CHARS for item in errors)
+    assert warnings == [{"code": "RENDERER_WARNING", "message": "Warning: render fallback"}]
+
+
+def test_husk_diagnostics_unreadable_log_is_not_clean(tmp_path: Path) -> None:
+    worker = _load_script("_husk_worker.py")
+    errors, warnings = worker._file_render_diagnostics(tmp_path / "missing.log")
+    assert errors[0]["code"] == "STDERR_SCAN_FAILED"
+    assert warnings == []
+
+
+def test_husk_diagnostics_classifies_before_truncating_messages() -> None:
+    worker = _load_script("_husk_worker.py")
+    errors, warnings = worker._render_diagnostics("prefix " * 300 + "hou.OperationFailed: broken")
+    assert errors[0]["code"] == "HOUDINI_OPERATION_FAILED"
+    assert len(errors[0]["message"]) == worker._MAX_DIAGNOSTIC_CHARS
+    assert warnings == []
 
 
 def test_husk_worker_reports_renderer_warning_without_failing_written_output(tmp_path: Path) -> None:


### PR DESCRIPTION
Husk could report a clean render when procedural errors occurred earlier than the final 64 KB of stderr, even if it wrote a degraded EXR. Scan the completed log with bounded reads and bounded diagnostic storage so those errors remain visible; classify messages before truncation and treat unreadable logs as diagnostic failures.

Refs #238. Real licensed Houdini 22.0.368 / Core 0.20.14 acceptance reproduced a zero-exit hair procedural failure with a written EXR. The job reports `state=failed`, `render_outcome=completed_with_render_errors`, and verified written-file evidence. A repeatable fixture is included at `.github/scripts/run_houdini_husk_acceptance.py`.

Validation: 1202 passed, 1 skipped, 3 deselected; Ruff, Python 3.7 syntax, and CLI skill metadata validation passed. Regression coverage includes errors surrounded by long progress logs, split severity tokens, record limits, and unreadable logs.
