### PR TITLE
docs: add canonical agent quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,17 @@ jobs:
         run: ruff check src/ tests/ tools/ packaging/
       - name: Ruff format check
         run: ruff format --check src/ tests/ tools/ packaging/
+      - uses: actions/checkout@v6
+        with:
+          repository: dcc-mcp/dcc-mcp-agent-plugins
+          ref: 54b9d46a9fcefab1ed3a6aafc18da6ab4198ad25
+          path: .agent-plugins
+      - name: Check Agent quickstart
+        run: >-
+          python .agent-plugins/scripts/sync_adapter_readme.py
+          --repository ${{ github.event.repository.name }}
+          --readme README.md
+          --check
       - name: Install dcc-mcp-cli (runtime skill validator)
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@
   <img src="docs/assets/dcc-mcp-houdini.svg" alt="DCC-MCP · HOUDINI" width="600">
 </p>
 
+<!-- dcc-mcp-agent-quickstart:start -->
+## Use Houdini with AI agents
+
+Install the official DCC-MCP Agent Skill. Codex users can use the native plugin
+marketplace:
+
+```powershell
+codex plugin marketplace add dcc-mcp/dcc-mcp-agent-plugins
+codex plugin add dcc-mcp@dcc-mcp
+```
+
+For Claude Code, CodeBuddy, Cursor, Gemini CLI, and other supported agents, use
+the [official installation guide](https://github.com/dcc-mcp/dcc-mcp-agent-plugins#install). Start Houdini,
+enable this adapter, and verify that the running instance is registered:
+
+```powershell
+dcc-mcp-cli list
+```
+
+Then ask your agent:
+
+```text
+Use dcc-mcp to inspect the current Houdini scene.
+```
+
+The list must include `dcc_type=houdini`. If it does not, follow the
+[connection troubleshooting guide](https://github.com/dcc-mcp/dcc-mcp-agent-plugins#adapter-connection-troubleshooting).
+<!-- dcc-mcp-agent-quickstart:end -->
+
 ## Agent workflow
 
 AI agents should use the shared gateway through `dcc-mcp-cli`; IDE users may


### PR DESCRIPTION
## Summary
- add the generated Agent Skill quickstart to the README
- pin the canonical generator in CI to prevent drift

## Validation
- 1,261 tests passed (1 skipped)
- Ruff and Python 3.7 syntax checks passed
- generator check passed