### PR TITLE
feat: add bounded primitive topology inspection

### DIFF
--- a/.github/scripts/run_houdini_topology.py
+++ b/.github/scripts/run_houdini_topology.py
@@ -1,0 +1,45 @@
+"""Licensed real-HOM smoke; creates only transient geometry in fresh Hython."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import hou
+
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root / "src"))
+sys.path.insert(0, str(root / "tests"))
+from skill_loader import skill_script_import_context  # noqa: E402
+
+import dcc_mcp_houdini  # noqa: E402
+
+assert root in Path(dcc_mcp_houdini.__file__).resolve().parents
+script = root / "src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_primitive_topology.py"
+spec = importlib.util.spec_from_file_location("live_primitive_topology", script)
+module = importlib.util.module_from_spec(spec)
+with skill_script_import_context(spec):
+    spec.loader.exec_module(module)
+container = hou.node("/obj").createNode("geo", "topology_probe")
+box = container.createNode("box")
+result = module.get_primitive_topology(box.path(), offset=1, limit=2, vertex_limit=3)
+assert result["success"], result
+data = result["context"]
+assert data["total_count"] == 6 and data["next_offset"] == 3
+geo = box.geometry()
+for row in data["primitives"]:
+    primitive = geo.prim(row["primitive_index"])
+    assert row["point_indices"] == [v.point().number() for v in primitive.vertices()][:3]
+    assert row["closed"] and row["vertices_truncated"] and row["vertex_count"] == 4
+print(
+    json.dumps(
+        {
+            "houdini": hou.applicationVersionString(),
+            "result": data,
+            "vertices_type": type(geo.prim(0).vertices()).__name__,
+        }
+    ),
+    flush=True,
+)
+container.destroy()
+print("HOUDINI_TOPOLOGY_PROBE_PASSED", flush=True)

--- a/docs/guide/domain-capability-coverage.md
+++ b/docs/guide/domain-capability-coverage.md
@@ -6,7 +6,7 @@ The catalog contains 38 packages and 260 tools after the primitive-topology foll
 
 | Domain | Implemented | Evidence and remaining work |
 | --- | --- | --- |
-| Geometry data | Paged attribute values, named intrinsics, and ordered primitive vertex-to-point references | Topology pagination/truncation tests pass; the topology follow-up still needs real-HOM acceptance. Full manifoldness analysis remains future work. |
+| Geometry data | Paged attribute values, named intrinsics, and ordered primitive vertex-to-point references | Pagination/truncation tests and a licensed Houdini 22.0.368 topology smoke pass. Full manifoldness analysis remains future work. |
 | Copernicus | Modern copnet creation, typed filter graph construction, connections and cached diagnostics | Real constant-to-blur graph created and inspected. Image cooking/export remains a separate verification step. Legacy COP2 is rejected. |
 | Pyro / FLIP / RBD / Vellum | DOP containers and typed solver skeletons, parameter readback/rollback, structural diagnostics | All four solver types created in Houdini 22.0.368. Sources, object data, output wiring, and simulated results are still required; these are not runnable effect templates. |
 | PDG / TOP | Containers, tasks, checked dependencies, item states, blocking/nonblocking cook outcomes | Real two-item Wedge task completed; failed/canceled/incomplete states covered deterministically. Farm scheduler and distributed job acceptance remain separate. |
@@ -28,6 +28,11 @@ test. It verifies the imported adapter belongs to this checkout, creates only
 transient in-memory nodes, and exits nonzero on a failed contract. The final
 marker is `HOUDINI_CAPABILITY_PROBE_PASSED`. The MCP transport smoke is
 `.github/scripts/run_houdini_e2e.py`.
+
+For the isolated ordered-topology check, run
+`hython .github/scripts/run_houdini_topology.py`. It compares paged results with
+real HOM vertex order, checks truncation and closure, and destroys its temporary
+geometry. The success marker is `HOUDINI_TOPOLOGY_PROBE_PASSED`.
 
 ## Issue batch
 

--- a/docs/guide/domain-capability-coverage.md
+++ b/docs/guide/domain-capability-coverage.md
@@ -2,11 +2,11 @@
 
 This iteration adds 3 on-demand skill packages and 15 tools over main:
 4 Copernicus, 4 DOP simulation, 5 PDG/TOP, and 2 geometry data queries.
-The catalog contains 38 packages and 259 tools. Minimal startup is unchanged.
+The catalog contains 38 packages and 260 tools after the primitive-topology follow-up. Minimal startup is unchanged.
 
 | Domain | Implemented | Evidence and remaining work |
 | --- | --- | --- |
-| Geometry data | Paged point/primitive/vertex/detail values; named primitive intrinsics with bounded JSON | Unit pagination/truncation tests and real-HOM point/intrinsic reads. Full topology analysis remains future work. |
+| Geometry data | Paged attribute values, named intrinsics, and ordered primitive vertex-to-point references | Topology pagination/truncation tests pass; the topology follow-up still needs real-HOM acceptance. Full manifoldness analysis remains future work. |
 | Copernicus | Modern copnet creation, typed filter graph construction, connections and cached diagnostics | Real constant-to-blur graph created and inspected. Image cooking/export remains a separate verification step. Legacy COP2 is rejected. |
 | Pyro / FLIP / RBD / Vellum | DOP containers and typed solver skeletons, parameter readback/rollback, structural diagnostics | All four solver types created in Houdini 22.0.368. Sources, object data, output wiring, and simulated results are still required; these are not runnable effect templates. |
 | PDG / TOP | Containers, tasks, checked dependencies, item states, blocking/nonblocking cook outcomes | Real two-item Wedge task completed; failed/canceled/incomplete states covered deterministically. Farm scheduler and distributed job acceptance remain separate. |

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/SKILL.md
@@ -31,7 +31,7 @@ main` because they call `hou`. Prefer these over
   and `create_curve_guides` (bounded inline JSON or JSON-file polyline/NURBS
   guide topology).
 - **`geometry-query`** (read-only except cook): `get_geometry_info`,
-  `list_attributes`, `get_attribute_values`, `get_primitive_intrinsics`,
+  `list_attributes`, `get_attribute_values`, `get_primitive_intrinsics`, `get_primitive_topology`,
   `list_groups`, `get_cook_status`.
 
 `get_attribute_values` supports point, primitive, vertex (linear index), and
@@ -40,6 +40,11 @@ Each value is bounded to 64 items and 1024 serialized characters and reports
 truncation. `get_primitive_intrinsics` reads up to 32 named properties, including
 packed transforms and bounds. These calls may trigger the SOP's normal cook to
 obtain geometry, but never change geometry or write files.
+
+`get_primitive_topology` reads up to 32 primitives and 128 ordered point references
+per primitive. `next_offset` pages primitives; `vertices_truncated` marks incomplete
+vertex lists. Closure is null for primitive types without a closure query. This
+is an inspection primitive, not a manifoldness or full-mesh validation result.
 
 ## Tracer-bullet flow
 

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_primitive_topology.py
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/scripts/get_primitive_topology.py
@@ -1,0 +1,57 @@
+"""Inspect a bounded page of ordered primitive vertex-to-point references."""
+
+from itertools import islice
+
+from _geo_common import cooked_geometry, get_node
+from dcc_mcp_core.skill import skill_entry, skill_error, skill_exception, skill_success
+
+from dcc_mcp_houdini._bounded_values import require_range
+
+
+def get_primitive_topology(node_path: str, offset: int = 0, limit: int = 16, vertex_limit: int = 64) -> dict:
+    try:
+        import hou
+    except ImportError:
+        return skill_error("Houdini not available", "hou could not be imported")
+    try:
+        require_range(offset, "offset", 0, 2147483647)
+        require_range(limit, "limit", 1, 32)
+        require_range(vertex_limit, "vertex_limit", 1, 128)
+        node = get_node(hou, node_path)
+        geo = cooked_geometry(node)
+        total = geo.primCount()
+        rows = []
+        for index in range(offset, min(total, offset + limit)):
+            primitive = geo.prim(index)
+            if primitive is None:
+                raise RuntimeError("Geometry changed during topology inspection")
+            count = primitive.numVertices()
+            points = [v.point().number() for v in islice(primitive.vertices(), vertex_limit)]
+            closed = getattr(primitive, "isClosed", None)
+            rows.append(
+                {
+                    "primitive_index": index,
+                    "primitive_type": str(primitive.type()),
+                    "vertex_count": count,
+                    "point_indices": points,
+                    "vertices_truncated": count > len(points),
+                    "closed": bool(closed()) if callable(closed) else None,
+                }
+            )
+        next_offset = offset + len(rows)
+        return skill_success(
+            "Read ordered primitive topology",
+            node_path=node.path(),
+            total_count=total,
+            offset=offset,
+            count=len(rows),
+            primitives=rows,
+            next_offset=next_offset if next_offset < total else None,
+        )
+    except Exception as exc:
+        return skill_exception(exc, message="Failed to read primitive topology")
+
+
+@skill_entry
+def main(**kwargs):
+    return get_primitive_topology(**kwargs)

--- a/src/dcc_mcp_houdini/skills/houdini-geometry/tools.yaml
+++ b/src/dcc_mcp_houdini/skills/houdini-geometry/tools.yaml
@@ -1,4 +1,23 @@
 tools:
+  - name: get_primitive_topology
+    description: Read a bounded page of primitives with ordered vertex-to-point indices, primitive types, closure and explicit vertex truncation. Does not infer manifoldness or triangulate geometry.
+    source_file: scripts/get_primitive_topology.py
+    execution: sync
+    affinity: main
+    group: geometry-query
+    read_only: true
+    destructive: false
+    idempotent: true
+    annotations: {read_only_hint: true, destructive_hint: false, idempotent_hint: true}
+    input_schema:
+      type: object
+      additionalProperties: false
+      required: [node_path]
+      properties:
+        node_path: {type: string, minLength: 1}
+        offset: {type: integer, minimum: 0, maximum: 2147483647, default: 0}
+        limit: {type: integer, minimum: 1, maximum: 32, default: 16}
+        vertex_limit: {type: integer, minimum: 1, maximum: 128, default: 64}
   - name: create_primitive
     description: >-
       Create a common SOP primitive (box, sphere, grid, tube, curve, null,

--- a/tests/test_geometry_data_queries.py
+++ b/tests/test_geometry_data_queries.py
@@ -25,6 +25,51 @@ def load(name):
     return module
 
 
+def test_topology_pages_primitives_and_bounds_vertex_iteration():
+    accesses, vertices = [], []
+
+    def primitive(index):
+        accesses.append(index)
+
+        def iterate():
+            for point_index in (9, 2, 7, 4):
+                vertices.append(point_index)
+                yield SimpleNamespace(point=lambda p=point_index: SimpleNamespace(number=lambda: p))
+
+        return SimpleNamespace(numVertices=lambda: 4, vertices=iterate, type=lambda: "Polygon", isClosed=lambda: True)
+
+    geo = SimpleNamespace(primCount=lambda: 10, prim=primitive)
+    node = SimpleNamespace(path=lambda: "/obj/geo1/OUT", geometry=lambda: geo)
+    with patch.dict(sys.modules, {"hou": SimpleNamespace(node=lambda _: node)}):
+        result = load("get_primitive_topology").get_primitive_topology(
+            "/obj/geo1/OUT", offset=3, limit=1, vertex_limit=2
+        )
+    assert result["success"]
+    assert accesses == [3] and vertices == [9, 2]
+    data = result["context"]
+    assert data["next_offset"] == 4 and data["total_count"] == 10
+    assert data["primitives"] == [
+        {
+            "primitive_index": 3,
+            "primitive_type": "Polygon",
+            "vertex_count": 4,
+            "point_indices": [9, 2],
+            "vertices_truncated": True,
+            "closed": True,
+        }
+    ]
+
+
+@pytest.mark.parametrize("kwargs", [{"offset": -1}, {"limit": True}, {"limit": 33}, {"vertex_limit": 129}])
+def test_topology_rejects_invalid_bounds_before_hom(kwargs):
+    def forbidden(_):
+        raise AssertionError("Invalid request accessed HOM")
+
+    with patch.dict(sys.modules, {"hou": SimpleNamespace(node=forbidden)}):
+        result = load("get_primitive_topology").get_primitive_topology("/obj/geo1/OUT", **kwargs)
+    assert not result["success"]
+
+
 def make_geometry(owner, values):
     accesses = []
     attribute = SimpleNamespace(dataType=lambda: "Float", size=lambda: 3)


### PR DESCRIPTION
Add a typed geometry query for ordered primitive vertex-to-point references, with bounded primitive pages and vertex truncation. This exposes topology data without raw scripting or unbounded geometry enumeration.

Validation: 209 geometry/skill/metadata tests passed; Ruff passed. A licensed Houdini 22.0.368 headless smoke verified real vertex order, closure, pagination and truncation using transient geometry. Includes the repeatable smoke fixture. Docker E2E still requires SideFX CI credentials; full modeling acceptance remains separate.
