### PR TITLE
fix: paginate tools in live Houdini E2E

### DIFF
--- a/.github/scripts/run_houdini_e2e.py
+++ b/.github/scripts/run_houdini_e2e.py
@@ -41,6 +41,24 @@ def _tool_names(payload):
     return [tool.get("name") for tool in result.get("tools", []) if tool.get("name")]
 
 
+def _all_tool_names(url):
+    """Follow MCP tools/list cursors; a first page is not the full catalog."""
+    names = []
+    seen = set()
+    cursor = None
+    for _ in range(256):
+        payload = _post(url, "tools/list", {"cursor": cursor} if cursor else None)
+        assert "result" in payload, payload
+        names.extend(_tool_names(payload))
+        cursor = payload["result"].get("nextCursor")
+        if not cursor:
+            return names
+        if not isinstance(cursor, str) or cursor in seen:
+            raise AssertionError("Invalid or repeated tools/list cursor")
+        seen.add(cursor)
+    raise AssertionError("tools/list exceeded 256 pages")
+
+
 def _find_tool(names, suffix):
     for name in names:
         if name == suffix or name.endswith("__" + suffix):
@@ -144,13 +162,13 @@ def _run_client(server):
     )
     assert initialized["result"]["serverInfo"]["name"] == "dcc-mcp-houdini", initialized
 
-    initial_names = _tool_names(_post(url, "tools/list"))
+    initial_names = _all_tool_names(url)
     load_skill = _find_tool(initial_names, "load_skill")
     for skill_name in ("houdini-scripting", "houdini-nodes", "houdini-kinefx"):
         loaded = _call_tool(url, load_skill, {"skill_name": skill_name})
         assert loaded.get("context", {}).get("loaded") is not False, loaded
 
-    names = _tool_names(_post(url, "tools/list"))
+    names = _all_tool_names(url)
     get_session_info = _find_tool(names, "get_session_info")
     execute_python = _find_tool(names, "execute_python")
     inspect_selection = _find_tool(names, "inspect_selection")

--- a/tests/test_houdini_e2e_runner.py
+++ b/tests/test_houdini_e2e_runner.py
@@ -69,3 +69,26 @@ def test_headless_e2e_rethrows_worker_failure_on_owner_thread() -> None:
         module._serve_with_client_worker(serve_headless, client, join_timeout=1)
 
     assert observed["stop_signaled"] is True
+
+
+def test_live_e2e_follows_tool_catalog_pagination() -> None:
+    module = _load_script()
+    requests = []
+
+    def post(url, method, params=None):
+        requests.append((method, params))
+        if params is None:
+            return {"result": {"tools": [{"name": "load_skill"}], "nextCursor": "page2"}}
+        assert params == {"cursor": "page2"}
+        return {"result": {"tools": [{"name": "inspect_selection"}]}}
+
+    module._post = post
+    assert module._all_tool_names("http://localhost") == ["load_skill", "inspect_selection"]
+    assert requests == [("tools/list", None), ("tools/list", {"cursor": "page2"})]
+
+
+def test_live_e2e_rejects_repeated_catalog_cursor() -> None:
+    module = _load_script()
+    module._post = lambda *_args: {"result": {"tools": [], "nextCursor": "loop"}}
+    with pytest.raises(AssertionError, match="repeated"):
+        module._all_tool_names("http://localhost")


### PR DESCRIPTION
The live Houdini E2E runner inspected only the first page of `tools/list`, so it could fail to find loaded tools depending on catalog order. Follow every cursor with cycle and page-count guards.

Refs #203.

Validation: four harness regression tests passed. The complete MCP E2E ran through `serve_headless` on licensed Houdini 22.0.368 with Core 0.20.14: `inspect_selection elapsed_seconds=0.011 point_count=1 packed_count=1` and `Houdini MCP E2E passed` were both emitted. Credential-enabled Docker CI remains a separate acceptance gate.
