### PR TITLE
fix: preserve physical scale in typed FBX exports

### DIFF
--- a/.github/scripts/run_houdini_fbx_units_acceptance.py
+++ b/.github/scripts/run_houdini_fbx_units_acceptance.py
@@ -1,0 +1,70 @@
+"""Check a real Filmbox export's physical size in a fresh licensed Hython.
+
+This fixture reads the native ASCII FBX representation produced by Houdini 22.
+It does not substitute for an engine import and world-bounds readback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+import hou
+
+import dcc_mcp_houdini
+
+ROOT = Path(__file__).resolve().parents[2]
+assert ROOT in Path(dcc_mcp_houdini.__file__).resolve().parents, "Install this checkout first"
+sys.path.insert(0, str(ROOT / "tests"))
+from skill_loader import skill_script_import_context  # noqa: E402
+
+
+def main():
+    path = ROOT / "src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_fbx.py"
+    spec = importlib.util.spec_from_file_location("fbx_units_acceptance", path)
+    module = importlib.util.module_from_spec(spec)
+    with skill_script_import_context(spec):
+        spec.loader.exec_module(module)
+    parent = hou.node("/obj").createNode("geo", "unit_card", run_init_scripts=False)
+    try:
+        grid = parent.createNode("grid")
+        grid.setParms({"orient": 0, "sizex": 2.8, "sizey": 4.2, "ty": 2.1, "rows": 2, "cols": 2})
+        grid.setRenderFlag(True)
+        directory = Path(tempfile.mkdtemp(prefix="houdini-fbx-units-"))
+        measured = []
+        for enabled in (True, False):
+            output = directory / ("converted.fbx" if enabled else "numeric.fbx")
+            kwargs = {} if enabled else {"convert_units": False}
+            result = module.export_fbx(str(output), root_node=parent.path(), **kwargs)
+            assert result["success"], result
+            context = result["context"]
+            assert context["unit_conversion_enabled"] is enabled
+            assert context["written_files"] == [str(output)] and not context["warnings"]
+            content = output.read_text(encoding="utf-8")
+            vertices = re.search(r"Vertices:\s*\*\d+\s*\{\s*a:\s*([^}]+)", content)
+            assert vertices, "Expected ASCII FBX geometry"
+            coordinates = [float(value) for value in vertices.group(1).strip().split(",")]
+            mesh_model = re.search(r'Model:\s*\d+,\s*"Model::[^"]+",\s*"Mesh"\s*\{(.*?)\n\t\}', content, re.S)
+            assert mesh_model, "Expected FBX mesh model"
+            scale = re.search(r'"Lcl Scaling"[^\n]*?,\s*"A",([^\n]+)', mesh_model.group(1))
+            scale_x = float(scale.group(1).split(",")[0]) if scale else 1.0
+            unit = re.search(r'"UnitScaleFactor"[^\n]*?,\s*"",([^\n]+)', content)
+            assert unit, "Expected FBX unit declaration"
+            unit_cm = float(unit.group(1))
+            width_m = (max(coordinates[::3]) - min(coordinates[::3])) * scale_x * unit_cm / 100
+            expected = 2.8 if enabled else 0.028
+            assert abs(width_m - expected) < 1e-5, (enabled, width_m)
+            measured.append({"convert_units": enabled, "physical_width_m": width_m})
+            hou.node(context["rop"]["path"]).destroy()
+        print(json.dumps({"houdini": hou.applicationVersionString(), "measurements": measured}))
+        print("HOUDINI_FBX_UNITS_ACCEPTANCE_PASSED", flush=True)
+    finally:
+        parent.destroy()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/SKILL.md
@@ -43,6 +43,15 @@ not produce.
 | Rigged/scene to game engine | `export_fbx` | `root_node` selects the `/obj` subtree. |
 | USD/Solaris pipelines | `export_usd` | Exports a LOP node's composed `stage()`; reports `root_layer`. |
 
+`export_fbx` defaults to `convert_units=true`: it enables the native Filmbox
+unit-conversion toggle and reports its readback as `unit_conversion_enabled`.
+Without conversion, a meter-authored object can arrive 100 times too small
+when the FBX declares centimeters. Engines must honor the exported node
+transforms and units once; do not add another factor of 100 after conversion.
+Use `convert_units=false` only for a pipeline intentionally managing numeric
+units itself. An unavailable or mismatched conversion toggle fails before
+rendering. Always verify physical world bounds and pivot in the target engine.
+
 ## Tracer-bullet flow (local, no render farm)
 
 1. `houdini_geometry__create_primitive(parent_path="/obj/geo1", primitive="box")`

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_fbx.py
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/scripts/export_fbx.py
@@ -21,8 +21,12 @@ def export_fbx(
     frame_range: Optional[List[float]] = None,
     render: bool = True,
     create_dirs: bool = True,
+    convert_units: bool = True,
 ) -> dict:
     """Create a Filmbox FBX ROP under /out and (optionally) render *root_node*."""
+    if not isinstance(convert_units, bool):
+        return skill_error("Invalid unit conversion", "convert_units must be a boolean")
+    rop = None
     try:
         import hou  # noqa: PLC0415
     except ImportError:
@@ -35,6 +39,15 @@ def export_fbx(
         if out is None:
             out = hou.node("/").createNode("ropnet", node_name="out")
         rop = out.createNode("filmboxfbx", node_name="fbx_export")
+        # Houdini coordinates are normally meters; FBX defaults to centimeters.
+        # Leaving this native toggle off silently shrinks engine imports 100x.
+        unit_parm = rop.parm("convertunits")
+        if unit_parm is None:
+            raise ValueError("Filmbox FBX does not expose the required convertunits parameter")
+        unit_parm.set(convert_units)
+        unit_conversion_enabled = bool(unit_parm.eval())
+        if unit_conversion_enabled != convert_units:
+            raise ValueError("Filmbox FBX unit conversion readback does not match the request")
         used = set_first_parm(rop, ("sopoutput", "filename", "outfile", "output"), output_path)
         # FBX ROP exports the subtree rooted at this node.
         set_first_parm(rop, ("startnode",), root_node)
@@ -57,11 +70,14 @@ def export_fbx(
             rop=node_summary(rop),
             output_path=output_path,
             frame_range=applied_range,
+            unit_conversion_enabled=unit_conversion_enabled,
             written_files=written,
             skipped=skipped,
             warnings=warnings,
         )
     except Exception as exc:
+        if rop is not None:
+            rop.destroy()
         return skill_exception(exc, message="Failed to export FBX")
 
 

--- a/src/dcc_mcp_houdini/skills/houdini-interchange/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-interchange/tools.yaml
@@ -120,7 +120,8 @@ tools:
   - name: export_fbx
     description: >-
       Export an /obj subtree to FBX via a Filmbox FBX ROP, with optional frame
-      range and render. Reports skipped outputs and runtime limitations.
+      range and render. Enables native scene-unit conversion by default to
+      preserve physical size in engines; reports conversion readback.
     source_file: scripts/export_fbx.py
     execution: async
     affinity: main
@@ -142,6 +143,12 @@ tools:
         root_node:
           type: string
           default: /obj
+        convert_units:
+          type: boolean
+          default: true
+          description: >-
+            Enable Houdini's native scene-unit to FBX-unit conversion. Disable
+            only for a pipeline that deliberately handles numeric units itself.
         frame_range:
           type: array
           items: {type: number}

--- a/tests/test_interchange_skills.py
+++ b/tests/test_interchange_skills.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
+import pytest
 from skill_loader import skill_script_import_context
 
 _SKILLS_ROOT = Path(__file__).parent.parent / "src" / "dcc_mcp_houdini" / "skills"
@@ -158,14 +159,17 @@ class TestExportAlembic:
 
 
 class TestExportFbx:
-    def test_export_configures_fbx_rop(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("requested", [None, True, False])
+    def test_export_configures_fbx_rop(self, tmp_path: Path, requested) -> None:
         mod = _load_script("export_fbx.py")
         out = tmp_path / "scene.fbx"
         sopoutput = MagicMock()
         startnode = MagicMock()
+        units = MagicMock()
+        units.set.side_effect = lambda value: setattr(units.eval, "return_value", value)
         rop = _node("/out/fbx_export", "fbx_export", "filmboxfbx")
         rop.parmTuple.return_value = None
-        rop.parm.side_effect = lambda n: {"sopoutput": sopoutput, "startnode": startnode}.get(n)
+        rop.parm.side_effect = lambda n: {"sopoutput": sopoutput, "startnode": startnode, "convertunits": units}.get(n)
         out_net = _node("/out", "out", "ropnet")
         out_net.createNode.return_value = rop
         obj = _node("/obj", "obj")
@@ -173,12 +177,43 @@ class TestExportFbx:
         mock_hou.node.side_effect = lambda p: {"/out": out_net, "/obj": obj}.get(p)
 
         with patch.dict(sys.modules, {"hou": mock_hou}):
-            result = mod.export_fbx(str(out), root_node="/obj", render=False)
+            kwargs = {} if requested is None else {"convert_units": requested}
+            result = mod.export_fbx(str(out), root_node="/obj", render=False, **kwargs)
 
         assert result["success"] is True
         sopoutput.set.assert_called_once_with(str(out))
         startnode.set.assert_called_once_with("/obj")
+        expected = True if requested is None else requested
+        units.set.assert_called_once_with(expected)
+        assert result["context"]["unit_conversion_enabled"] is expected
         assert result["context"]["skipped"] == [str(out)]
+
+    @pytest.mark.parametrize("missing", [True, False])
+    def test_unit_contract_failure_does_not_render(self, tmp_path, missing):
+        mod = _load_script("export_fbx.py")
+        rop = _node("/out/fbx_export", "fbx_export", "filmboxfbx")
+        units = MagicMock()
+        units.eval.return_value = False  # A write that fails to take effect.
+        rop.parm.return_value = None if missing else units
+        parent = _node("/out", "out", "ropnet")
+        parent.createNode.return_value = rop
+        mock_hou = MagicMock()
+        mock_hou.node.return_value = parent
+        output = tmp_path / "never-written.fbx"
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_fbx(str(output))
+        assert result["success"] is False
+        rop.render.assert_not_called()
+        rop.destroy.assert_called_once()
+        assert not output.exists()
+
+    def test_rejects_non_boolean_units(self, tmp_path):
+        mod = _load_script("export_fbx.py")
+        mock_hou = MagicMock()
+        with patch.dict(sys.modules, {"hou": mock_hou}):
+            result = mod.export_fbx(str(tmp_path / "bad.fbx"), convert_units="false")
+        assert result["success"] is False
+        mock_hou.node.assert_not_called()
 
 
 class TestExportUsd:


### PR DESCRIPTION
FBX exports left Houdini's native unit-conversion toggle disabled, so a 2.8-meter card could import as 0.028 meters in an engine. Enable `convert_units` by default, expose an explicit opt-out for pipelines managing numeric units themselves, and return the native toggle's readback. Missing or mismatched unit settings fail before rendering and remove the newly created ROP.

Validation: 179 interchange/discovery tests passed; Ruff checks and formatting passed. A licensed Houdini 22.0.368 fixture exported both modes and verified physical FBX widths of 2.8 meters with conversion and 0.028 meters without it. The repeatable fixture is `.github/scripts/run_houdini_fbx_units_acceptance.py`; target-engine world-bounds verification remains distinct from this native FBX check.
