### PR TITLE
fix: compare Houdini loft parents by node equality

### DIFF
--- a/.github/scripts/run_houdini_modeling_acceptance.py
+++ b/.github/scripts/run_houdini_modeling_acceptance.py
@@ -1,0 +1,116 @@
+"""Live MCP acceptance for the three modeling operations in issue 266.
+
+Run in a fresh hython process with this checkout installed. This focused
+fixture is not a replay of the full reference asset evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import hou
+from run_houdini_e2e import _call_tool, _find_tool, _post, _serve_with_client_worker, _tool_names
+
+import dcc_mcp_houdini
+
+
+def _run_client(server):
+    url = server.mcp_url
+    _post(
+        url,
+        "initialize",
+        {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "houdini-modeling-acceptance", "version": "1"},
+        },
+    )
+    for skill in ("houdini-nodes", "houdini-geometry", "houdini-mesh-ops"):
+        _call_tool(url, "load_skill", {"skill_name": skill})
+    names, seen, cursor = [], set(), None
+    for _ in range(256):
+        payload = _post(url, "tools/list", {"cursor": cursor} if cursor else None)
+        names.extend(_tool_names(payload))
+        cursor = payload.get("result", {}).get("nextCursor")
+        if not cursor:
+            break
+        assert cursor not in seen, "repeated tools/list cursor"
+        seen.add(cursor)
+    else:
+        raise AssertionError("tools/list exceeded 256 pages")
+    calls = []
+
+    def call(name, **arguments):
+        assert name != "execute_python"
+        payload = _call_tool(url, _find_tool(names, name), arguments)
+        calls.append({"tool": name, "success": payload.get("success") is True})
+        print(json.dumps(calls[-1]), flush=True)
+        assert payload.get("success") is True, payload
+        return payload.get("context", {})
+
+    name = "modeling_acceptance_" + uuid.uuid4().hex[:8]
+    geo_path = "/obj/" + name
+    call("create_node", parent_path="/obj", node_type="geo", node_name=name)
+    try:
+        sections = []
+        for index, (length, radius) in enumerate(((-2, 0.3), (0, 0.8), (2, 0.5))):
+            section_name = "fuselage_section_{}".format(index)
+            path = geo_path + "/" + section_name
+            call("create_node", parent_path=geo_path, node_type="circle", node_name=section_name)
+            call(
+                "set_node_parms",
+                node_path=path,
+                parameters={"type": "poly", "divs": 8, "rad": [radius, radius], "t": [0, 0, length]},
+            )
+            sections.append(path)
+        hull = call("loft_sections", sections=sections, node_name="fuselage")
+        assert hull["readback"]["verified"] and hull["readback"]["primitive_count"] > 0
+        call("create_primitive", parent_path=geo_path, primitive="box", node_name="rim")
+        rim = call("bevel_edges", input_path=geo_path + "/rim", group="*", distance=0.05, divisions=2)
+        assert rim["readback"]["verified"]
+        assert rim["readback"]["point_count"] > rim["readback"]["before"]["point_count"]
+        call("create_primitive", parent_path=geo_path, primitive="box", node_name="rotor_blade")
+        call(
+            "set_node_parms", node_path=geo_path + "/rotor_blade", parameters={"size": [2, 0.08, 0.25], "t": [1, 0, 0]}
+        )
+        rotor = call(
+            "array_instances",
+            input_path=geo_path + "/rotor_blade",
+            count=4,
+            radius=0.15,
+            axis="y",
+            source_forward="+x",
+            node_name="rotor_array",
+        )
+        assert rotor["readback"]["orientation"]["verified"]
+        assert rotor["readback"]["orientation"]["point_count"] == 4
+        assert rotor["readback"]["point_count"] == 4 * rotor["readback"]["before"]["point_count"]
+        print(
+            "Houdini modeling acceptance passed: "
+            + json.dumps(
+                {
+                    "scope": "focused loft, bevel and rotor fixture",
+                    "typed_calls": len(calls),
+                    "raw_scripting_calls": 0,
+                    "raw_scripting_share": 0.0,
+                    "hull_primitives": hull["readback"]["primitive_count"],
+                    "bevel_points": rim["readback"]["point_count"],
+                    "rotor_points": rotor["readback"]["point_count"],
+                }
+            ),
+            flush=True,
+        )
+    finally:
+        call("delete_node", node_path=geo_path)
+
+
+def main():
+    print("Houdini:", hou.applicationVersionString(), flush=True)
+    _serve_with_client_worker(
+        dcc_mcp_houdini.serve_headless, _run_client, join_timeout=30, port=0, gateway_port=0, register_builtins=True
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ci/houdini-modeling-acceptance.md
+++ b/docs/ci/houdini-modeling-acceptance.md
@@ -1,0 +1,22 @@
+# Typed modeling acceptance
+
+In a fresh licensed Houdini Python process, with this checkout installed:
+
+```sh
+hython .github/scripts/run_houdini_modeling_acceptance.py
+```
+
+The runner uses MCP calls while `serve_headless` pumps HOM on its owner thread.
+It creates a uniquely named transient object, authors three fuselage sections,
+lofts them, bevels a rim blockout, builds a four-blade radial array, verifies
+geometry and orientation receipts, and deletes the object. A failure is rethrown
+on the owner thread and exits nonzero.
+
+The final marker records typed-call and raw-scripting counts for this focused
+fixture. It excludes loading and cleanup from the denominator. This is not a
+replay or visual acceptance of the full Apache reference asset, materials, UVs,
+hierarchy, and renders.
+
+On Houdini 22.0.368 / Core 0.20.14, the fixture completed with 13 typed authoring
+calls, zero raw scripting calls, 16 loft primitives, 56 beveled points, and
+32 rotor points. The complete issue #266 reference evaluation remains separate.

--- a/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/loft_sections.py
+++ b/src/dcc_mcp_houdini/skills/houdini-mesh-ops/scripts/loft_sections.py
@@ -30,7 +30,7 @@ def loft_sections(sections: List[str], node_name: Optional[str] = None) -> dict:
         parent = sources[0].parent()
         if parent is None:
             raise ValueError("First loft section has no parent SOP network")
-        if any(source.parent() is not parent for source in sources[1:]):
+        if any(source.parent() != parent for source in sources[1:]):
             raise ValueError("All loft sections must share one parent SOP network")
         before = geometry_readback(sources[0])
         merge = parent.createNode("merge")

--- a/tests/test_typed_modeling_verbs.py
+++ b/tests/test_typed_modeling_verbs.py
@@ -343,7 +343,8 @@ def test_inset_reuses_verified_polyextrude_without_raw_execution() -> None:
     assert result["context"]["readback"]["verified"] is True
 
 
-def test_loft_sections_wires_bounded_same_network_inputs_and_reads_back() -> None:
+@pytest.mark.parametrize("distinct_parent_handles", [False, True])
+def test_loft_sections_wires_bounded_same_network_inputs_and_reads_back(distinct_parent_handles) -> None:
     tools = yaml.safe_load((_SKILL_ROOT / "tools.yaml").read_text(encoding="utf-8"))["tools"]
     contract = next(item for item in tools if item["name"] == "loft_sections")
     sections_schema = contract["input_schema"]["properties"]["sections"]
@@ -360,8 +361,21 @@ def test_loft_sections_wires_bounded_same_network_inputs_and_reads_back() -> Non
         )
         for index in range(3)
     ]
+
+    class ParentHandle:
+        """HOM can return distinct Python wrappers for the same node."""
+
+        def __init__(self, node):
+            self.node = node
+
+        def __eq__(self, other):
+            return isinstance(other, ParentHandle) and self.node is other.node
+
+        def __getattr__(self, name):
+            return getattr(self.node, name)
+
     for section in sections:
-        section._parent = parent
+        section._parent = ParentHandle(parent) if distinct_parent_handles else parent
     by_path = {section.path(): section for section in sections}
     original_create = parent.createNode
 


### PR DESCRIPTION
`loft_sections` rejected sections from the same SOP network because HOM returns distinct Python wrappers for equal parent nodes. Compare nodes by equality and cover distinct wrappers in the regression test.

Refs #266. Adds a reproducible live MCP fixture using `serve_headless` for fuselage lofts, bevels, and a four-blade radial array.

Validation: 41 focused modeling/transaction tests passed. Licensed Houdini 22.0.368 with Core 0.20.14 completed the fixture with 13 typed authoring calls, zero raw scripting calls, 16 loft primitives, 56 beveled points, and 32 rotor points. This focused fixture does not replace the complete Apache reference-asset evaluation.
